### PR TITLE
Add documentation hub and navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Setup uses the robot's **Add another user** Bluetooth window. Routine control,
 state, and maps use the robot's encrypted local service without Matter or cloud
 relays.
 
+**[Documentation](docs/README.md)** — Installation, local pairing, cleaning
+plans, automation, privacy, and troubleshooting.
+
 ## Status
 
 Home Assistant 2026.7 is the tested baseline and the minimum version accepted by

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,61 @@
+# Matic (Unofficial) documentation
+
+[Project overview](../README.md) · [Install](../README.md#install) ·
+[Get support](#support)
+
+This is the documentation home for the independent, community-maintained Home
+Assistant integration for Matic robot vacuums. The guides are versioned with
+the integration so instructions and behavior stay aligned with each release.
+
+## Get started
+
+- [Install Matic (Unofficial)](../README.md#install) — Add the HACS custom
+  repository or install the integration manually.
+- [Local pairing](hermes-pairing.md) — Complete discovery and authorization,
+  understand Bluetooth requirements, and recover from pairing failures.
+- [Limits and troubleshooting](../README.md#limits-and-troubleshooting) — Check
+  discovery, passkey, room-mapping, firmware, and Bluetooth constraints.
+
+## Use and automate
+
+- [Entities, controls, and actions](automation.md#entity-contract) — Use the
+  complete Home Assistant surface exposed by one robot.
+- [Saved cleaning plans](automation.md#saved-plans) — Choose rooms, customize
+  per-room cleaning, and save the top-to-bottom order.
+- [Intelligent rotation](automation.md#intelligent-rotation) — Prioritize rooms
+  that have waited longest when a cleaning window ends early.
+- [Events and blueprints](automation.md#events-and-observability) — Build
+  presence, schedule, dashboard, and custom automation workflows.
+- [Map and cleaning experience](../README.md#cleaning-ux-and-automation) — Add
+  the local floor-plan camera and configure room-aware plans.
+
+## Privacy and security
+
+- [Privacy and local-data model](privacy.md) — Review stored credentials,
+  diagnostics, room and map data, backups, and deauthorization.
+- [Security policy](../SECURITY.md) — Understand the security model and report a
+  vulnerability privately.
+- [Recording-related protocol notes](recording-protocol.md) — Review observed
+  camera and microphone semantics that are intentionally outside the
+  integration's supported controls.
+
+## Project
+
+- [Contributing](../CONTRIBUTING.md) — Set up development, run the required
+  checks, and prepare a focused pull request.
+- [License](../LICENSE) — MIT License.
+- [Release](https://github.com/ProspectOre/matic-home-assistant/releases/latest)
+  — Download the current published version and review its release notes.
+
+## Support
+
+Start with [limits and troubleshooting](../README.md#limits-and-troubleshooting)
+and the relevant guide above. If the problem remains:
+
+- [Ask the Home Assistant community](https://community.home-assistant.io/t/matic-unofficial-local-robot-vacuum-control-map-room-plans-and-intelligent-rotation/1017684)
+- [Report a bug](https://github.com/ProspectOre/matic-home-assistant/issues/new?template=bug_report.yml)
+- [Request a feature](https://github.com/ProspectOre/matic-home-assistant/issues/new?template=feature_request.yml)
+
+Home Assistant diagnostics are created only when you click **Download
+diagnostics**. Inspect the file before sharing it because the redacted report
+still contains home-specific map, room, Wi-Fi, schedule, and protocol context.

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -1,5 +1,8 @@
 # Entity and automation reference
 
+[Documentation home](README.md) · [Project overview](../README.md) ·
+[Get support](README.md#support)
+
 The integration exposes Home Assistant entities and actions for robot state,
 settings, cleaning, and saved plans.
 

--- a/docs/hermes-pairing.md
+++ b/docs/hermes-pairing.md
@@ -1,5 +1,8 @@
 # Local pairing
 
+[Documentation home](README.md) · [Project overview](../README.md) ·
+[Get support](README.md#support)
+
 Status: verified on a Matic robot with Home Assistant 2026.7 and the built-in
 Bluetooth adapter in Home Assistant Yellow.
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,5 +1,8 @@
 # Privacy and local-data model
 
+[Documentation home](README.md) · [Project overview](../README.md) ·
+[Get support](README.md#support)
+
 After one-time authorization, Home Assistant talks directly to the robot's
 encrypted local service. Routine control, state, and maps stay inside the home.
 The integration does not receive or store Matic account or cloud-session

--- a/docs/recording-protocol.md
+++ b/docs/recording-protocol.md
@@ -1,5 +1,8 @@
 # Recording-related protocol notes
 
+[Documentation home](README.md) · [Project overview](../README.md) ·
+[Get support](README.md#support)
+
 These notes document recording-related semantics observed in the robot's local
 protocol. They are not part of the Matic for Home Assistant 0.1 entity or action
 contract. The integration does not request these properties or collections,


### PR DESCRIPTION
## What changed

- add a focused documentation hub for setup, pairing, automations, privacy, recordings, troubleshooting, and support
- link the hub prominently from the project README
- add consistent navigation between every long-form guide

## Why

The integration documentation had strong individual guides but no clear starting point or consistent route between them. This gives owners and contributors a single, predictable entry point without duplicating content.

## Impact

Users can find the right setup or troubleshooting guide faster, and contributors have a cleaner documentation structure to maintain.

## Validation

- 387 tests passed
- Ruff passed
- MyPy passed
- public-tree privacy check passed
- `git diff --check` passed