### PR TITLE
Release v0.2.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -24,8 +24,8 @@ body:
   - type: input
     attributes:
       label: Bluetooth setup
-      description: Built-in adapter or USB model, and whether ESPHome Bluetooth proxies are present. Pairing needs a local adapter; proxies cannot run setup.
-      placeholder: HA Yellow built-in / TP-Link UB500 USB; 3 ESPHome proxies
+      description: Local adapter model, approximate distance and obstructions to Matic, whether Bluetooth proxies are present, and any other BLE scanner integrations. Pairing needs the local adapter; proxies cannot run setup.
+      placeholder: USB adapter about 5 ft away with clear line of sight; 3 ESPHome proxies; Bermuda installed
     validations:
       required: true
   - type: dropdown

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ Home Assistant 2026.7 is the tested baseline and the minimum version accepted by
 HACS. Compatibility with other Home Assistant releases has not been validated.
 
 The integration has been tested on a real robot and a stock Home Assistant
-Yellow. One robot creates 44 entities: 18 sensors, 12 binary sensors, 4 buttons,
-4 switches, 3 selects, 1 number, 1 camera, and 1 vacuum.
+Yellow. One robot creates 48 fixed entities — 21 sensors, 12 binary sensors,
+4 buttons, 4 switches, 3 selects, 1 number, 1 camera, 1 update, and 1 vacuum —
+plus two opt-in room statistics sensors per mapped room.
 Setup, state, map, cleaning, and settings paths have been exercised on the robot,
 and the integration is covered by automated tests.
 
@@ -37,10 +38,12 @@ and the integration is covered by automated tests.
   optical camera frames.
 - Activity, battery, rooms, hardware/software/protocol, current area, update,
   Wi-Fi, schedule, local cleaning history, dock/sink, Matter-pairing,
-  robot SSH-tunnel permission, and robot diagnostic-upload state.
+  robot SSH-tunnel permission, diagnostic-upload state, and persistent firmware
+  compatibility health.
 - Controls for child lock, pet-waste avoidance, Hey Matic, double-pass mopping,
   and water flow.
-- Bounded raw collection reads for known non-credential Hermes state.
+- Payload-free endpoint inspection and persistent weekly firmware compatibility
+  snapshots for every known non-credential Hermes read surface.
 
 ## Home Assistant capabilities
 
@@ -126,15 +129,19 @@ integration has no telemetry, crash uploader, analytics endpoint, or maintainer
 cloud.
 
 If a user explicitly clicks **Download diagnostics**, Home Assistant generates
-a local report for that user to inspect and share. The report redacts
-credentials, addresses, certificate identity, and serial numbers while retaining
-the user-owned map, room, Wi-Fi, schedule, and protocol state needed for
-technical diagnosis. See [the privacy model](docs/privacy.md).
+a local report from a strict safe-field allowlist. It omits credentials,
+addresses, certificate identity, serial numbers, names, maps, pose, room and Area
+context, Wi-Fi identities, schedules, and session details. See
+[the privacy model](docs/privacy.md).
 
 ## Bluetooth permissions
 
 Home Assistant OS manages supported local Bluetooth adapters; the robot-display
-passkey flow was tested on Home Assistant Yellow. Home Assistant Container
+passkey flow was tested on Home Assistant Yellow. For setup, place the local
+adapter within a few feet of Matic with as little furniture or other obstruction
+between them as practical; receiving a passive advertisement from farther away
+does not prove the adapter can sustain the interactive pairing connection.
+Home Assistant Container
 installations need `NET_ADMIN`, `NET_RAW`, and the read-only host D-Bus socket;
 follow Home Assistant's [Bluetooth container instructions](https://www.home-assistant.io/integrations/bluetooth/#additional-details-for-container).
 If Home Assistant reports the adapter as degraded, fix that repair and restart
@@ -143,8 +150,13 @@ uses the LAN.
 
 ## Limits and troubleshooting
 
-- Firmware changes can require an update because this is an unofficial local
-  protocol integration.
+- Firmware changes can require an integration update because this is an
+  unofficial local protocol integration. Check the
+  [firmware compatibility ledger](docs/firmware-compatibility.md) for observed
+  versions and validation status. A newly observed version emits the
+  `matic_robot_firmware_changed` event; run the **Firmware snapshot** action to
+  compare all known read endpoints with the prior snapshot. A Repair is created
+  only when that comparison finds compatibility drift.
 - Rooms without an exact Area name or unique alias require one manual mapping.
 - The map camera is a local floor-plan rendering. No optical-camera live stream
   has been verified or exposed.
@@ -162,8 +174,12 @@ uses the LAN.
 - A new Bluetooth pairing deliberately proves physical access: someone at the
   robot must read its displayed code, and Home Assistant must use a Bluetooth
   adapter built into or directly attached to its host for that interactive
-  exchange. Bluetooth proxies are not supported for setup. This is not a
-  signal-strength limitation. Routine use is LAN-only after authorization.
+  exchange. Bluetooth proxies are not supported for setup. If a proxy can see
+  Matic but the local adapter cannot, move the local adapter closer and remove
+  obstructions. If pairing fails, temporarily disable Bluetooth proxies while
+  retrying so discovery and pairing stay on the local adapter. If that adapter
+  still misses fresh advertisements, reload its Home Assistant integration or
+  replug it before retrying. Routine use is LAN-only after authorization.
 - For bugs, use the repository's bug-report form after reviewing and sanitizing
   diagnostics. Report vulnerabilities privately as described in
   [SECURITY.md](SECURITY.md). Never attach credentials, maps, captures, backups,

--- a/custom_components/matic_robot/__init__.py
+++ b/custom_components/matic_robot/__init__.py
@@ -21,14 +21,19 @@ from .const import (
     CONF_HERMES_CREDENTIAL,
     CONF_HOSTNAME,
     CONF_SERIAL_NUMBER,
+    DATA_FIRMWARE_TRACKER,
     DATA_PLAN_MANAGER,
     DOMAIN,
     PLATFORMS,
 )
 from .coordinator import MaticCoordinator
+from .firmware import FirmwareTracker
 from .frontend import async_register_room_plan_editor
+from .migrations import async_migrate_entry
 from .plans import CleaningPlanManager
 from .services import async_register_services
+
+__all__ = ["async_migrate_entry"]
 
 
 @dataclass(slots=True)
@@ -38,6 +43,7 @@ class MaticRuntimeData:
     client: MaticHermesClient
     coordinator: MaticCoordinator
     cleaning_plans: CleaningPlanManager
+    firmware_tracker: FirmwareTracker
 
 
 MaticConfigEntry = ConfigEntry[MaticRuntimeData]
@@ -67,6 +73,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: MaticConfigEntry) -> boo
         seconds_from_gmt=int(offset.total_seconds()) if offset is not None else 0,
     )
     try:
+        firmware_tracker = hass.data[DOMAIN][DATA_FIRMWARE_TRACKER]
         coordinator = MaticCoordinator(
             hass,
             client,
@@ -77,10 +84,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: MaticConfigEntry) -> boo
             coverage_setting=CoverageSetting(
                 entry.options.get(CONF_COVERAGE_SETTING, CoverageSetting.STANDARD)
             ),
+            firmware_tracker=firmware_tracker,
         )
         await coordinator.async_config_entry_first_refresh()
         plans = hass.data[DOMAIN][DATA_PLAN_MANAGER]
-        entry.runtime_data = MaticRuntimeData(client, coordinator, plans)
+        entry.runtime_data = MaticRuntimeData(
+            client, coordinator, plans, firmware_tracker
+        )
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     except BaseException:
         client.close()
@@ -93,3 +103,12 @@ async def async_unload_entry(hass: HomeAssistant, entry: MaticConfigEntry) -> bo
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         entry.runtime_data.client.close()
     return unload_ok
+
+
+async def async_remove_entry(hass: HomeAssistant, entry: MaticConfigEntry) -> None:
+    """Erase the removed robot's persisted firmware history and repairs."""
+    tracker: FirmwareTracker | None = hass.data.get(DOMAIN, {}).get(
+        DATA_FIRMWARE_TRACKER
+    )
+    if tracker is not None:
+        await tracker.async_remove_robot(entry.entry_id)

--- a/custom_components/matic_robot/binary_sensor.py
+++ b/custom_components/matic_robot/binary_sensor.py
@@ -83,6 +83,7 @@ DESCRIPTIONS = (
         key="matter_pairing_mode",
         translation_key="matter_pairing_mode",
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
         value_fn=lambda state: state.telemetry.matter_pairing_enabled,
     ),
     MaticBinarySensorDescription(
@@ -95,12 +96,14 @@ DESCRIPTIONS = (
         key="ssh_tunnel_permission",
         translation_key="ssh_tunnel_permission",
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
         value_fn=lambda state: state.telemetry.ssh_tunnel_permission,
     ),
     MaticBinarySensorDescription(
         key="diagnostic_upload",
         translation_key="diagnostic_upload",
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
         value_fn=lambda state: state.telemetry.uploader_opt_in,
     ),
 )

--- a/custom_components/matic_robot/camera.py
+++ b/custom_components/matic_robot/camera.py
@@ -35,6 +35,8 @@ class MaticMapCamera(MaticEntity, Camera):
         Camera.__init__(self)
         MaticEntity.__init__(self, entry)
         self._attr_unique_id = f"{self.coordinator.data.info.serial_number}_map"
+        self._cached_image_key: tuple[object, ...] | None = None
+        self._cached_image: bytes | None = None
 
     async def async_camera_image(
         self,
@@ -45,7 +47,18 @@ class MaticMapCamera(MaticEntity, Camera):
         data = self.coordinator.data
         requested_width = min(max(width or 1024, 256), 2048)
         requested_height = min(max(height or 1024, 256), 2048)
-        return await self.hass.async_add_executor_job(
+        # The floor plan object is cached by the coordinator between map
+        # refreshes, so identity is stable; the pose is re-fetched every
+        # cycle and must be compared by value.
+        cache_key = (
+            id(data.floor_plan),
+            data.pose,
+            requested_width,
+            requested_height,
+        )
+        if cache_key == self._cached_image_key and self._cached_image is not None:
+            return self._cached_image
+        image = await self.hass.async_add_executor_job(
             partial(
                 render_floor_plan,
                 data.floor_plan,
@@ -54,3 +67,6 @@ class MaticMapCamera(MaticEntity, Camera):
                 height=requested_height,
             )
         )
+        self._cached_image_key = cache_key
+        self._cached_image = image
+        return image

--- a/custom_components/matic_robot/client/api.py
+++ b/custom_components/matic_robot/client/api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import math
 import socket
 import ssl
@@ -10,6 +11,7 @@ import struct
 from collections.abc import AsyncIterator
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from datetime import UTC, datetime
+from time import monotonic
 from types import TracebackType
 from typing import cast
 from uuid import UUID
@@ -19,6 +21,7 @@ from grpclib.client import Channel
 from grpclib.const import Status
 from grpclib.exceptions import GRPCError, ProtocolError, StreamTerminatedError
 from grpclib.protocol import H2Protocol
+from h2.exceptions import H2Error
 
 from .auth import HermesCredential
 from .commands import (
@@ -30,10 +33,13 @@ from .commands import (
     encode_user_command,
     encode_user_data,
 )
+from .endpoints import HERMES_ENDPOINT_MAP, HermesEndpointKind
 from .exceptions import (
     AuthenticationRequiredError,
     CannotConnectError,
+    EndpointUnsupportedError,
     InvalidRobotCertificateError,
+    MaticError,
     PairingModeRequiredError,
 )
 from .floor_plan import decode_floor_plan, decode_pose
@@ -68,8 +74,13 @@ from .tls import (
 )
 from .wire import decode_fields, first_bytes, first_varint
 
+_LOGGER = logging.getLogger(__name__)
+
 HERMES_TARGET_KEY = "hermes-target"
 _RPC_TIMEOUT = 10.0
+# Streamed collection reads have per-message timeouts; this caps the whole
+# read so a slow-dripping stream cannot hold a poll cycle open for minutes.
+_COLLECTION_TIMEOUT = 30.0
 
 _TELEMETRY_PROPERTIES = (
     "current_version",
@@ -104,6 +115,18 @@ _WEEKDAYS = (
     "friday",
     "saturday",
 )
+
+
+async def _async_cancel_stream(stream: object) -> None:
+    """Cancel a bounded read without failing on an already-closed stream.
+
+    Live robots reset collection streams on their side once the reader stops
+    consuming; cancellation is cleanup, and the collected data stays valid.
+    """
+    try:
+        await stream.cancel()  # type: ignore[attr-defined]
+    except OSError, StreamTerminatedError, ProtocolError, H2Error:
+        pass
 
 
 def _response_value_bytes(response: CollectionResponse) -> bytes:
@@ -218,6 +241,8 @@ class MaticHermesClient(AbstractAsyncContextManager["MaticHermesClient"]):
         self._seconds_from_gmt = seconds_from_gmt
         self._channel: Channel | None = None
         self._connect_lock = asyncio.Lock()
+        self._endpoint_health: dict[str, str] = {}
+        self._command_health: dict[str, str] = {}
 
     async def __aenter__(self) -> MaticHermesClient:
         await self.async_connect()
@@ -288,19 +313,24 @@ class MaticHermesClient(AbstractAsyncContextManager["MaticHermesClient"]):
         """Map every transport failure onto the Matic error hierarchy.
 
         Besides ``TimeoutError`` and ``GRPCError`` this also catches the plain
-        ``OSError``/``ConnectionResetError`` and grpclib ``StreamTerminatedError``
-        /``ProtocolError`` that a dropped HTTP/2 stream can raise, so no raw
+        ``OSError``/``ConnectionResetError``, grpclib ``StreamTerminatedError``
+        /``ProtocolError``, and raw ``h2`` protocol errors (live robots reset
+        streams mid-conversation, observed as ``StreamClosedError``) so no raw
         transport exception escapes an RPC. Messages stay non-sensitive.
         """
         try:
             yield
         except TimeoutError as err:
             raise CannotConnectError(f"Hermes {description} timed out") from err
-        except (OSError, StreamTerminatedError, ProtocolError) as err:
+        except (OSError, StreamTerminatedError, ProtocolError, H2Error) as err:
             raise CannotConnectError(f"Hermes {description} connection failed") from err
         except GRPCError as err:
             if err.status is Status.UNAUTHENTICATED:
                 raise AuthenticationRequiredError(err.message) from err
+            if err.status in (Status.UNIMPLEMENTED, Status.NOT_FOUND):
+                raise EndpointUnsupportedError(
+                    f"Hermes {description} is not implemented by this firmware"
+                ) from err
             raise CannotConnectError(err.message or err.status.name) from err
 
     async def async_get_info(self) -> RobotInfo:
@@ -506,15 +536,21 @@ class MaticHermesClient(AbstractAsyncContextManager["MaticHermesClient"]):
     async def _async_optional_property(self, name: str) -> bytes | None:
         """Return one optional property without hiding core robot state."""
         try:
-            return await self.async_get_property(name)
-        except AuthenticationRequiredError, CannotConnectError:
+            value = await self.async_get_property(name)
+            self._endpoint_health[name] = "ok"
+            return value
+        except (AuthenticationRequiredError, CannotConnectError) as err:
+            self._endpoint_health[name] = type(err).__name__
             return None
 
     async def _async_optional_collection_count(self, name: str) -> int | None:
         """Return one optional collection count."""
         try:
-            return await self.async_get_collection_count(name)
-        except AuthenticationRequiredError, CannotConnectError:
+            value = await self.async_get_collection_count(name)
+            self._endpoint_health[name] = "ok"
+            return value
+        except (AuthenticationRequiredError, CannotConnectError) as err:
+            self._endpoint_health[name] = type(err).__name__
             return None
 
     async def _async_optional_collection(
@@ -522,8 +558,11 @@ class MaticHermesClient(AbstractAsyncContextManager["MaticHermesClient"]):
     ) -> tuple[HermesCollectionEntry, ...] | None:
         """Return an optional local collection without hiding core state."""
         try:
-            return await self.async_get_collection_entries(name, limit=limit)
-        except AuthenticationRequiredError, CannotConnectError:
+            value = await self.async_get_collection_entries(name, limit=limit)
+            self._endpoint_health[name] = "ok"
+            return value
+        except (AuthenticationRequiredError, CannotConnectError) as err:
+            self._endpoint_health[name] = type(err).__name__
             return None
 
     async def async_get_property(self, collection_name: str) -> bytes:
@@ -580,7 +619,11 @@ class MaticHermesClient(AbstractAsyncContextManager["MaticHermesClient"]):
             ) as stream:
                 await stream.send_message(request, end=True)
                 cancel_stream = False
+                deadline = monotonic() + _COLLECTION_TIMEOUT
                 while count < 4096:
+                    if monotonic() >= deadline:
+                        cancel_stream = True
+                        break
                     try:
                         async with asyncio.timeout(3 if count == 0 else 0.15):
                             response = await stream.recv_message()
@@ -594,7 +637,7 @@ class MaticHermesClient(AbstractAsyncContextManager["MaticHermesClient"]):
                 if count >= 4096:
                     cancel_stream = True
                 if cancel_stream:
-                    await stream.cancel()
+                    await _async_cancel_stream(stream)
         return count
 
     async def async_get_collection_entries(
@@ -626,7 +669,11 @@ class MaticHermesClient(AbstractAsyncContextManager["MaticHermesClient"]):
             ) as stream:
                 await stream.send_message(request, end=True)
                 cancel_stream = False
+                deadline = monotonic() + _COLLECTION_TIMEOUT
                 while len(entries) < limit:
+                    if monotonic() >= deadline:
+                        cancel_stream = True
+                        break
                     try:
                         timeout = first_timeout if not entries else idle_timeout
                         async with asyncio.timeout(timeout):
@@ -645,8 +692,36 @@ class MaticHermesClient(AbstractAsyncContextManager["MaticHermesClient"]):
                 if len(entries) >= limit:
                     cancel_stream = True
                 if cancel_stream:
-                    await stream.cancel()
+                    await _async_cancel_stream(stream)
         return tuple(entries)
+
+    async def async_inspect_endpoint(
+        self, endpoint_name: str, *, limit: int = 1
+    ) -> tuple[HermesCollectionEntry, ...]:
+        """Read a known endpoint through its evidence-backed transport shape."""
+        try:
+            endpoint = HERMES_ENDPOINT_MAP[endpoint_name]
+        except KeyError:
+            raise ValueError(f"Unknown Hermes endpoint: {endpoint_name}") from None
+        result: tuple[HermesCollectionEntry, ...]
+        try:
+            if endpoint.kind is HermesEndpointKind.PROPERTY:
+                value = await self.async_get_property(endpoint_name)
+                result = (HermesCollectionEntry(b"", value),)
+            else:
+                result = await self.async_get_collection_entries(
+                    endpoint_name, limit=limit
+                )
+        except (AuthenticationRequiredError, CannotConnectError) as err:
+            self._endpoint_health[endpoint_name] = type(err).__name__
+            raise
+        self._endpoint_health[endpoint_name] = "ok"
+        return result
+
+    @property
+    def endpoint_health(self) -> dict[str, str]:
+        """Return non-sensitive read health for observed endpoints."""
+        return dict(self._endpoint_health)
 
     async def async_send_user_command(self, command: UserCommand) -> None:
         """Send one live-verified command through the authenticated user channel."""
@@ -723,12 +798,39 @@ class MaticHermesClient(AbstractAsyncContextManager["MaticHermesClient"]):
         )
         metadata = dict(self._metadata or {})
         metadata[HERMES_TARGET_KEY] = channel_name
-        async with self._map_stream_errors("command"), asyncio.timeout(_RPC_TIMEOUT):
-            async with HermesStub(channel).SendToChannel.open(
-                metadata=metadata
-            ) as stream:
-                await stream.send_message(request, end=True)
-                await stream.recv_message()
+        try:
+            async with (
+                self._map_stream_errors("command"),
+                asyncio.timeout(_RPC_TIMEOUT),
+            ):
+                async with HermesStub(channel).SendToChannel.open(
+                    metadata=metadata
+                ) as stream:
+                    await stream.send_message(request, end=True)
+                    response = await stream.recv_message()
+        except MaticError as err:
+            self._command_health[channel_name] = type(err).__name__
+            raise
+        # The response schema is private, so its fields stay unread until
+        # fixture evidence exists; whether the robot acknowledged at all is
+        # transport-level and safe to observe.
+        if response is None:
+            self._command_health[channel_name] = "unacknowledged"
+            _LOGGER.debug(
+                "Hermes %s command stream closed without a response", channel_name
+            )
+        else:
+            self._command_health[channel_name] = "acknowledged"
+            _LOGGER.debug(
+                "Hermes %s command acknowledged with a %d-byte response",
+                channel_name,
+                response.ByteSize(),
+            )
+
+    @property
+    def command_health(self) -> dict[str, str]:
+        """Return non-sensitive acknowledgment health for sent commands."""
+        return dict(self._command_health)
 
     @property
     def _metadata(self) -> dict[str, str] | None:
@@ -968,11 +1070,14 @@ def _decode_uploader_state(payload: object) -> bool | None:
     for field in fields:
         if field.number == 1 and isinstance(field.value, bytes):
             return False
-        if field.number == 2 and isinstance(field.value, bytes):
-            try:
-                return bool(first_varint(field.value, 1))
-            except DecodeError:
-                return False
+        if field.number == 2:
+            if isinstance(field.value, int):
+                return bool(field.value)
+            if isinstance(field.value, bytes):
+                try:
+                    return bool(first_varint(field.value, 1))
+                except DecodeError:
+                    return False
     return None
 
 

--- a/custom_components/matic_robot/client/endpoints.py
+++ b/custom_components/matic_robot/client/endpoints.py
@@ -1,0 +1,93 @@
+"""Authoritative Hermes endpoint metadata for reads and firmware checks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class HermesEndpointKind(StrEnum):
+    """How a Hermes endpoint must be read."""
+
+    PROPERTY = "property"
+    COLLECTION = "collection"
+
+
+class HermesEndpointSensitivity(StrEnum):
+    """Maximum privacy classification for an endpoint payload."""
+
+    DIAGNOSTIC = "diagnostic"
+    HOME_CONTEXT = "home_context"
+
+
+@dataclass(frozen=True, slots=True)
+class HermesEndpoint:
+    """Describe one observed, non-credential Hermes read endpoint."""
+
+    name: str
+    kind: HermesEndpointKind
+    sensitivity: HermesEndpointSensitivity = HermesEndpointSensitivity.HOME_CONTEXT
+
+
+def _property(
+    name: str,
+    sensitivity: HermesEndpointSensitivity = HermesEndpointSensitivity.HOME_CONTEXT,
+) -> HermesEndpoint:
+    return HermesEndpoint(name, HermesEndpointKind.PROPERTY, sensitivity)
+
+
+def _collection(
+    name: str,
+    sensitivity: HermesEndpointSensitivity = HermesEndpointSensitivity.HOME_CONTEXT,
+) -> HermesEndpoint:
+    return HermesEndpoint(name, HermesEndpointKind.COLLECTION, sensitivity)
+
+
+# This is the single source of truth for public Hermes inspection. Endpoint kind
+# is evidence-based: properties return one current value, while collections may
+# stream zero or more keyed records. Credential stores are intentionally absent.
+HERMES_ENDPOINTS = (
+    _property("active_session_key"),
+    _collection("approximate_trajectory"),
+    _property("child_lock_enabled_state", HermesEndpointSensitivity.DIAGNOSTIC),
+    _collection("coverage_corridor"),
+    _collection("coverage_marker"),
+    _property("coverage_plan"),
+    _collection("coverage_session_history"),
+    _collection("coverage_session_thumbnails"),
+    _property("coverage_time", HermesEndpointSensitivity.DIAGNOSTIC),
+    _property("current_version", HermesEndpointSensitivity.DIAGNOSTIC),
+    _property("deep_mop_override_setting_state", HermesEndpointSensitivity.DIAGNOSTIC),
+    _collection("displayed_mission"),
+    _collection("dock_detections", HermesEndpointSensitivity.DIAGNOSTIC),
+    _collection("jukebox_state"),
+    _property("kabuki_state", HermesEndpointSensitivity.DIAGNOSTIC),
+    _collection("labeled_missions"),
+    _property("latest_pose"),
+    _collection("map_combined_coverage"),
+    _collection("map_compressed_rgb"),
+    _collection("map_compressed_rgb_higher"),
+    _collection("map_integrated"),
+    _collection("map_semantics"),
+    _collection("map_semantics_override"),
+    _property("matter_pairing_state", HermesEndpointSensitivity.DIAGNOSTIC),
+    _collection("planned_path"),
+    _property("petwaste_enabled_state", HermesEndpointSensitivity.DIAGNOSTIC),
+    _collection("schedule_event_previews"),
+    _collection("schedule_events"),
+    _collection("semantics_override"),
+    _collection("sink_summon_locations"),
+    _collection("sink_summons"),
+    _property("time_zone"),
+    _property("update_config", HermesEndpointSensitivity.DIAGNOSTIC),
+    _property("update_state", HermesEndpointSensitivity.DIAGNOSTIC),
+    _property("uploader_config_state", HermesEndpointSensitivity.DIAGNOSTIC),
+    _property("user_tunnel_ssh_permission", HermesEndpointSensitivity.DIAGNOSTIC),
+    _property("voice_enabled_state", HermesEndpointSensitivity.DIAGNOSTIC),
+    _property("water_flow_override_state", HermesEndpointSensitivity.DIAGNOSTIC),
+    _property("wifi_status"),
+    _collection("zones"),
+)
+
+HERMES_ENDPOINT_MAP = {endpoint.name: endpoint for endpoint in HERMES_ENDPOINTS}
+HERMES_ENDPOINT_NAMES = tuple(HERMES_ENDPOINT_MAP)

--- a/custom_components/matic_robot/client/exceptions.py
+++ b/custom_components/matic_robot/client/exceptions.py
@@ -21,5 +21,9 @@ class AuthenticationRequiredError(MaticError):
     """The requested operation requires a Hermes credential."""
 
 
+class EndpointUnsupportedError(MaticError):
+    """The robot's current firmware does not implement this endpoint."""
+
+
 class PairingModeRequiredError(MaticError):
     """The robot is not accepting a new local Hermes user."""

--- a/custom_components/matic_robot/config_flow.py
+++ b/custom_components/matic_robot/config_flow.py
@@ -200,6 +200,7 @@ class MaticRobotConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Configure a certificate-pinned local Matic robot."""
 
     VERSION = 1
+    MINOR_VERSION = 2
 
     @staticmethod
     def async_get_options_flow(

--- a/custom_components/matic_robot/const.py
+++ b/custom_components/matic_robot/const.py
@@ -11,53 +11,9 @@ PLATFORMS: Final = [
     "select",
     "sensor",
     "switch",
+    "update",
     "vacuum",
 ]
-
-# Locally observed, non-credential Hermes collections. This allowlist powers
-# advanced diagnostics without allowing arbitrary reads of future secret stores.
-HERMES_COLLECTIONS: Final = (
-    "active_session_key",
-    "approximate_trajectory",
-    "child_lock_enabled_state",
-    "coverage_corridor",
-    "coverage_marker",
-    "coverage_plan",
-    "coverage_session_history",
-    "coverage_session_thumbnails",
-    "coverage_time",
-    "current_version",
-    "deep_mop_override_setting_state",
-    "displayed_mission",
-    "dock_detections",
-    "jukebox_state",
-    "kabuki_state",
-    "labeled_missions",
-    "latest_pose",
-    "map_combined_coverage",
-    "map_compressed_rgb",
-    "map_compressed_rgb_higher",
-    "map_integrated",
-    "map_semantics",
-    "map_semantics_override",
-    "matter_pairing_state",
-    "planned_path",
-    "petwaste_enabled_state",
-    "schedule_event_previews",
-    "schedule_events",
-    "semantics_override",
-    "sink_summon_locations",
-    "sink_summons",
-    "time_zone",
-    "update_config",
-    "update_state",
-    "uploader_config_state",
-    "user_tunnel_ssh_permission",
-    "voice_enabled_state",
-    "water_flow_override_state",
-    "wifi_status",
-    "zones",
-)
 
 CONF_CERTIFICATE_FINGERPRINT: Final = "certificate_fingerprint"
 CONF_CLEANING_MODE: Final = "cleaning_mode"
@@ -69,5 +25,11 @@ CONF_SERIAL_NUMBER: Final = "serial_number"
 DEFAULT_PORT: Final = 16320
 SERVICE_TYPE: Final = "_matic_hermes._tcp.local."
 UPDATE_INTERVAL_SECONDS: Final = 30
+SLOW_UPDATE_INTERVAL_SECONDS: Final = 300
+MAP_UPDATE_INTERVAL_SECONDS: Final = 900
 
 DATA_PLAN_MANAGER: Final = "cleaning_plan_manager"
+DATA_FIRMWARE_TRACKER: Final = "firmware_tracker"
+
+EVENT_FIRMWARE_CHANGED: Final = f"{DOMAIN}_firmware_changed"
+EVENT_CLEANING_FINISHED: Final = f"{DOMAIN}_cleaning_finished"

--- a/custom_components/matic_robot/coordinator.py
+++ b/custom_components/matic_robot/coordinator.py
@@ -5,19 +5,40 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import timedelta
+from time import monotonic
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .client.api import MaticHermesClient
 from .client.commands import CleaningMode, CoverageSetting
-from .client.exceptions import AuthenticationRequiredError, MaticError
-from .client.models import FloorPlan, RobotPose, RobotState, RobotTelemetry
-from .const import DOMAIN, UPDATE_INTERVAL_SECONDS
+from .client.exceptions import (
+    AuthenticationRequiredError,
+    CertificateMismatchError,
+    InvalidRobotCertificateError,
+    MaticError,
+)
+from .client.models import FloorPlan, RobotInfo, RobotPose, RobotState, RobotTelemetry
+from .const import (
+    DOMAIN,
+    EVENT_CLEANING_FINISHED,
+    MAP_UPDATE_INTERVAL_SECONDS,
+    SLOW_UPDATE_INTERVAL_SECONDS,
+    UPDATE_INTERVAL_SECONDS,
+)
+from .firmware import FirmwareTracker, async_build_firmware_snapshot
 
 _LOGGER = logging.getLogger(__name__)
+
+# A sweep with this many failed endpoint reads right after an OTA is far more
+# likely a flaky reboot window than real drift; retry before recording it.
+SNAPSHOT_FAILURE_THRESHOLD = 8
+SNAPSHOT_RETRY_SECONDS = 900
+SNAPSHOT_MAX_ATTEMPTS = 3
 
 
 class MaticCoordinator(DataUpdateCoordinator[RobotState]):
@@ -33,6 +54,7 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
         *,
         cleaning_mode: CleaningMode = CleaningMode.BOTH,
         coverage_setting: CoverageSetting = CoverageSetting.STANDARD,
+        firmware_tracker: FirmwareTracker | None = None,
     ) -> None:
         super().__init__(
             hass,
@@ -45,37 +67,104 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
         self.client = client
         self.cleaning_mode = cleaning_mode
         self.coverage_setting = coverage_setting
+        self.firmware_tracker = firmware_tracker
+        self._cached_info: RobotInfo | None = None
+        self._cached_floor_plan: FloorPlan | None = None
+        self._cached_telemetry: RobotTelemetry | None = None
+        self._map_refresh_due = 0.0
+        self._slow_refresh_due = 0.0
+        self._force_full_refresh = False
+        self._snapshot_versions_in_progress: set[str] = set()
+        self._snapshot_attempts: dict[str, int] = {}
+        self._snapshot_retry_after = 0.0
+        self._device_software_version: str | None = None
+        self._last_session_key: tuple[str | None, str] | None = None
+        self._identity_issue_active = False
 
     async def _async_update_data(self) -> RobotState:
         try:
             info, operational, floor_plan, pose, telemetry = await asyncio.gather(
-                self.client.async_get_info(),
+                self._async_info(),
                 self.client.async_get_state(),
                 self._async_optional_floor_plan(),
                 self._async_optional_pose(),
                 self._async_optional_telemetry(),
             )
-            return RobotState(
+            state = RobotState(
                 info=info,
                 operational=operational,
                 floor_plan=floor_plan,
                 pose=pose,
                 telemetry=telemetry,
             )
+            version = telemetry.software_version or operational.software_version
+            if version is not None:
+                self._async_update_device_software(version, info.serial_number)
+            self._async_clear_identity_issue()
+            self._async_fire_session_finished(state, version)
+            if self.firmware_tracker is not None:
+                await self.firmware_tracker.async_observe_version(
+                    self.config_entry.entry_id,
+                    version,
+                    telemetry.protocol_version,
+                    device_id=self._device_id(info.serial_number),
+                )
+                if (
+                    version is not None
+                    and version not in self._snapshot_versions_in_progress
+                    and monotonic() >= self._snapshot_retry_after
+                    and self.firmware_tracker.needs_snapshot(
+                        self.config_entry.entry_id, version
+                    )
+                ):
+                    self._snapshot_versions_in_progress.add(version)
+                    self.config_entry.async_create_background_task(
+                        self.hass,
+                        self._async_capture_firmware_snapshot(
+                            self.firmware_tracker, state, version
+                        ),
+                        f"{DOMAIN} firmware snapshot",
+                    )
+            return state
         except AuthenticationRequiredError as err:
             raise ConfigEntryAuthFailed(
                 "The robot rejected its local Home Assistant credential"
             ) from err
+        except (CertificateMismatchError, InvalidRobotCertificateError) as err:
+            self._async_raise_identity_issue()
+            raise UpdateFailed(
+                f"The robot's TLS identity no longer matches its pinned"
+                f" certificate: {err}"
+            ) from err
         except MaticError as err:
             raise UpdateFailed(str(err)) from err
+        finally:
+            self._force_full_refresh = False
+
+    async def _async_info(self) -> RobotInfo:
+        """Read immutable identity once per coordinator lifetime."""
+        if self._cached_info is None:
+            self._cached_info = await self.client.async_get_info()
+        return self._cached_info
 
     async def _async_optional_floor_plan(self) -> FloorPlan | None:
         """Read map geometry without hiding core state if unavailable."""
+        now = monotonic()
+        if (
+            not self._force_full_refresh
+            and self._cached_floor_plan is not None
+            and now < self._map_refresh_due
+        ):
+            return self._cached_floor_plan
         try:
-            return await self.client.async_get_floor_plan()
+            floor_plan = await self.client.async_get_floor_plan()
+            self._cached_floor_plan = floor_plan
+            self._map_refresh_due = now + MAP_UPDATE_INTERVAL_SECONDS
+            return floor_plan
         except MaticError as err:
             _LOGGER.debug("Optional Hermes floor plan unavailable: %s", err)
-            return None
+            self._map_refresh_due = now + UPDATE_INTERVAL_SECONDS
+            return self._cached_floor_plan
 
     async def _async_optional_pose(self) -> RobotPose | None:
         """Read map pose without hiding core state if unavailable."""
@@ -87,8 +176,144 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
 
     async def _async_optional_telemetry(self) -> RobotTelemetry:
         """Read settings and lifecycle telemetry without hiding core state."""
+        now = monotonic()
+        if (
+            not self._force_full_refresh
+            and self._cached_telemetry is not None
+            and now < self._slow_refresh_due
+        ):
+            return self._cached_telemetry
         try:
-            return await self.client.async_get_telemetry()
+            telemetry = await self.client.async_get_telemetry()
+            self._cached_telemetry = telemetry
+            self._slow_refresh_due = now + SLOW_UPDATE_INTERVAL_SECONDS
+            return telemetry
         except MaticError as err:
             _LOGGER.debug("Optional Hermes telemetry unavailable: %s", err)
-            return RobotTelemetry()
+            self._slow_refresh_due = now + UPDATE_INTERVAL_SECONDS
+            return self._cached_telemetry or RobotTelemetry()
+
+    async def async_request_full_refresh(self) -> None:
+        """Refresh slow settings immediately after a local write."""
+        self._force_full_refresh = True
+        await self.async_request_refresh()
+
+    async def _async_capture_firmware_snapshot(
+        self,
+        tracker: FirmwareTracker,
+        state: RobotState,
+        version: str,
+    ) -> None:
+        """Persist one background snapshot without delaying normal state."""
+        try:
+            snapshot = await async_build_firmware_snapshot(self.client, state)
+            attempts = self._snapshot_attempts.get(version, 0) + 1
+            self._snapshot_attempts[version] = attempts
+            failed = int(snapshot["failed_endpoints"])
+            if (
+                failed >= SNAPSHOT_FAILURE_THRESHOLD
+                and attempts < SNAPSHOT_MAX_ATTEMPTS
+            ):
+                self._snapshot_retry_after = monotonic() + SNAPSHOT_RETRY_SECONDS
+                _LOGGER.warning(
+                    "Deferring the firmware endpoint snapshot for %s: %d of %d"
+                    " reads failed (attempt %d of %d); retrying later",
+                    version,
+                    failed,
+                    snapshot["endpoint_count"],
+                    attempts,
+                    SNAPSHOT_MAX_ATTEMPTS,
+                )
+                return
+            if failed >= SNAPSHOT_FAILURE_THRESHOLD:
+                _LOGGER.warning(
+                    "Recording a degraded firmware endpoint snapshot for %s"
+                    " after %d attempts: %d of %d reads failed",
+                    version,
+                    attempts,
+                    failed,
+                    snapshot["endpoint_count"],
+                )
+            await tracker.async_record_snapshot(self.config_entry.entry_id, snapshot)
+            self._snapshot_attempts.pop(version, None)
+        finally:
+            self._snapshot_versions_in_progress.discard(version)
+
+    @callback
+    def _async_fire_session_finished(
+        self, state: RobotState, version: str | None
+    ) -> None:
+        """Announce a newly completed robot cleaning session exactly once."""
+        session = state.telemetry.latest_session
+        if session is None or session.ended_at is None:
+            return
+        key = (session.started_at, session.ended_at)
+        previous = self._last_session_key
+        self._last_session_key = key
+        if previous is None or previous == key:
+            return
+        self.hass.bus.async_fire(
+            EVENT_CLEANING_FINISHED,
+            {
+                "entry_id": self.config_entry.entry_id,
+                "device_id": self._device_id(state.info.serial_number),
+                "started_at": session.started_at,
+                "ended_at": session.ended_at,
+                "duration_seconds": session.duration_seconds,
+                "completed": session.completed,
+                "rooms": list(session.rooms),
+                "room_durations": dict(session.room_durations),
+                "firmware_version": version,
+            },
+        )
+
+    @callback
+    def _async_raise_identity_issue(self) -> None:
+        """Surface a pinned-identity mismatch distinctly from network noise."""
+        if self._identity_issue_active:
+            return
+        self._identity_issue_active = True
+        _LOGGER.error(
+            "The robot at the configured address presented a TLS certificate"
+            " that does not match the pinned robot identity; refusing to"
+            " communicate until it matches or the entry is reconfigured"
+        )
+        ir.async_create_issue(
+            self.hass,
+            DOMAIN,
+            f"robot_identity_changed_{self.config_entry.entry_id}",
+            is_fixable=False,
+            is_persistent=False,
+            severity=ir.IssueSeverity.ERROR,
+            translation_key="robot_identity_changed",
+        )
+
+    @callback
+    def _async_clear_identity_issue(self) -> None:
+        """Withdraw the identity warning after a verified reconnect."""
+        if not self._identity_issue_active:
+            return
+        self._identity_issue_active = False
+        _LOGGER.warning("The robot's TLS identity matches its pinned certificate again")
+        ir.async_delete_issue(
+            self.hass,
+            DOMAIN,
+            f"robot_identity_changed_{self.config_entry.entry_id}",
+        )
+
+    def _device_id(self, serial_number: str) -> str | None:
+        """Return the Home Assistant device id for event payloads."""
+        registry = dr.async_get(self.hass)
+        device = registry.async_get_device(identifiers={(DOMAIN, serial_number)})
+        return device.id if device is not None else None
+
+    def _async_update_device_software(self, version: str, serial_number: str) -> None:
+        """Keep Home Assistant's device firmware field current after an OTA."""
+        if version == self._device_software_version:
+            return
+        registry = dr.async_get(self.hass)
+        device = registry.async_get_device(identifiers={(DOMAIN, serial_number)})
+        if device is None:
+            return
+        registry.async_update_device(device.id, sw_version=version)
+        self._device_software_version = version

--- a/custom_components/matic_robot/diagnostics.py
+++ b/custom_components/matic_robot/diagnostics.py
@@ -2,57 +2,100 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict
 from typing import Any
 
-from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.core import HomeAssistant
 
 from . import MaticConfigEntry
-from .const import (
-    CONF_CERTIFICATE_FINGERPRINT,
-    CONF_HERMES_CREDENTIAL,
-    CONF_SERIAL_NUMBER,
-)
-
-TO_REDACT = {
-    "host",
-    "hostname",
-    "ip4_address",
-    "ip6_address",
-    CONF_CERTIFICATE_FINGERPRINT,
-    CONF_HERMES_CREDENTIAL,
-    CONF_SERIAL_NUMBER,
-}
+from .const import CONF_HERMES_CREDENTIAL
 
 
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: MaticConfigEntry
 ) -> dict[str, Any]:
     """Return redacted diagnostics."""
-    return async_redact_data(
-        {
-            "entry": dict(entry.data),
-            "robot": asdict(entry.runtime_data.coordinator.data.info),
-            "operational": asdict(entry.runtime_data.coordinator.data.operational),
-            "telemetry": asdict(entry.runtime_data.coordinator.data.telemetry),
-            "floor_plan": (
-                asdict(floor_plan)
-                if (
-                    floor_plan := getattr(
-                        entry.runtime_data.coordinator.data, "floor_plan", None
-                    )
-                )
-                is not None
-                else None
-            ),
-            "pose": (
-                asdict(pose)
-                if (pose := getattr(entry.runtime_data.coordinator.data, "pose", None))
-                is not None
-                else None
-            ),
-            "last_update_success": (entry.runtime_data.coordinator.last_update_success),
+    state = entry.runtime_data.coordinator.data
+    info = state.info
+    operational = state.operational
+    telemetry = state.telemetry
+    floor_plan = getattr(state, "floor_plan", None)
+    endpoint_health = entry.runtime_data.client.endpoint_health
+    command_health = entry.runtime_data.client.command_health
+    return {
+        "entry": {
+            "port": entry.data.get("port"),
+            "credential_configured": CONF_HERMES_CREDENTIAL in entry.data,
         },
-        TO_REDACT,
-    )
+        "robot": {
+            "hardware_revision": info.hardware_revision,
+            "encrypted": info.encrypted,
+            "requires_auth": info.requires_auth,
+            "network_auth": info.network_auth,
+        },
+        "operational": {
+            "battery_percentage": operational.battery_percentage,
+            "state_codes": list(operational.state_codes),
+            "error_codes": list(operational.error_codes),
+            "error_names": list(operational.error_names),
+            "activity": operational.activity,
+            "software_version": operational.software_version,
+            "release_channel": operational.release_channel,
+            "robot_profile": operational.robot_profile,
+        },
+        "telemetry": {
+            "software_version": telemetry.software_version,
+            "software_profile": telemetry.software_profile,
+            "protocol_version": telemetry.protocol_version,
+            "update_channel": telemetry.update_channel,
+            "update_state": telemetry.update_state,
+            "wifi_state": telemetry.wifi_state,
+            "wifi_signal_dbm": telemetry.wifi_signal_dbm,
+            "known_network_count": sum(
+                network.known for network in telemetry.wifi_networks
+            ),
+            "visible_network_count": len(telemetry.wifi_networks),
+            "scheduled_cleanings": telemetry.scheduled_cleanings,
+            "local_cleaning_sessions": telemetry.local_cleaning_sessions,
+            "child_lock_enabled": telemetry.child_lock_enabled,
+            "pet_waste_enabled": telemetry.pet_waste_enabled,
+            "voice_enabled": telemetry.voice_enabled,
+            "matter_pairing_enabled": telemetry.matter_pairing_enabled,
+            "deep_mop_enabled": telemetry.deep_mop_enabled,
+            "water_flow_factor": telemetry.water_flow_factor,
+            "ssh_tunnel_permission": telemetry.ssh_tunnel_permission,
+            "uploader_opt_in": telemetry.uploader_opt_in,
+            "active_cleaning_session": telemetry.active_cleaning_session,
+            "dock_detections": telemetry.dock_detections,
+            "sink_summon_locations": telemetry.sink_summon_locations,
+            "coverage_time_seconds": telemetry.coverage_time_seconds,
+        },
+        "map": {
+            "available": floor_plan is not None,
+            "room_count": len(floor_plan.rooms) if floor_plan is not None else 0,
+            "pose_available": getattr(state, "pose", None) is not None,
+        },
+        "endpoint_health": {
+            "observed": len(endpoint_health),
+            "healthy": sum(status == "ok" for status in endpoint_health.values()),
+            "failures": {
+                name: status
+                for name, status in endpoint_health.items()
+                if status != "ok"
+            },
+        },
+        "command_health": {
+            "observed": len(command_health),
+            "acknowledged": sum(
+                status == "acknowledged" for status in command_health.values()
+            ),
+            "failures": {
+                name: status
+                for name, status in command_health.items()
+                if status != "acknowledged"
+            },
+        },
+        "firmware_tracking": entry.runtime_data.firmware_tracker.summary(
+            entry.entry_id
+        ),
+        "last_update_success": entry.runtime_data.coordinator.last_update_success,
+    }

--- a/custom_components/matic_robot/entity.py
+++ b/custom_components/matic_robot/entity.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import slugify
 
 from . import MaticConfigEntry
 from .const import DOMAIN
@@ -30,3 +31,21 @@ class MaticEntity(CoordinatorEntity[MaticCoordinator]):
                 state.telemetry.software_version or state.operational.software_version
             ),
         )
+        self._matic_device_name = info.name or "Matic"
+        self._matic_serial = info.serial_number
+
+    @property
+    def suggested_object_id(self) -> str | None:
+        """Anchor object ids to stable keys instead of translated names.
+
+        The registry prefixes the device name itself for named entities, so
+        the returned id must stay unprefixed; the vacuum returns None so it
+        becomes the bare device name.
+        """
+        unique_id = self.unique_id
+        if unique_id is None:
+            return None
+        key = unique_id.removeprefix(f"{self._matic_serial}_")
+        if key == "vacuum":
+            return None
+        return slugify(key)

--- a/custom_components/matic_robot/firmware.py
+++ b/custom_components/matic_robot/firmware.py
@@ -1,0 +1,342 @@
+"""Persistent, privacy-safe firmware compatibility observations."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from collections.abc import Callable, Mapping
+from copy import deepcopy
+from typing import Any, cast
+
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.storage import Store
+from homeassistant.util import dt as dt_util
+
+from .client.api import MaticHermesClient
+from .client.endpoints import HERMES_ENDPOINTS, HermesEndpoint
+from .client.exceptions import MaticError
+from .client.models import HermesCollectionEntry, RobotState
+from .const import DOMAIN, EVENT_FIRMWARE_CHANGED
+
+STORAGE_VERSION = 1
+STORAGE_KEY = f"{DOMAIN}.firmware"
+MAX_HISTORY = 52
+
+
+class FirmwareTracker:
+    """Persist safe weekly snapshots and signal newly observed firmware."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        self.hass = hass
+        self._store = Store[dict[str, Any]](
+            hass, STORAGE_VERSION, STORAGE_KEY, private=True
+        )
+        self._data: dict[str, Any] = {"robots": {}}
+        self._listeners: dict[str, set[Callable[[], None]]] = {}
+        self._lock = asyncio.Lock()
+
+    async def async_load(self) -> None:
+        """Load prior firmware observations."""
+        self._data = await self._store.async_load() or {"robots": {}}
+
+    async def async_observe_version(
+        self,
+        robot_id: str,
+        version: str | None,
+        protocol: int | None,
+        *,
+        device_id: str | None = None,
+    ) -> bool:
+        """Record a version and create a repair only when it changes."""
+        if version is None:
+            return False
+        async with self._lock:
+            robot = self._robot(robot_id)
+            previous = robot.get("observed_version")
+            previous_protocol = robot.get("observed_protocol")
+            if previous == version and previous_protocol == protocol:
+                return False
+            robot["observed_version"] = version
+            robot["observed_protocol"] = protocol
+            robot["compatibility_status"] = "pending"
+            await self._store.async_save(self._data)
+        self._notify(robot_id)
+        if previous is None:
+            return False
+
+        self.hass.bus.async_fire(
+            EVENT_FIRMWARE_CHANGED,
+            {
+                "entry_id": robot_id,
+                "device_id": device_id,
+                "previous_version": previous,
+                "firmware_version": version,
+                "previous_protocol": previous_protocol,
+                "protocol_version": protocol,
+            },
+        )
+        return True
+
+    async def async_remove_robot(self, robot_id: str) -> None:
+        """Forget a removed entry's snapshots and withdraw its repair."""
+        async with self._lock:
+            if self._data.get("robots", {}).pop(robot_id, None) is None:
+                return
+            await self._store.async_save(self._data)
+        ir.async_delete_issue(self.hass, DOMAIN, self.issue_id(robot_id))
+
+    async def async_record_snapshot(
+        self, robot_id: str, snapshot: Mapping[str, Any]
+    ) -> dict[str, Any]:
+        """Persist one safe snapshot and return its comparison with the prior one."""
+        async with self._lock:
+            robot = self._robot(robot_id)
+            previous = robot.get("snapshot")
+            current = deepcopy(dict(snapshot))
+            comparison = _compare_snapshots(previous, current)
+            history = robot.setdefault("history", [])
+            release_comparison = comparison
+            if previous is not None and previous.get("firmware_version") == current.get(
+                "firmware_version"
+            ):
+                previous_release = next(
+                    (
+                        item
+                        for item in reversed(history)
+                        if item.get("firmware_version")
+                        != current.get("firmware_version")
+                    ),
+                    None,
+                )
+                if previous_release is not None:
+                    release_comparison = _compare_snapshots(previous_release, current)
+            robot["snapshot"] = current
+            robot["compatibility_status"] = _compatibility_status(
+                robot.get("compatibility_status"), release_comparison
+            )
+            robot["last_comparison"] = {
+                "changed_endpoints": len(release_comparison["changed_endpoints"]),
+                "content_changed_endpoints": len(
+                    release_comparison["content_changed_endpoints"]
+                ),
+            }
+            history.append(current)
+            del history[:-MAX_HISTORY]
+            await self._store.async_save(self._data)
+        self._notify(robot_id)
+        previous_version = previous.get("firmware_version") if previous else None
+        if (
+            release_comparison["firmware_changed"]
+            and release_comparison["changed_endpoints"]
+        ):
+            ir.async_create_issue(
+                self.hass,
+                DOMAIN,
+                self.issue_id(robot_id),
+                is_fixable=False,
+                is_persistent=True,
+                severity=ir.IssueSeverity.WARNING,
+                translation_key="firmware_regression",
+                translation_placeholders={
+                    "previous": str(previous_version),
+                    "current": str(current.get("firmware_version")),
+                    "count": str(len(release_comparison["changed_endpoints"])),
+                },
+            )
+        elif release_comparison["baseline"] or release_comparison["firmware_changed"]:
+            ir.async_delete_issue(self.hass, DOMAIN, self.issue_id(robot_id))
+        return comparison
+
+    def summary(self, robot_id: str) -> dict[str, Any]:
+        """Return a payload-free summary suitable for diagnostics."""
+        robot = self._data.get("robots", {}).get(robot_id, {})
+        snapshot = robot.get("snapshot") or {}
+        comparison = robot.get("last_comparison") or {}
+        return {
+            "observed_version": robot.get("observed_version"),
+            "observed_protocol": robot.get("observed_protocol"),
+            "compatibility_status": robot.get("compatibility_status", "pending"),
+            "last_snapshot_at": snapshot.get("captured_at"),
+            "snapshot_count": len(robot.get("history", [])),
+            "endpoint_count": snapshot.get("endpoint_count"),
+            "populated_endpoints": snapshot.get("populated_endpoints"),
+            "empty_endpoints": snapshot.get("empty_endpoints"),
+            "failed_endpoints": snapshot.get("failed_endpoints"),
+            "changed_endpoints": comparison.get("changed_endpoints"),
+            "content_changed_endpoints": comparison.get("content_changed_endpoints"),
+        }
+
+    def needs_snapshot(self, robot_id: str, version: str) -> bool:
+        """Return whether this firmware lacks a completed endpoint snapshot."""
+        snapshot = self._data.get("robots", {}).get(robot_id, {}).get("snapshot", {})
+        return bool(snapshot.get("firmware_version") != version)
+
+    @callback
+    def async_add_listener(
+        self, robot_id: str, listener: Callable[[], None]
+    ) -> Callable[[], None]:
+        """Subscribe an entity to firmware observation changes."""
+        listeners = self._listeners.setdefault(robot_id, set())
+        listeners.add(listener)
+
+        @callback
+        def remove_listener() -> None:
+            listeners.discard(listener)
+
+        return remove_listener
+
+    @staticmethod
+    def issue_id(robot_id: str) -> str:
+        """Return a stable non-identifying repair key."""
+        digest = hashlib.sha256(robot_id.encode()).hexdigest()[:12]
+        return f"firmware_changed_{digest}"
+
+    def _robot(self, robot_id: str) -> dict[str, Any]:
+        return cast(
+            dict[str, Any],
+            self._data.setdefault("robots", {}).setdefault(robot_id, {}),
+        )
+
+    @callback
+    def _notify(self, robot_id: str) -> None:
+        for listener in list(self._listeners.get(robot_id, set())):
+            listener()
+
+
+def _compare_snapshots(
+    previous: Mapping[str, Any] | None, current: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Compare safe endpoint fingerprints without exposing payloads."""
+    if previous is None:
+        return {
+            "baseline": True,
+            "firmware_changed": False,
+            "protocol_changed": False,
+            "changed_endpoints": [],
+            "content_changed_endpoints": [],
+        }
+    previous_endpoints = {item["name"]: item for item in previous.get("endpoints", [])}
+    current_endpoints = {item["name"]: item for item in current.get("endpoints", [])}
+    names = previous_endpoints.keys() | current_endpoints.keys()
+    availability_changed = sorted(
+        name
+        for name in names
+        if _compatibility_signature(previous_endpoints.get(name))
+        != _compatibility_signature(current_endpoints.get(name))
+    )
+    content_changed = sorted(
+        name
+        for name in names
+        if previous_endpoints.get(name) != current_endpoints.get(name)
+    )
+    return {
+        "baseline": False,
+        "firmware_changed": previous.get("firmware_version")
+        != current.get("firmware_version"),
+        "protocol_changed": previous.get("protocol_version")
+        != current.get("protocol_version"),
+        "changed_endpoints": availability_changed,
+        "content_changed_endpoints": content_changed,
+    }
+
+
+def _compatibility_signature(endpoint: Mapping[str, Any] | None) -> tuple[Any, ...]:
+    """Return only transport-level fields that indicate compatibility drift.
+
+    Populated and empty both mean the endpoint answered; whether it held data
+    at sweep time depends on robot activity, not firmware capability.
+    """
+    if endpoint is None:
+        return ()
+    status = endpoint.get("status")
+    if status in ("populated", "empty"):
+        status = "reachable"
+    return (
+        endpoint.get("kind"),
+        status,
+        endpoint.get("error_type"),
+    )
+
+
+def _compatibility_status(current: str | None, comparison: Mapping[str, Any]) -> str:
+    """Translate one snapshot comparison into durable HA-facing health."""
+    if comparison["baseline"]:
+        return "baseline"
+    if comparison["firmware_changed"] and comparison["changed_endpoints"]:
+        return "regression"
+    if comparison["firmware_changed"]:
+        return "compatible"
+    return current or "current"
+
+
+def snapshot_timestamp() -> str:
+    """Return one normalized timestamp for a persisted snapshot."""
+    return dt_util.utcnow().isoformat()
+
+
+def fingerprint_entry(value: HermesCollectionEntry) -> dict[str, Any]:
+    """Return irreversible metadata for one Hermes value."""
+    return {
+        "key_size": len(value.key),
+        "value_size": len(value.value),
+        "key_sha256": hashlib.sha256(value.key).hexdigest(),
+        "value_sha256": hashlib.sha256(value.value).hexdigest(),
+    }
+
+
+async def _async_snapshot_endpoint(
+    client: MaticHermesClient,
+    endpoint: HermesEndpoint,
+    semaphore: asyncio.Semaphore,
+) -> dict[str, Any]:
+    """Read one endpoint into a payload-free compatibility record."""
+    try:
+        async with semaphore:
+            values = await client.async_inspect_endpoint(endpoint.name, limit=1)
+    except MaticError as err:
+        return {
+            "name": endpoint.name,
+            "kind": endpoint.kind,
+            "sensitivity": endpoint.sensitivity,
+            "status": "error",
+            "error_type": type(err).__name__,
+            "entries": [],
+        }
+    return {
+        "name": endpoint.name,
+        "kind": endpoint.kind,
+        "sensitivity": endpoint.sensitivity,
+        "status": "populated" if values else "empty",
+        "entries": [fingerprint_entry(value) for value in values],
+    }
+
+
+async def async_build_firmware_snapshot(
+    client: MaticHermesClient, state: RobotState
+) -> dict[str, Any]:
+    """Capture every known endpoint without retaining any payload bytes."""
+    semaphore = asyncio.Semaphore(4)
+    endpoints = await asyncio.gather(
+        *(
+            _async_snapshot_endpoint(client, endpoint, semaphore)
+            for endpoint in HERMES_ENDPOINTS
+        )
+    )
+    firmware_version = (
+        state.telemetry.software_version or state.operational.software_version
+    )
+    return {
+        "captured_at": snapshot_timestamp(),
+        "firmware_version": firmware_version,
+        "protocol_version": state.telemetry.protocol_version,
+        "endpoint_count": len(endpoints),
+        "populated_endpoints": sum(
+            endpoint["status"] == "populated" for endpoint in endpoints
+        ),
+        "empty_endpoints": sum(endpoint["status"] == "empty" for endpoint in endpoints),
+        "failed_endpoints": sum(
+            endpoint["status"] == "error" for endpoint in endpoints
+        ),
+        "endpoints": endpoints,
+    }

--- a/custom_components/matic_robot/manifest.json
+++ b/custom_components/matic_robot/manifest.json
@@ -19,9 +19,10 @@
   "issue_tracker": "https://github.com/ProspectOre/matic-home-assistant/issues",
   "requirements": [
     "grpclib==0.4.9",
+    "h2>=4",
     "protobuf>=6"
   ],
-  "version": "0.1.2",
+  "version": "0.2.0",
   "zeroconf": [
     "_matic_hermes._tcp.local."
   ]

--- a/custom_components/matic_robot/migrations.py
+++ b/custom_components/matic_robot/migrations.py
@@ -1,0 +1,57 @@
+"""Pre-1.0 migrations to the integration's canonical data model."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util import slugify
+
+from .const import CONF_SERIAL_NUMBER, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate one config entry to the current schema exactly once.
+
+    Running under the entry's minor version means a user rename applied
+    after this migration is never touched again on later restarts.
+    """
+    if entry.version > 1:
+        return False
+    if entry.minor_version < 2:
+        _async_migrate_entity_ids(hass, entry)
+        hass.config_entries.async_update_entry(entry, minor_version=2)
+    return True
+
+
+def _async_migrate_entity_ids(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Move pre-0.2.0 registry entries to descriptive canonical entity IDs."""
+    serial_number = entry.data.get(CONF_SERIAL_NUMBER)
+    if serial_number is None:
+        return
+    device = dr.async_get(hass).async_get_device(identifiers={(DOMAIN, serial_number)})
+    device_name = (device.name if device is not None else None) or "Matic"
+    registry = er.async_get(hass)
+    prefix = f"{serial_number}_"
+    for registry_entry in er.async_entries_for_config_entry(registry, entry.entry_id):
+        if not registry_entry.unique_id.startswith(prefix):
+            continue
+        key = registry_entry.unique_id.removeprefix(prefix)
+        object_id = slugify(device_name if key == "vacuum" else f"{device_name}_{key}")
+        desired = f"{registry_entry.domain}.{object_id}"
+        if desired == registry_entry.entity_id:
+            continue
+        if registry.async_get(desired) is not None:
+            _LOGGER.info(
+                "Keeping entity id %s: the canonical id %s is already in use",
+                registry_entry.entity_id,
+                desired,
+            )
+            continue
+        _LOGGER.info("Migrating entity id %s to %s", registry_entry.entity_id, desired)
+        registry.async_update_entity(registry_entry.entity_id, new_entity_id=desired)

--- a/custom_components/matic_robot/number.py
+++ b/custom_components/matic_robot/number.py
@@ -53,4 +53,4 @@ class MaticWaterFlowNumber(MaticEntity, NumberEntity):
     async def async_set_native_value(self, value: float) -> None:
         """Set the robot's official 0.5x to 2.0x water-flow factor."""
         await self.coordinator.client.async_set_water_flow(value)
-        await self.coordinator.async_request_refresh()
+        await self.coordinator.async_request_full_refresh()

--- a/custom_components/matic_robot/sensor.py
+++ b/custom_components/matic_robot/sensor.py
@@ -4,19 +4,29 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any
 
 from homeassistant.components.sensor import (
+    RestoreSensor,
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
+    SensorStateClass,
 )
-from homeassistant.const import PERCENTAGE, EntityCategory
+from homeassistant.const import (
+    PERCENTAGE,
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    EntityCategory,
+    UnitOfTime,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util import dt as dt_util
+from homeassistant.util import slugify
 
 from . import MaticConfigEntry
-from .client.models import RobotState
+from .client.models import RobotState, Room
 from .entity import MaticEntity
 
 PARALLEL_UPDATES = 0
@@ -65,6 +75,28 @@ SOFTWARE_DESCRIPTION = SensorEntityDescription(
     entity_category=EntityCategory.DIAGNOSTIC,
 )
 
+FIRMWARE_COMPATIBILITY_DESCRIPTION = SensorEntityDescription(
+    key="firmware_compatibility",
+    translation_key="firmware_compatibility",
+    entity_category=EntityCategory.DIAGNOSTIC,
+)
+
+ROOM_DURATION_DESCRIPTION = SensorEntityDescription(
+    key="room_clean_duration",
+    translation_key="room_clean_duration",
+    device_class=SensorDeviceClass.DURATION,
+    native_unit_of_measurement=UnitOfTime.SECONDS,
+    state_class=SensorStateClass.MEASUREMENT,
+    entity_registry_enabled_default=False,
+)
+
+ROOM_LAST_CLEANED_DESCRIPTION = SensorEntityDescription(
+    key="room_last_cleaned",
+    translation_key="room_last_cleaned",
+    device_class=SensorDeviceClass.TIMESTAMP,
+    entity_registry_enabled_default=False,
+)
+
 
 @dataclass(frozen=True, kw_only=True)
 class MaticStateSensorDescription(SensorEntityDescription):
@@ -103,36 +135,64 @@ STATE_DESCRIPTIONS = (
         key="wifi_state",
         translation_key="wifi_state",
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
         value_fn=lambda state: state.telemetry.wifi_state,
     ),
     MaticStateSensorDescription(
         key="scheduled_cleanings",
         translation_key="scheduled_cleanings",
+        entity_registry_enabled_default=False,
         value_fn=lambda state: state.telemetry.scheduled_cleanings,
     ),
     MaticStateSensorDescription(
         key="local_cleaning_sessions",
         translation_key="local_cleaning_sessions",
+        entity_registry_enabled_default=False,
         value_fn=lambda state: state.telemetry.local_cleaning_sessions,
     ),
     MaticStateSensorDescription(
         key="dock_detections",
         translation_key="dock_detections",
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
         value_fn=lambda state: state.telemetry.dock_detections,
     ),
     MaticStateSensorDescription(
         key="sink_summon_locations",
         translation_key="sink_summon_locations",
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
         value_fn=lambda state: state.telemetry.sink_summon_locations,
     ),
     MaticStateSensorDescription(
         key="coverage_time",
         translation_key="coverage_time",
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
         native_unit_of_measurement="s",
         value_fn=lambda state: state.telemetry.coverage_time_seconds,
+    ),
+    MaticStateSensorDescription(
+        key="last_run_duration",
+        translation_key="last_run_duration",
+        device_class=SensorDeviceClass.DURATION,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda state: (
+            state.telemetry.latest_session.duration_seconds
+            if state.telemetry.latest_session is not None
+            else None
+        ),
+    ),
+    MaticStateSensorDescription(
+        key="wifi_signal",
+        translation_key="wifi_signal",
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+        value_fn=lambda state: state.telemetry.wifi_signal_dbm,
     ),
 )
 
@@ -143,6 +203,25 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up Matic diagnostic sensors."""
+    coordinator = entry.runtime_data.coordinator
+    known_rooms: set[str] = set()
+
+    def _new_room_entities() -> list[SensorEntity]:
+        """Build opt-in statistics sensors for rooms not yet seen."""
+        floor_plan = coordinator.data.floor_plan
+        if floor_plan is None:
+            return []
+        new_rooms = [room for room in floor_plan.rooms if room.id not in known_rooms]
+        known_rooms.update(room.id for room in new_rooms)
+        return [
+            entity
+            for room in new_rooms
+            for entity in (
+                MaticRoomDurationSensor(entry, room),
+                MaticRoomLastCleanedSensor(entry, room),
+            )
+        ]
+
     async_add_entities(
         [
             MaticActivitySensor(entry),
@@ -153,12 +232,22 @@ async def async_setup_entry(
             MaticActiveCleaningPlanSensor(entry),
             MaticNextCleaningRoomSensor(entry),
             MaticSoftwareVersionSensor(entry),
+            MaticFirmwareCompatibilitySensor(entry),
             *(
                 MaticStateSensor(entry, description)
                 for description in STATE_DESCRIPTIONS
             ),
+            *_new_room_entities(),
         ]
     )
+
+    @callback
+    def _async_add_new_rooms() -> None:
+        """Add statistics sensors when the floor plan grows a room."""
+        if new_entities := _new_room_entities():
+            async_add_entities(new_entities)
+
+    entry.async_on_unload(coordinator.async_add_listener(_async_add_new_rooms))
 
 
 class MaticHardwareRevisionSensor(MaticEntity, SensorEntity):
@@ -237,6 +326,8 @@ class MaticSoftwareVersionSensor(MaticEntity, SensorEntity):
         state = self.coordinator.data
         return state.telemetry.software_version or state.operational.software_version
 
+    _unrecorded_attributes = frozenset({"timezone"})
+
     @property
     def extra_state_attributes(self) -> dict[str, object]:
         """Expose safe build metadata for update-aware automations."""
@@ -250,10 +341,55 @@ class MaticSoftwareVersionSensor(MaticEntity, SensorEntity):
         }
 
 
+class MaticFirmwareCompatibilitySensor(MaticEntity, SensorEntity):
+    """Persistent firmware and endpoint compatibility state."""
+
+    entity_description = FIRMWARE_COMPATIBILITY_DESCRIPTION
+
+    def __init__(self, entry: MaticConfigEntry) -> None:
+        super().__init__(entry)
+        self._entry_id = entry.entry_id
+        self._tracker = entry.runtime_data.firmware_tracker
+        self._attr_unique_id = (
+            f"{self.coordinator.data.info.serial_number}_firmware_compatibility"
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to background snapshot completion."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self._tracker.async_add_listener(
+                self._entry_id, self._async_firmware_updated
+            )
+        )
+
+    @callback
+    def _async_firmware_updated(self) -> None:
+        self.async_write_ha_state()
+
+    @property
+    def available(self) -> bool:
+        """Keep persisted compatibility visible while the robot is offline."""
+        return True
+
+    @property
+    def native_value(self) -> str:
+        """Return pending, baseline, compatible, or regression."""
+        return str(self._tracker.summary(self._entry_id)["compatibility_status"])
+
+    @property
+    def extra_state_attributes(self) -> dict[str, object]:
+        """Return only payload-free snapshot counts and versions."""
+        return self._tracker.summary(self._entry_id)
+
+
 class MaticStateSensor(MaticEntity, SensorEntity):
     """A safe, independently addressable local telemetry field."""
 
     entity_description: MaticStateSensorDescription
+    _unrecorded_attributes = frozenset(
+        {"ssid", "schedules", "latest_rooms", "latest_room_durations"}
+    )
 
     def __init__(
         self,
@@ -287,15 +423,6 @@ class MaticStateSensor(MaticEntity, SensorEntity):
                     network.known for network in telemetry.wifi_networks
                 ),
                 "visible_networks": len(telemetry.wifi_networks),
-                "networks": [
-                    {
-                        "ssid": network.ssid,
-                        "signal_dbm": network.signal_dbm,
-                        "connected": network.connected,
-                        "known": network.known,
-                    }
-                    for network in telemetry.wifi_networks
-                ],
             }
         if key == "scheduled_cleanings":
             room_names = (
@@ -345,6 +472,7 @@ class MaticRoomsSensor(MaticEntity, SensorEntity):
     """Expose the active floor's room inventory."""
 
     entity_description = ROOMS_DESCRIPTION
+    _unrecorded_attributes = frozenset({"room_names", "segments"})
 
     def __init__(self, entry: MaticConfigEntry) -> None:
         super().__init__(entry)
@@ -372,6 +500,17 @@ class MaticCleaningHistorySensor(MaticEntity, SensorEntity):
     """Expose durable managed-plan outcomes for advanced automations."""
 
     entity_description = HISTORY_DESCRIPTION
+    _unrecorded_attributes = frozenset(
+        {
+            "last_completed_by_room",
+            "plans",
+            "plan_history",
+            "selected_plan",
+            "selected_plan_name",
+            "active_plan",
+            "last_interrupted_plan",
+        }
+    )
 
     def __init__(self, entry: MaticConfigEntry) -> None:
         super().__init__(entry)
@@ -405,7 +544,12 @@ class MaticCleaningHistorySensor(MaticEntity, SensorEntity):
     @property
     def extra_state_attributes(self) -> dict[str, object]:
         """Return per-room timestamps, rotation records, and active plan."""
-        return self._history.snapshot(self._serial_number)
+        snapshot = self._history.snapshot(self._serial_number)
+        return {
+            **snapshot,
+            "plan_count": len(snapshot["plans"]),
+            "plan_running": snapshot["active_plan"] is not None,
+        }
 
 
 class _MaticPlanSensor(MaticEntity, SensorEntity):
@@ -439,6 +583,7 @@ class MaticActiveCleaningPlanSensor(_MaticPlanSensor):
     """Expose the running plan and exact active room."""
 
     entity_description = ACTIVE_PLAN_DESCRIPTION
+    _unrecorded_attributes = frozenset({"active"})
 
     def __init__(self, entry: MaticConfigEntry) -> None:
         super().__init__(entry)
@@ -454,13 +599,14 @@ class MaticActiveCleaningPlanSensor(_MaticPlanSensor):
     def extra_state_attributes(self) -> dict[str, object] | None:
         """Return the active room and start time."""
         active = self._history.snapshot(self._serial_number)["active_plan"]
-        return dict(active) if active else None
+        return {"active": dict(active)} if active else None
 
 
 class MaticNextCleaningRoomSensor(_MaticPlanSensor):
     """Preview the next room due in the selected saved plan."""
 
     entity_description = NEXT_ROOM_DESCRIPTION
+    _unrecorded_attributes = frozenset({"preview"})
 
     def __init__(self, entry: MaticConfigEntry) -> None:
         super().__init__(entry)
@@ -489,4 +635,106 @@ class MaticNextCleaningRoomSensor(_MaticPlanSensor):
     @property
     def extra_state_attributes(self) -> dict[str, object] | None:
         """Return the complete dry-run preview for automation templates."""
-        return self._preview()
+        preview = self._preview()
+        return {"preview": preview} if preview else None
+
+
+class _MaticRoomStatisticsSensor(MaticEntity, RestoreSensor):
+    """Opt-in, restore-backed statistics for one named room.
+
+    Values persist across restarts and robot outages so long-term
+    statistics survive sessions the robot completes while HA is down.
+    """
+
+    def __init__(self, entry: MaticConfigEntry, room: Room) -> None:
+        super().__init__(entry)
+        self._room_id = room.id
+        self._attr_translation_placeholders = {"room": room.name}
+        self._suggested_suffix = room.name
+
+    @property
+    def suggested_object_id(self) -> str | None:
+        """Name the entity after the room, not its opaque identifier."""
+        suffix = self.entity_description.key.removeprefix("room_")
+        return slugify(f"{self._suggested_suffix}_{suffix}")
+
+    @property
+    def available(self) -> bool:
+        """Keep historical room facts visible while the robot is offline."""
+        return True
+
+    def _room_session_value(self) -> tuple[str, int] | None:
+        """Return this room's (ended_at, seconds) from the latest session."""
+        state = self.coordinator.data
+        session = state.telemetry.latest_session
+        if session is None or session.ended_at is None or state.floor_plan is None:
+            return None
+        room = next(
+            (item for item in state.floor_plan.rooms if item.id == self._room_id),
+            None,
+        )
+        if room is None:
+            return None
+        durations = dict(session.room_durations)
+        if room.name not in durations:
+            return None
+        return session.ended_at, durations[room.name]
+
+    @callback
+    def _async_apply_session(self) -> None:
+        """Apply the latest finished session that included this room."""
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self._async_apply_session()
+        super()._handle_coordinator_update()
+
+
+class MaticRoomDurationSensor(_MaticRoomStatisticsSensor):
+    """How long the robot spent in one room during its latest visit."""
+
+    entity_description = ROOM_DURATION_DESCRIPTION
+
+    def __init__(self, entry: MaticConfigEntry, room: Room) -> None:
+        super().__init__(entry, room)
+        self._attr_unique_id = f"{self._matic_serial}_room_{room.id}_clean_duration"
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the last known duration, then apply any newer session."""
+        await super().async_added_to_hass()
+        data = await self.async_get_last_sensor_data()
+        if data is not None and isinstance(data.native_value, (int, float)):
+            self._attr_native_value = int(data.native_value)
+        self._async_apply_session()
+
+    @callback
+    def _async_apply_session(self) -> None:
+        """Apply the latest finished session that included this room."""
+        if (value := self._room_session_value()) is not None:
+            self._attr_native_value = value[1]
+
+
+class MaticRoomLastCleanedSensor(_MaticRoomStatisticsSensor):
+    """When the robot last finished a session that covered one room."""
+
+    entity_description = ROOM_LAST_CLEANED_DESCRIPTION
+
+    def __init__(self, entry: MaticConfigEntry, room: Room) -> None:
+        super().__init__(entry, room)
+        self._attr_unique_id = f"{self._matic_serial}_room_{room.id}_last_cleaned"
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the last known timestamp, then apply any newer session."""
+        await super().async_added_to_hass()
+        data = await self.async_get_last_sensor_data()
+        if data is not None and isinstance(data.native_value, datetime):
+            self._attr_native_value = data.native_value
+        self._async_apply_session()
+
+    @callback
+    def _async_apply_session(self) -> None:
+        """Apply the latest finished session that included this room."""
+        if (value := self._room_session_value()) is not None:
+            ended_at = dt_util.parse_datetime(value[0])
+            if ended_at is not None:
+                self._attr_native_value = dt_util.as_utc(ended_at)

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import base64
-import hashlib
 from copy import deepcopy
 from typing import Any
 
@@ -35,8 +33,18 @@ from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.util import slugify
 
 from .client.commands import CleaningMode, CoverageSetting
+from .client.endpoints import HERMES_ENDPOINT_MAP, HERMES_ENDPOINT_NAMES
 from .client.exceptions import MaticError
-from .const import DATA_PLAN_MANAGER, DOMAIN, HERMES_COLLECTIONS
+from .const import (
+    DATA_FIRMWARE_TRACKER,
+    DATA_PLAN_MANAGER,
+    DOMAIN,
+)
+from .firmware import (
+    FirmwareTracker,
+    async_build_firmware_snapshot,
+    fingerprint_entry,
+)
 from .plans import CleaningPlanManager, CleaningRoom, resolve_rooms
 
 SERVICE_CLEAN = "clean"
@@ -53,7 +61,8 @@ SERVICE_SELECT_PLAN = "select_plan"
 SERVICE_SAVE_PLAN_ROOM = "save_plan_room"
 SERVICE_DELETE_PLAN_ROOM = "delete_plan_room"
 SERVICE_MOVE_PLAN_ROOM = "move_plan_room"
-SERVICE_FETCH_HERMES_COLLECTION = "fetch_hermes_collection"
+SERVICE_INSPECT_HERMES_ENDPOINT = "inspect_hermes_endpoint"
+SERVICE_FIRMWARE_SNAPSHOT = "firmware_snapshot"
 TARGET_KEYS = (
     ATTR_ENTITY_ID,
     ATTR_DEVICE_ID,
@@ -150,19 +159,16 @@ MOVE_PLAN_ROOM_SCHEMA = cv.make_entity_service_schema(
     }
 )
 
-FETCH_COLLECTION_SERVICE_SCHEMA = cv.make_entity_service_schema(
+INSPECT_ENDPOINT_SERVICE_SCHEMA = cv.make_entity_service_schema(
     {
-        vol.Required("collection"): vol.In(HERMES_COLLECTIONS),
+        vol.Required("endpoint"): vol.In(HERMES_ENDPOINT_NAMES),
         vol.Optional("limit", default=32): vol.All(
             vol.Coerce(int), vol.Range(min=1, max=256)
         ),
-        vol.Optional("include_payload", default=False): cv.boolean,
-        vol.Optional("payload_format", default="base64"): vol.In(("base64", "hex")),
-        vol.Optional("max_bytes", default=65536): vol.All(
-            vol.Coerce(int), vol.Range(min=0, max=1048576)
-        ),
     }
 )
+
+FIRMWARE_SNAPSHOT_SCHEMA = cv.make_entity_service_schema({})
 
 
 async def async_register_services(hass: HomeAssistant) -> None:
@@ -171,6 +177,9 @@ async def async_register_services(hass: HomeAssistant) -> None:
     manager = CleaningPlanManager(hass)
     await manager.async_load()
     hass.data.setdefault(DOMAIN, {})[DATA_PLAN_MANAGER] = manager
+    firmware_tracker = FirmwareTracker(hass)
+    await firmware_tracker.async_load()
+    hass.data[DOMAIN][DATA_FIRMWARE_TRACKER] = firmware_tracker
 
     async def async_clean(call: ServiceCall) -> None:
         """Route the complete verified cleaning matrix to selected vacuums."""
@@ -549,54 +558,58 @@ async def async_register_services(hass: HomeAssistant) -> None:
         supports_response=SupportsResponse.OPTIONAL,
     )
 
-    async def async_fetch_collection(call: ServiceCall) -> dict[str, Any]:
-        """Return a bounded snapshot from the non-credential Hermes allowlist."""
+    async def async_inspect_endpoint(call: ServiceCall) -> dict[str, Any]:
+        """Return payload-free fingerprints from the Hermes allowlist."""
         entity_ids = _resolve_loaded_matic_vacuums(hass, call)
         if len(entity_ids) != 1:
             raise _validation_error(
-                "Raw Hermes inspection requires exactly one Matic robot",
+                "Hermes endpoint inspection requires exactly one Matic robot",
                 "single_robot_required",
             )
         entry = _entry_for_entity(hass, entity_ids[0])
-        collection = call.data["collection"]
-        values = await entry.runtime_data.client.async_get_collection_entries(
-            collection, limit=call.data["limit"]
+        endpoint_name = call.data["endpoint"]
+        endpoint = HERMES_ENDPOINT_MAP[endpoint_name]
+        values = await entry.runtime_data.client.async_inspect_endpoint(
+            endpoint_name, limit=call.data["limit"]
         )
-        include = call.data["include_payload"]
-        maximum = call.data["max_bytes"]
-        encoding = call.data["payload_format"]
-        response_entries: list[dict[str, Any]] = []
-        for value in values:
-            item: dict[str, Any] = {
-                "key_size": len(value.key),
-                "value_size": len(value.value),
-                "key_sha256": hashlib.sha256(value.key).hexdigest(),
-                "value_sha256": hashlib.sha256(value.value).hexdigest(),
-            }
-            if include:
-                key = value.key[:maximum]
-                payload = value.value[:maximum]
-                if encoding == "hex":
-                    item["key"] = key.hex()
-                    item["value"] = payload.hex()
-                else:
-                    item["key"] = base64.b64encode(key).decode()
-                    item["value"] = base64.b64encode(payload).decode()
-                item["key_truncated"] = len(key) < len(value.key)
-                item["value_truncated"] = len(payload) < len(value.value)
-            response_entries.append(item)
         return {
-            "collection": collection,
+            "endpoint": endpoint_name,
+            "kind": endpoint.kind,
+            "sensitivity": endpoint.sensitivity,
             "entry_count": len(values),
             "limit": call.data["limit"],
-            "entries": response_entries,
+            "entries": [fingerprint_entry(value) for value in values],
         }
 
     hass.services.async_register(
         DOMAIN,
-        SERVICE_FETCH_HERMES_COLLECTION,
-        async_fetch_collection,
-        schema=FETCH_COLLECTION_SERVICE_SCHEMA,
+        SERVICE_INSPECT_HERMES_ENDPOINT,
+        async_inspect_endpoint,
+        schema=INSPECT_ENDPOINT_SERVICE_SCHEMA,
+        supports_response=SupportsResponse.ONLY,
+    )
+
+    async def async_firmware_snapshot(call: ServiceCall) -> dict[str, Any]:
+        """Capture and persist one payload-free compatibility snapshot."""
+        entity_ids = _resolve_loaded_matic_vacuums(hass, call)
+        if len(entity_ids) != 1:
+            raise _validation_error(
+                "Firmware snapshots require exactly one Matic robot",
+                "single_robot_required",
+            )
+        entry = _entry_for_entity(hass, entity_ids[0])
+        state = entry.runtime_data.coordinator.data
+        snapshot = await async_build_firmware_snapshot(entry.runtime_data.client, state)
+        comparison = await firmware_tracker.async_record_snapshot(
+            entry.entry_id, snapshot
+        )
+        return {**snapshot, "comparison": comparison}
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_FIRMWARE_SNAPSHOT,
+        async_firmware_snapshot,
+        schema=FIRMWARE_SNAPSHOT_SCHEMA,
         supports_response=SupportsResponse.ONLY,
     )
 
@@ -816,9 +829,13 @@ def _saved_plan_context(
         )
     entity_id = entity_ids[0]
     entry = _entry_for_entity(hass, entity_id)
-    serial_number = entry.runtime_data.coordinator.data.info.serial_number
-    state = hass.states.get(entity_id)
-    room_map = state.attributes.get("rooms", {}) if state is not None else {}
+    data = entry.runtime_data.coordinator.data
+    serial_number = data.info.serial_number
+    room_map = (
+        {room.id: room.name for room in data.floor_plan.rooms}
+        if data.floor_plan is not None
+        else {}
+    )
     if require_rooms and not room_map:
         raise _validation_error(
             "The robot's room map is unavailable", "room_plan_unavailable"

--- a/custom_components/matic_robot/services.yaml
+++ b/custom_components/matic_robot/services.yaml
@@ -180,10 +180,10 @@ move_plan_room:
           max: 100
           mode: box
 
-fetch_hermes_collection:
+inspect_hermes_endpoint:
   target: *vacuum_target
   fields:
-    collection:
+    endpoint:
       required: true
       selector:
         select:
@@ -235,19 +235,6 @@ fetch_hermes_collection:
           min: 1
           max: 256
           mode: box
-    include_payload:
-      default: false
-      selector:
-        boolean:
-    payload_format:
-      default: base64
-      selector:
-        select:
-          options: [base64, hex]
-    max_bytes:
-      default: 65536
-      selector:
-        number:
-          min: 0
-          max: 1048576
-          mode: box
+
+firmware_snapshot:
+  target: *vacuum_target

--- a/custom_components/matic_robot/strings.json
+++ b/custom_components/matic_robot/strings.json
@@ -35,8 +35,8 @@
       "pairing_code_rejected": "The robot did not accept that code, so a new pairing was started. Enter the new code the robot is showing right away.",
       "pairing_incomplete": "Pairing started but did not finish. Keep the robot near Home Assistant's Bluetooth adapter, turn Pairing mode off and on, then try again.",
       "pairing_mode_confirmation_required": "Turn on Pairing mode first, then check the box to continue.",
-      "pairing_mode_off": "The robot is not accepting new users right now. Turn on Pairing mode in the Matic app, then try again.",
-      "pairing_timeout": "Pairing did not finish within five minutes. Turn Pairing mode off and on, keep the robot near Home Assistant's Bluetooth adapter, and try again. Details are in Settings → System → Logs."
+      "pairing_mode_off": "Home Assistant's local Bluetooth adapter did not receive a fresh pairing advertisement. Turn Pairing mode off and on, put the adapter within a few feet of Matic with minimal obstruction, temporarily disable Bluetooth proxies, then try again.",
+      "pairing_timeout": "Pairing did not finish within five minutes. Turn Pairing mode off and on, put Home Assistant's local Bluetooth adapter within a few feet of Matic, temporarily disable Bluetooth proxies, and try again. If it still misses the robot, reload or replug the adapter. Details are in Settings → System → Logs."
     },
     "step": {
       "discovery_failed": {
@@ -63,7 +63,7 @@
         "title": "Enter the robot's address"
       },
       "pair": {
-        "description": "In the Matic app, go to Settings → Connectivity → Add another user and turn on Pairing mode. Confirm below only after the pairing window is open. The robot will display a six-digit code and Home Assistant will ask for it.",
+        "description": "Put Home Assistant's local Bluetooth adapter within a few feet of Matic. In the Matic app, go to Settings → Connectivity → Add another user and turn on Pairing mode. Confirm below only after the pairing window is open. The robot will display a six-digit code and Home Assistant will ask for it.",
         "data": {
           "pairing_mode_enabled": "Pairing mode is on"
         },
@@ -80,7 +80,7 @@
         "title": "Enter the code shown on Matic"
       },
       "reauth_confirm": {
-        "description": "In the Matic app, go to Settings → Connectivity → Add another user and turn on Pairing mode. Confirm below only after the pairing window is open. The robot will display a six-digit code and Home Assistant will ask for it before replacing its local access.",
+        "description": "Put Home Assistant's local Bluetooth adapter within a few feet of Matic. In the Matic app, go to Settings → Connectivity → Add another user and turn on Pairing mode. Confirm below only after the pairing window is open. The robot will display a six-digit code and Home Assistant will ask for it before replacing its local access.",
         "data": {
           "pairing_mode_enabled": "Pairing mode is on"
         },
@@ -376,6 +376,16 @@
       "software_version": {
         "name": "Software version"
       },
+      "firmware_compatibility": {
+        "name": "Firmware compatibility",
+        "state": {
+          "pending": "Checking",
+          "baseline": "Baseline recorded",
+          "compatible": "Compatible",
+          "regression": "Regression detected",
+          "current": "Current"
+        }
+      },
       "sink_summon_locations": {
         "name": "Sink summon locations"
       },
@@ -406,6 +416,18 @@
       },
       "next_cleaning_room": {
         "name": "Next room to clean"
+      },
+      "room_clean_duration": {
+        "name": "{room} last clean duration"
+      },
+      "room_last_cleaned": {
+        "name": "{room} last cleaned"
+      },
+      "last_run_duration": {
+        "name": "Last run duration"
+      },
+      "wifi_signal": {
+        "name": "Wi-Fi signal"
       }
     },
     "switch": {
@@ -420,6 +442,11 @@
       },
       "voice_assistant": {
         "name": "Hey Matic"
+      }
+    },
+    "update": {
+      "firmware": {
+        "name": "Firmware"
       }
     }
   },
@@ -471,6 +498,16 @@
     },
     "unsupported_command": {
       "message": "That Matic command is not supported. Use start, clean_all, clean_rooms, clean_segments, pause, resume, stop, dock, or return_home."
+    }
+  },
+  "issues": {
+    "firmware_regression": {
+      "title": "Matic firmware compatibility changed",
+      "description": "After Matic updated from {previous} to {current}, {count} Hermes endpoint(s) changed availability or transport status. Review the **Firmware snapshot** response and compatibility ledger."
+    },
+    "robot_identity_changed": {
+      "title": "Matic robot identity changed",
+      "description": "The device at the configured Matic address presented a TLS certificate that does not match the pinned robot identity. Communication is blocked until the certificate matches again. If the robot was factory reset or replaced, re-pair it through **Settings > Devices & Services > Matic Robot > Reconfigure**."
     }
   },
   "services": {
@@ -668,31 +705,23 @@
         }
       }
     },
-    "fetch_hermes_collection": {
-      "name": "Fetch Hermes collection",
-      "description": "Reads a size-limited snapshot from a supported local Hermes collection. Credential collections are blocked.",
+    "inspect_hermes_endpoint": {
+      "name": "Inspect Hermes endpoint",
+      "description": "Reads payload-free sizes and SHA-256 fingerprints from a supported local Hermes endpoint. Credential endpoints are blocked.",
       "fields": {
-        "collection": {
-          "name": "Collection",
+        "endpoint": {
+          "name": "Endpoint",
           "description": "Local Hermes property or collection to inspect."
         },
         "limit": {
           "name": "Entry limit",
           "description": "Maximum collection entries to return."
-        },
-        "include_payload": {
-          "name": "Include payload",
-          "description": "Include size-limited raw key/value bytes in the response. Raw payloads may contain private device or home data."
-        },
-        "payload_format": {
-          "name": "Payload format",
-          "description": "Encoding used when raw payloads are included."
-        },
-        "max_bytes": {
-          "name": "Maximum bytes",
-          "description": "Maximum bytes included from each key and value."
         }
       }
+    },
+    "firmware_snapshot": {
+      "name": "Firmware snapshot",
+      "description": "Checks every known non-credential Hermes endpoint, stores a payload-free weekly compatibility record, and reports changes from the prior snapshot."
     }
   }
 }

--- a/custom_components/matic_robot/switch.py
+++ b/custom_components/matic_robot/switch.py
@@ -113,4 +113,4 @@ class MaticSettingSwitch(MaticEntity, SwitchEntity):
                 setting,
                 enabled,
             )
-        await self.coordinator.async_request_refresh()
+        await self.coordinator.async_request_full_refresh()

--- a/custom_components/matic_robot/translations/en.json
+++ b/custom_components/matic_robot/translations/en.json
@@ -35,8 +35,8 @@
       "pairing_code_rejected": "The robot did not accept that code, so a new pairing was started. Enter the new code the robot is showing right away.",
       "pairing_incomplete": "Pairing started but did not finish. Keep the robot near Home Assistant's Bluetooth adapter, turn Pairing mode off and on, then try again.",
       "pairing_mode_confirmation_required": "Turn on Pairing mode first, then check the box to continue.",
-      "pairing_mode_off": "The robot is not accepting new users right now. Turn on Pairing mode in the Matic app, then try again.",
-      "pairing_timeout": "Pairing did not finish within five minutes. Turn Pairing mode off and on, keep the robot near Home Assistant's Bluetooth adapter, and try again. Details are in Settings → System → Logs."
+      "pairing_mode_off": "Home Assistant's local Bluetooth adapter did not receive a fresh pairing advertisement. Turn Pairing mode off and on, put the adapter within a few feet of Matic with minimal obstruction, temporarily disable Bluetooth proxies, then try again.",
+      "pairing_timeout": "Pairing did not finish within five minutes. Turn Pairing mode off and on, put Home Assistant's local Bluetooth adapter within a few feet of Matic, temporarily disable Bluetooth proxies, and try again. If it still misses the robot, reload or replug the adapter. Details are in Settings → System → Logs."
     },
     "step": {
       "discovery_failed": {
@@ -63,7 +63,7 @@
         "title": "Enter the robot's address"
       },
       "pair": {
-        "description": "In the Matic app, go to Settings → Connectivity → Add another user and turn on Pairing mode. Confirm below only after the pairing window is open. The robot will display a six-digit code and Home Assistant will ask for it.",
+        "description": "Put Home Assistant's local Bluetooth adapter within a few feet of Matic. In the Matic app, go to Settings → Connectivity → Add another user and turn on Pairing mode. Confirm below only after the pairing window is open. The robot will display a six-digit code and Home Assistant will ask for it.",
         "data": {
           "pairing_mode_enabled": "Pairing mode is on"
         },
@@ -80,7 +80,7 @@
         "title": "Enter the code shown on Matic"
       },
       "reauth_confirm": {
-        "description": "In the Matic app, go to Settings → Connectivity → Add another user and turn on Pairing mode. Confirm below only after the pairing window is open. The robot will display a six-digit code and Home Assistant will ask for it before replacing its local access.",
+        "description": "Put Home Assistant's local Bluetooth adapter within a few feet of Matic. In the Matic app, go to Settings → Connectivity → Add another user and turn on Pairing mode. Confirm below only after the pairing window is open. The robot will display a six-digit code and Home Assistant will ask for it before replacing its local access.",
         "data": {
           "pairing_mode_enabled": "Pairing mode is on"
         },
@@ -376,6 +376,16 @@
       "software_version": {
         "name": "Software version"
       },
+      "firmware_compatibility": {
+        "name": "Firmware compatibility",
+        "state": {
+          "pending": "Checking",
+          "baseline": "Baseline recorded",
+          "compatible": "Compatible",
+          "regression": "Regression detected",
+          "current": "Current"
+        }
+      },
       "sink_summon_locations": {
         "name": "Sink summon locations"
       },
@@ -406,6 +416,18 @@
       },
       "next_cleaning_room": {
         "name": "Next room to clean"
+      },
+      "room_clean_duration": {
+        "name": "{room} last clean duration"
+      },
+      "room_last_cleaned": {
+        "name": "{room} last cleaned"
+      },
+      "last_run_duration": {
+        "name": "Last run duration"
+      },
+      "wifi_signal": {
+        "name": "Wi-Fi signal"
       }
     },
     "switch": {
@@ -420,6 +442,11 @@
       },
       "voice_assistant": {
         "name": "Hey Matic"
+      }
+    },
+    "update": {
+      "firmware": {
+        "name": "Firmware"
       }
     }
   },
@@ -471,6 +498,16 @@
     },
     "unsupported_command": {
       "message": "That Matic command is not supported. Use start, clean_all, clean_rooms, clean_segments, pause, resume, stop, dock, or return_home."
+    }
+  },
+  "issues": {
+    "firmware_regression": {
+      "title": "Matic firmware compatibility changed",
+      "description": "After Matic updated from {previous} to {current}, {count} Hermes endpoint(s) changed availability or transport status. Review the **Firmware snapshot** response and compatibility ledger."
+    },
+    "robot_identity_changed": {
+      "title": "Matic robot identity changed",
+      "description": "The device at the configured Matic address presented a TLS certificate that does not match the pinned robot identity. Communication is blocked until the certificate matches again. If the robot was factory reset or replaced, re-pair it through **Settings > Devices & Services > Matic Robot > Reconfigure**."
     }
   },
   "services": {
@@ -668,31 +705,23 @@
         }
       }
     },
-    "fetch_hermes_collection": {
-      "name": "Fetch Hermes collection",
-      "description": "Reads a size-limited snapshot from a supported local Hermes collection. Credential collections are blocked.",
+    "inspect_hermes_endpoint": {
+      "name": "Inspect Hermes endpoint",
+      "description": "Reads payload-free sizes and SHA-256 fingerprints from a supported local Hermes endpoint. Credential endpoints are blocked.",
       "fields": {
-        "collection": {
-          "name": "Collection",
+        "endpoint": {
+          "name": "Endpoint",
           "description": "Local Hermes property or collection to inspect."
         },
         "limit": {
           "name": "Entry limit",
           "description": "Maximum collection entries to return."
-        },
-        "include_payload": {
-          "name": "Include payload",
-          "description": "Include size-limited raw key/value bytes in the response. Raw payloads may contain private device or home data."
-        },
-        "payload_format": {
-          "name": "Payload format",
-          "description": "Encoding used when raw payloads are included."
-        },
-        "max_bytes": {
-          "name": "Maximum bytes",
-          "description": "Maximum bytes included from each key and value."
         }
       }
+    },
+    "firmware_snapshot": {
+      "name": "Firmware snapshot",
+      "description": "Checks every known non-credential Hermes endpoint, stores a payload-free weekly compatibility record, and reports changes from the prior snapshot."
     }
   }
 }

--- a/custom_components/matic_robot/update.py
+++ b/custom_components/matic_robot/update.py
@@ -1,0 +1,70 @@
+"""Read-only firmware update surface for Matic Hermes."""
+
+from __future__ import annotations
+
+from homeassistant.components.update import (
+    UpdateDeviceClass,
+    UpdateEntity,
+    UpdateEntityDescription,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import MaticConfigEntry
+from .entity import MaticEntity
+
+PARALLEL_UPDATES = 0
+
+UPDATE_DESCRIPTION = UpdateEntityDescription(
+    key="firmware",
+    translation_key="firmware",
+    device_class=UpdateDeviceClass.FIRMWARE,
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: MaticConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the read-only Matic firmware update entity."""
+    async_add_entities([MaticFirmwareUpdate(entry)])
+
+
+class MaticFirmwareUpdate(MaticEntity, UpdateEntity):
+    """Surface robot-managed OTA state in Home Assistant's update UI.
+
+    The robot never reports the target version over Hermes, so a pending
+    OTA shows as an unknown latest version; installs stay robot-managed.
+    """
+
+    entity_description = UPDATE_DESCRIPTION
+
+    def __init__(self, entry: MaticConfigEntry) -> None:
+        super().__init__(entry)
+        self._attr_unique_id = f"{self.coordinator.data.info.serial_number}_firmware"
+
+    @property
+    def installed_version(self) -> str | None:
+        """Return the robot's current firmware version."""
+        state = self.coordinator.data
+        return state.telemetry.software_version or state.operational.software_version
+
+    @property
+    def latest_version(self) -> str | None:
+        """Return the installed version unless the robot reports a pending OTA."""
+        if self.coordinator.data.telemetry.update_state == "available":
+            return None
+        return self.installed_version
+
+    @property
+    def extra_state_attributes(self) -> dict[str, object]:
+        """Expose the robot's own updater state for automations."""
+        telemetry = self.coordinator.data.telemetry
+        return {
+            "update_state": telemetry.update_state,
+            "update_channel": (
+                telemetry.update_channel
+                or self.coordinator.data.operational.release_channel
+            ),
+        }

--- a/custom_components/matic_robot/vacuum.py
+++ b/custom_components/matic_robot/vacuum.py
@@ -58,6 +58,7 @@ class MaticVacuum(MaticEntity, StateVacuumEntity):
     """Authenticated local Matic vacuum controls."""
 
     _attr_supported_features = SUPPORTED_FEATURES
+    _unrecorded_attributes = frozenset({"rooms"})
 
     def __init__(self, entry: MaticConfigEntry) -> None:
         super().__init__(entry)

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,10 @@ the integration so instructions and behavior stay aligned with each release.
   understand Bluetooth requirements, and recover from pairing failures.
 - [Limits and troubleshooting](../README.md#limits-and-troubleshooting) — Check
   discovery, passkey, room-mapping, firmware, and Bluetooth constraints.
+- [Firmware compatibility](firmware-compatibility.md) — Track observed robot
+  versions, validation status, regressions, and newly discovered capabilities.
+- [Release notes — 0.2.0](release-notes-0.2.0.md) — What's new and what to
+  check when upgrading from 0.1.x.
 
 ## Use and automate
 
@@ -57,5 +61,6 @@ and the relevant guide above. If the problem remains:
 - [Request a feature](https://github.com/ProspectOre/matic-home-assistant/issues/new?template=feature_request.yml)
 
 Home Assistant diagnostics are created only when you click **Download
-diagnostics**. Inspect the file before sharing it because the redacted report
-still contains home-specific map, room, Wi-Fi, schedule, and protocol context.
+diagnostics**. The report uses a strict safe-field allowlist and omits map, room,
+Wi-Fi identity, schedule, session, credential, address, and certificate context;
+inspect it before sharing anyway.

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -8,8 +8,9 @@ settings, cleaning, and saved plans.
 
 ## Entity contract
 
-One configured robot creates 44 entities: 18 sensors, 12 binary sensors, 4
-buttons, 4 switches, 3 selects, 1 number, 1 camera, and 1 vacuum.
+One configured robot creates 48 fixed entities — 21 sensors, 12 binary
+sensors, 4 buttons, 4 switches, 3 selects, 1 number, 1 camera, 1 update, and
+1 vacuum — plus two opt-in statistics sensors per mapped room.
 
 - `vacuum`: primary robot state plus start/resume, pause, stop, dock, Area
   cleaning, named-room segments, and supported commands.
@@ -20,8 +21,13 @@ buttons, 4 switches, 3 selects, 1 number, 1 camera, and 1 vacuum.
 - `button`: run the default plan, intelligent-rotation override,
   top-to-bottom override, and stop-plan-and-dock.
 - `sensor`: activity, battery, rooms, cleaning history, active plan, next room,
-  firmware/protocol/update state, current area, Wi-Fi, schedules, local
-  sessions, dock/sink, and coverage.
+  firmware/protocol/update/compatibility state, current area, Wi-Fi state and
+  signal, schedules, local sessions, last run duration, dock/sink, coverage,
+  and two opt-in statistics sensors per mapped room (see
+  [Room statistics](#room-statistics-and-the-recorder)).
+- `update`: a read-only firmware surface in Home Assistant's update UI. The
+  robot manages its own OTA installs and never reports the target version, so
+  a pending update shows with an unknown latest version.
 - `binary_sensor`: cleaning, paused, returning, charging, low charge, fully
   charged, problem, update available, Matter pairing mode, active cleaning
   session, robot SSH tunnel permission, and robot diagnostic upload.
@@ -34,8 +40,10 @@ or action contract. See
 [Recording-related protocol notes](recording-protocol.md) for the observed but
 unavailable protocol semantics.
 
-Home Assistant owns entity IDs and registry customization. Stable unique IDs
-preserve user renames across restarts.
+The integration assigns descriptive canonical IDs such as
+`sensor.matic_software_version` and `camera.matic_map`. Before 1.0, setup migrates
+older numbered IDs to this model when the destination is free. Stable unique IDs
+continue to anchor every registry entity.
 
 **Fully charged** is a plain boolean with explicit `Fully charged` / `Not fully
 charged` states and a battery-check icon. It intentionally does not use Home
@@ -108,32 +116,77 @@ the visible saved order regardless of history.
 Plan actions accept human names or stable IDs where appropriate. Action fields
 are defined in `custom_components/matic_robot/services.yaml`.
 
-## Raw collection reads
+## Payload-free endpoint inspection
 
-`matic_robot.fetch_hermes_collection` returns a bounded snapshot of one
-allowlisted non-credential Hermes collection. It requires exactly one Matic
-robot. Fields:
+`matic_robot.inspect_hermes_endpoint` returns a bounded fingerprint snapshot of
+one allowlisted non-credential Hermes property or collection. It requires
+exactly one Matic robot. Fields:
 
-- `collection` (required): the collection to read, chosen from the allowlist in
+- `endpoint` (required): the property or collection to read, chosen from the allowlist in
   `services.yaml` (for example `wifi_status`, `schedule_events`, or
   `map_semantics`).
 - `limit` (default `32`, range 1–256): maximum entries to return.
-- `include_payload` (default `false`): when false, each entry returns only
-  key/value sizes and their SHA-256 hashes. Enable it to include the raw bytes.
-- `payload_format` (`base64` default, or `hex`): encoding for included payloads.
-- `max_bytes` (default `65536`, range 0–1048576): truncates each included key
-  and value; the response flags any truncation.
 
-The hash-only default limits routine inspection to sizes and hashes. Raw payload
-access requires explicit opt-in and may expose private device or home data.
+The response contains endpoint kind/sensitivity plus key/value sizes and SHA-256
+hashes. Raw bytes are never returned through the public Home Assistant action.
+The typed registry routes single-value properties correctly instead of treating
+every name as a collection stream.
+
+## Firmware snapshots
+
+`matic_robot.firmware_snapshot` checks all 40 known non-credential endpoints
+with four-way bounded concurrency. It stores up to 52 payload-free snapshots in
+Home Assistant and returns:
+
+- firmware and protocol versions;
+- populated, empty, and failed endpoint counts;
+- endpoint kind, sensitivity, status, sizes, and hashes;
+- availability/transport changes separately from ordinary content changes.
+
+When the coordinator observes a new firmware version, the integration fires
+`matic_robot_firmware_changed` with previous and current firmware/protocol
+values. A Home Assistant Repair is created only when the subsequent snapshot
+finds endpoint availability or transport drift; normal weekly OTAs remain
+silent. Snapshotting never promotes a firmware to control-verified; physical
+write validation remains deliberate.
+
+## Room statistics and the recorder
+
+Template-visible attributes and recorded history follow one deliberate model:
+
+- **Live attributes, never recorded.** The vacuum's `rooms` map, the rooms
+  sensor's `room_names`/`segments`, the Wi-Fi sensor's `ssid`, schedule
+  definitions, the latest session's rooms and per-room durations, and full
+  plan/history detail are all available to templates, dashboards, and
+  conditions through `state_attr()`. Every one of these attributes is excluded
+  from Home Assistant's recorder, so home context never accumulates in the
+  history database.
+- **Opt-in room statistics sensors.** Each mapped room gets a
+  `{room} last clean duration` sensor (long-term statistics; compare cleaning
+  time across firmware updates) and a `{room} last cleaned` timestamp sensor.
+  Both are disabled by default because enabling them intentionally records the
+  room's name and cleaning history; enable them per room under the device's
+  entity list when you want durable per-room trends.
+- **Always-recorded run metrics.** The `Last run duration` sensor records
+  numeric long-term statistics for every session without any room context, so
+  whole-run OTA comparisons work out of the box.
 
 ## Events and observability
 
 Room execution emits `matic_robot_room_started`,
 `matic_robot_room_completed`, `matic_robot_room_failed`, and
 `matic_robot_room_cancelled`. The Cleaning history sensor exposes per-room
-completion timestamps, plan history, active plan, interrupted plan, and
-completion/failure/cancellation counts.
+safe completion/failure totals. Exact plan and room details remain available
+through the response-only plan preview and management actions instead of being
+written into recorder-backed attributes.
+
+When the robot finishes a cleaning session the integration fires
+`matic_robot_cleaning_finished` with the session's start/end timestamps,
+duration, completion flag, rooms, per-room durations, the firmware version
+that produced the run, and the `device_id`/`entry_id` of the robot — one
+payload for post-clean notifications or custom logging.
+`matic_robot_firmware_changed` likewise carries `device_id`/`entry_id` so
+multi-robot homes can tell which robot updated.
 
 Use ordinary state triggers and conditions on any telemetry, setting, Activity,
 or binary sensor. This keeps automations composable with schedules, presence,

--- a/docs/firmware-compatibility.md
+++ b/docs/firmware-compatibility.md
@@ -1,0 +1,81 @@
+# Firmware compatibility
+
+Matic firmware can change the private Hermes protocol used by this unofficial
+integration. This ledger records only evidence that is safe to publish and
+separates an observed update from verified compatibility.
+
+## Status definitions
+
+- **Observed** — a firmware version was reported, but the integration has not
+  been checked after the update.
+- **Core read verified** — authenticated coordinator state, the floor plan, and
+  the primary Home Assistant surfaces work; optional reads or a full endpoint
+  sweep may still have documented gaps.
+- **Read verified** — discovery, authentication, coordinator refresh, state,
+  telemetry, and floor-plan reads work after the update.
+- **Control verified** — read verification passed and the supported Home
+  Assistant controls were exercised safely on a real robot.
+- **Regression** — a previously supported read or control is known to fail.
+
+## Compatibility ledger
+
+| Firmware | First observed | Integration | Status | Evidence | Changes or capabilities |
+| --- | --- | --- | --- | --- | --- |
+| [v168.11](firmware-versions/v168.md) | 2026-07-20 | 0.1.1 | Core read verified | Live on HA 2026.7.2; protocol 25; 40-name sweep complete | Core surfaces healthy; uploader-state decoder drift fixed in tree |
+
+An empty or pending entry is not a compatibility claim. Synthetic tests show
+that the integration handles the documented protocol shapes; only real-robot
+validation can establish behavior for a firmware release.
+
+See the [endpoint and Home Assistant map](firmware-endpoint-map.md) for every
+currently understood RPC, collection/property, channel, exposure, and candidate
+safe exposure. Copy the [version template](firmware-versions/template.md) after
+each OTA so weekly releases produce comparable snapshots rather than loose
+notes.
+
+## Validation record
+
+For each firmware, record the integration and Home Assistant versions, then
+check in this order:
+
+1. Confirm local discovery and authenticated coordinator refresh.
+2. Confirm software version, protocol version, operational state, battery,
+   update state, map, pose, and room data still decode.
+3. Review privacy-safe logs and downloaded diagnostics for new missing fields,
+   unknown state/error codes, or collection failures.
+4. Exercise supported controls deliberately: start, pause, resume, stop, dock,
+   room cleaning, cleaning modes, coverage levels, and saved plans.
+5. Record changed behavior, regressions, and newly observed fields or
+   capabilities. Link public fixtures, tests, issues, or pull requests when
+   available.
+
+The integration automatically records the first firmware as a baseline. Each
+newly observed version fires `matic_robot_firmware_changed` and starts one
+background, payload-free snapshot of all known endpoints. A Home Assistant
+Repair is created only when availability or transport status changes; a normal
+weekly OTA does not create an issue.
+
+The event can also drive a local notification:
+
+```yaml
+triggers:
+  - trigger: event
+    event_type: matic_robot_firmware_changed
+actions:
+  - action: persistent_notification.create
+    data:
+      title: Matic firmware changed
+      message: "Matic changed from {{ trigger.event.data.previous_version }} to {{ trigger.event.data.firmware_version }}. A safe endpoint snapshot is running automatically."
+```
+
+Do not publish robot credentials, passkeys, network addresses, MAC addresses,
+serial numbers, certificates, packet captures, floor maps, room names, Wi-Fi
+details, Home Assistant storage, or unredacted diagnostics.
+
+## Capability evidence rule
+
+A newly observed field may be documented as a candidate capability. It is not
+supported until its wire shape is understood and covered by synthetic tests.
+Never add a command from a guessed enum or payload: a write requires a
+byte-for-byte synthetic fixture, evidence that a real robot accepted it safely,
+and Home Assistant-native error handling.

--- a/docs/firmware-endpoint-map.md
+++ b/docs/firmware-endpoint-map.md
@@ -1,0 +1,99 @@
+# Firmware endpoint and Home Assistant map
+
+[Firmware ledger](firmware-compatibility.md) ·
+[Entity reference](automation.md#entity-contract)
+
+This is the integration's public protocol inventory. “Endpoint” means a Hermes
+gRPC method, collection/property name, or channel—not an HTTP endpoint. The
+inventory says what the code understands; each firmware snapshot records what a
+real robot actually returned after an OTA.
+
+## gRPC methods
+
+| Method | Use | Home Assistant surface |
+| --- | --- | --- |
+| `GetBotInfo` | Local identity, network and hardware metadata | Device info; hardware revision sensor; sensitive fields redacted |
+| `AuthToken` | Issue a scoped credential during physical Bluetooth pairing | Config/reauth flow only |
+| `Handshake` | Bind the authenticated Hermes session | Internal transport |
+| `FetchCollection` | Read typed properties and bounded collection streams | Coordinator reads; payload-free inspection and firmware-snapshot actions |
+| `SendToChannel` | Send verified session data, settings and commands | Vacuum/settings entities and actions below |
+
+## Decoded reads
+
+| Collection/property | Decoded data | Current HA exposure |
+| --- | --- | --- |
+| `kabuki_state` | Battery, state/error codes, activity, firmware fallback, channel/profile, current/previous area | Vacuum; activity, battery and current-area sensors; seven operational binary sensors; attributes |
+| `coverage_plan` | Mission, partition, named room IDs and geometry | Rooms sensor, map camera, vacuum segments/Areas, cleaning target |
+| `latest_pose` | Robot position and heading | Map camera |
+| `current_version` | Software/profile, protocol version, feature flag | Software and protocol sensors; software attributes |
+| `update_config` | Update channel | Update-channel sensor |
+| `update_state` | Update lifecycle | Update-state sensor and update-available binary sensor |
+| `wifi_status` | State, SSID, signal and visible/known networks | Wi-Fi state/signal/count summary; identities excluded from attributes |
+| `time_zone` | Robot timezone | Internal decoded telemetry; excluded from recorder attributes |
+| `schedule_events` | Local schedules, weekdays, time, rooms, ordering and enabled state | Scheduled-cleanings count; definitions excluded from attributes |
+| `coverage_session_history` | Local session count and latest session summary | Local-cleaning-session count and non-room summary |
+| `dock_detections` | Collection count | Dock-detections sensor |
+| `sink_summon_locations` | Collection count | Sink-summon-locations sensor |
+| `coverage_time` | Accumulated coverage seconds | Coverage-time sensor |
+| `child_lock_enabled_state` | Child-lock state | Child-lock switch |
+| `petwaste_enabled_state` | Pet-waste avoidance state | Pet-waste-avoidance switch |
+| `voice_enabled_state` | Hey Matic state | Voice-assistant switch |
+| `matter_pairing_state` | Pairing-mode presence | Matter-pairing binary sensor |
+| `deep_mop_override_setting_state` | Double-pass mop state | Deep-mop switch |
+| `water_flow_override_state` | Water-flow multiplier | Water-flow number |
+| `user_tunnel_ssh_permission` | Robot SSH permission | Diagnostic binary sensor |
+| `uploader_config_state` | Robot diagnostic-upload opt-in | Diagnostic-upload binary sensor |
+| `active_session_key` | Active cleaning-session presence | Active-cleaning-session binary sensor |
+
+## Allowlisted exploratory reads
+
+These are bounded, payload-free reads through `inspect_hermes_endpoint` and the
+weekly `firmware_snapshot` action. Payloads are not decoded into entities unless listed above. “Candidate” is a
+research direction, not a promise that the field exists or is safe on every
+firmware.
+
+| Collections | Possible safe HA use after evidence |
+| --- | --- |
+| `approximate_trajectory`, `planned_path` | Map path overlays or path-status diagnostics |
+| `coverage_corridor`, `coverage_marker` | Coverage/map annotations |
+| `coverage_session_thumbnails` | Local historical map thumbnail |
+| `displayed_mission`, `labeled_missions` | Mission identity/status sensor |
+| `jukebox_state` | Read-only robot media/voice status if privacy-safe |
+| `map_combined_coverage`, `map_compressed_rgb`, `map_compressed_rgb_higher`, `map_integrated` | Alternative local map layers |
+| `map_semantics`, `map_semantics_override`, `semantics_override`, `zones` | Room/zone semantics and map annotations |
+| `schedule_event_previews` | Schedule preview diagnostics |
+| `sink_summons` | Read-only sink event/history diagnostics |
+
+The authoritative typed registry is
+`custom_components/matic_robot/client/endpoints.py`; it also includes every
+decoded property above and supplies kind/sensitivity metadata to polling,
+inspection, snapshots, and documentation. Recording-related endpoints,
+credentials, arbitrary names, and raw payload output are deliberately excluded.
+
+## Verified writes
+
+| Channel | Payloads | Current HA exposure |
+| --- | --- | --- |
+| `user_data` | Local client identity, timezone and connection kind | Internal session setup |
+| `user_command` | Stop, pause, resume, dock | Vacuum actions and `send_command` |
+| `user_command` | Full-floor/room coverage; vacuum, mop or both; quick/standard; ordered/unordered | Vacuum start/Area/segment cleaning; `matic_robot.clean`; saved plans |
+| `child_lock_enabled_command` | Boolean | Child-lock switch |
+| `petwaste_enabled_command` | Boolean | Pet-waste-avoidance switch |
+| `voice_enabled_command` | Boolean | Voice-assistant switch |
+| `deep_mop_override_setting_command` | Enable/disable | Deep-mop switch |
+| `water_flow_override_command` | 0.5–2.0 in 0.1 steps | Water-flow number |
+
+No new write is exposed from a guessed name, enum, or payload. It requires an
+exact synthetic fixture, safe real-robot acceptance evidence, tests, and native
+Home Assistant error handling.
+
+## Version snapshots
+
+- [v168.11](firmware-versions/v168.md) — core reads and the 40-name hash-only
+  availability sweep live-verified 2026-07-20; writes remain untested.
+- [Snapshot template](firmware-versions/template.md) — copy after each OTA.
+
+The integration persists 52 safe snapshots, emits an event on a new version,
+raises a Home Assistant Repair only for compatibility drift, and separates
+endpoint availability changes from normal content changes. The Markdown ledger
+remains the reviewed compatibility claim.

--- a/docs/firmware-versions/template.md
+++ b/docs/firmware-versions/template.md
@@ -1,0 +1,47 @@
+# Matic firmware vNNN
+
+[Endpoint map](../firmware-endpoint-map.md) ·
+[Firmware ledger](../firmware-compatibility.md)
+
+status: observed / live validation pending  
+first_observed_pacific: YYYY-MM-DD  
+integration_version: X.Y.Z  
+home_assistant_version: YYYY.M  
+protocol_version: N
+
+## Endpoint snapshot
+
+| Surface | Status | Evidence / delta from preceding firmware |
+| --- | --- | --- |
+| Discovery and `GetBotInfo` | Pending | |
+| Authentication, handshake and session data | Pending | |
+| Core reads: `kabuki_state`, `coverage_plan`, `latest_pose` | Pending | |
+| 15 telemetry properties | Pending | |
+| Schedule and coverage-history collections | Pending | |
+| Dock and sink collection counts | Pending | |
+| Allowlisted exploratory reads | Pending | |
+| Stop, pause, resume and dock | Not tested | |
+| Coverage/room commands and cleaning settings | Not tested | |
+
+## Changes and capability candidates
+
+- Release notes:
+- Observed behavior changes:
+- Regressions:
+- New or changed fields/collections:
+- Possible safe Home Assistant exposure:
+
+## Promotion checklist
+
+- [ ] Record integration, Home Assistant and protocol versions.
+- [ ] Confirm coordinator refresh and decoded reads.
+- [ ] Run a hash-only exploratory availability sweep.
+- [ ] Review privacy-safe diagnostics for protocol drift.
+- [ ] Compare with the preceding firmware snapshot.
+- [ ] Exercise supported writes deliberately and record exact coverage.
+- [ ] Link sanitized fixtures, tests, issues and pull requests.
+- [ ] Update the public ledger and workspace firmware memory.
+
+Never commit downloaded diagnostics, raw robot payloads, credentials, network or
+device identifiers, maps, room names, Wi-Fi details, or other home data.
+

--- a/docs/firmware-versions/v168.md
+++ b/docs/firmware-versions/v168.md
@@ -1,0 +1,86 @@
+# Matic firmware v168.11
+
+[Endpoint map](../firmware-endpoint-map.md) ·
+[Firmware ledger](../firmware-compatibility.md)
+
+status: core read verified / optional decoder fixed / control validation pending  
+first_observed_pacific: 2026-07-20  
+integration_version: 0.1.1  
+home_assistant_version: 2026.7.2  
+protocol_version: 25
+
+## Endpoint snapshot
+
+| Surface | Status on v168 | Evidence / delta |
+| --- | --- | --- |
+| Discovery and `GetBotInfo` | Verified | Device and hardware metadata loaded |
+| Authentication, handshake and session data | Verified | Authenticated coordinator refresh succeeded without re-pairing |
+| `kabuki_state` and `coverage_plan` | Verified | Activity, battery, state/error surface, rooms, vacuum and map available |
+| `latest_pose` | Verified | Hash-only collection read returned a pose entry |
+| 15 telemetry properties | Verified | `coverage_time` is a known tombstone/default; both uploader-state wire forms are decoded in the current tree |
+| Schedule and coverage-history collections | Verified | Counts and decoded summaries populated |
+| Dock and sink collection counts | Verified | Both count sensors populated |
+| Allowlisted exploratory reads | Verified hash-only | All 40 allowlisted names probed with one-entry bounds and no payload inclusion |
+| Stop, pause, resume and dock | Not tested | Requires deliberate safe live exercise |
+| Coverage/room commands and cleaning settings | Not tested | Requires deliberate safe live exercise |
+
+## Changes and capability candidates
+
+- All 44 integration entities loaded. Core robot, map, room, settings, schedule,
+  history and diagnostic surfaces remained available after the OTA.
+- The robot reported no active Hermes error codes during inspection.
+- `coverage_time` is unknown because v168.11 currently returns the known
+  16-byte tombstone/default form. This is expected, not a regression.
+- With explicit owner approval, the two-byte diagnostic-upload value was
+  inspected locally and not retained. It is protobuf field 2 with a direct
+  boolean `true` value. The current decoder accepts only the older
+  length-delimited field-2 form, so installed integration 0.1.1 correctly fails
+  closed to `unknown`. The current tree now accepts both forms with synthetic
+  regression fixtures. This was decoder drift, not an endpoint failure.
+- The integration detail page reports 0.1.1. The HACS update entity reported an
+  older installed value, so the integration page is used as authority here.
+- No new endpoint, payload shape, or capability was established by this check.
+
+## Hash-only endpoint sweep
+
+Every allowlisted name was queried with `include_payload: false`, `limit: 1`,
+and no raw bytes retained.
+
+- **Returned an entry (20):** `active_session_key`,
+  `child_lock_enabled_state`, `coverage_session_history`, `coverage_time`,
+  `current_version`, `deep_mop_override_setting_state`, `displayed_mission`,
+  `dock_detections`, `latest_pose`, `map_semantics`, `matter_pairing_state`,
+  `petwaste_enabled_state`, `schedule_events`, `sink_summon_locations`,
+  `time_zone`, `update_state`, `uploader_config_state`,
+  `user_tunnel_ssh_permission`, `voice_enabled_state`, and `wifi_status`.
+- **Reachable but empty (12):** `approximate_trajectory`, `coverage_corridor`,
+  `coverage_marker`, `jukebox_state`, `labeled_missions`,
+  `map_combined_coverage`, `map_compressed_rgb_higher`, `planned_path`,
+  `schedule_event_previews`, `semantics_override`, `sink_summons`, and `zones`.
+- **Generic collection action rejected (8):** `coverage_plan`,
+  `coverage_session_thumbnails`, `kabuki_state`, `map_compressed_rgb`,
+  `map_integrated`, `map_semantics_override`, `update_config`, and
+  `water_flow_override_state`. Dedicated reads/entities independently prove
+  `coverage_plan`, `kabuki_state`, `update_config`, and
+  `water_flow_override_state`; do not classify these four as unavailable.
+
+`displayed_mission` and `map_semantics` are populated, unexposed capability
+candidates. They require privacy review, raw-shape evidence, synthetic fixtures,
+and tests before any Home Assistant entity or attribute is added.
+- Passing repository tests does not promote this snapshot to live-compatible.
+
+## Promotion checklist
+
+- [x] Record integration, Home Assistant and reported protocol versions.
+- [x] Confirm authenticated coordinator refresh and core decoded read groups.
+- [x] Run a hash-only availability sweep of the exploratory allowlist.
+- [x] Review privacy-safe entity state for unknown state/error codes and missing fields.
+- [ ] Compare availability and decoded shapes with the preceding snapshot.
+- [ ] Deliberately exercise supported writes; record partial coverage honestly.
+- [x] Record new candidates and distinguish transport-path failures from
+  endpoint regressions; payload evidence and fixtures remain pending.
+- [x] Teach the uploader-state decoder the v168.11 direct-boolean field-2 form
+  with exact synthetic true/false fixtures while preserving the earlier form.
+- [x] Promote the public ledger and workspace memory status.
+
+Never commit downloaded diagnostics or raw robot payloads to the public tree.

--- a/docs/hermes-pairing.md
+++ b/docs/hermes-pairing.md
@@ -38,9 +38,12 @@ by Home Assistant, followed by a container restart.
 A new Bluetooth pairing deliberately proves physical access: someone at the
 robot must read its displayed code. Home Assistant must use a Bluetooth adapter
 built into or directly attached to its host for that interactive exchange;
-Bluetooth proxies are not supported for setup. This is not a signal-strength
-limitation. Home Assistant Container uses the host's Linux BlueZ stack, which is
-why the D-Bus access and container permissions above are required.
+Bluetooth proxies are not supported for setup. Put the local adapter within a
+few feet of Matic with a clear path when possible. Passive advertisement range
+can be longer than reliable interactive-connection range, so a proxy seeing the
+robot does not prove the local adapter is close enough. Home Assistant Container
+uses the host's Linux BlueZ stack, which is why the D-Bus access and container
+permissions above are required.
 
 ## Troubleshooting signatures
 
@@ -48,18 +51,30 @@ Enable debug logging (`custom_components.matic_robot: debug`) and match the
 repeated line during a failing attempt:
 
 - `Found 0 fresh local Matic advertisement(s)` — the robot is not
-  broadcasting. Its pairing window expires silently and its screen shows
-  nothing while the window is open, so turn Pairing mode off and back on in
-  the Matic app and submit again promptly. If toggling never helps and a
-  10-second `bluetoothctl scan on` on the host hears no devices at all, the
-  host's Bluetooth adapter is wedged — reboot the Home Assistant host.
+  reaching the local adapter during that scan. Turn Pairing mode off and back
+  on, put the adapter within a few feet of Matic with minimal obstruction, and
+  submit again promptly. If the local adapter still misses fresh advertisements,
+  reload its Home Assistant integration or replug it. If a 10-second
+  `bluetoothctl scan on` on the host hears no devices at all, the host's
+  Bluetooth adapter is wedged — reboot the Home Assistant host.
 - `visible only through a remote Bluetooth proxy` — only ESPHome proxies can
-  see the robot; setup needs an adapter built into or attached to the host.
+  see the robot. Temporarily disable all Bluetooth proxies while retrying, and
+  move or extend the adapter built into or attached to the host closer to
+  Matic; only that local adapter can complete setup.
 - `failed during Bluetooth pairing` — the bond itself failed; the robot shows
   its code only after the bond starts, and each displayed code is valid for
   roughly 20 seconds.
 - The pairing-timeout warning in Settings → System → Logs always includes the
   last failing stage, so include it in bug reports.
+
+Home Assistant integrations using its supported Bluetooth API share the same
+scanner, and concurrent active-scan requests are deduplicated. Temporarily
+disabling another BLE integration can be a useful diagnostic, but a successful
+retry does not by itself prove that integration caused the failure; first rule
+out distance, obstruction, a stale pairing window, and an adapter that needs a
+reload, replug, or host reboot. Bluetooth proxies are the exception: disable
+them temporarily during a troubled pairing attempt so the local adapter is the
+only Bluetooth path presented to setup.
 
 ## Failure behavior
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -18,12 +18,22 @@ Any six-digit Bluetooth passkey shown on the robot is used only by the active
 pairing attempt; it is not stored in the config entry, logs, diagnostics, or
 rotation history.
 
-The entity state machine may contain activity, battery, room names and IDs,
-firmware metadata, current/previous area, preference states, Wi-Fi SSIDs and
-scan results, schedules, cleaning histories, and diagnostic state. Home
-Assistant's recorder may retain historical entity states according to the
-user's recorder settings. The local map camera renders room geometry and robot
-pose on demand; it contains no optical camera frames.
+The entity state machine contains activity, battery, firmware metadata,
+current/previous Area context, preference state, summary counts, and diagnostic
+state. High-context diagnostic entities are disabled by default. Attributes
+that carry home context — the connected Wi-Fi SSID, schedule definitions, room
+names and IDs, the latest session's rooms and durations, and full plan/history
+records — stay live on the state machine for templates but are declared
+unrecorded, so Home Assistant's recorder never writes them to the history
+database. The neighbor Wi-Fi scan list is not exposed at all. Two exceptions
+are deliberate and opt-in or explicit: the per-room statistics sensors are
+disabled by default and, when a user enables them, record that room's name and
+cleaning durations as long-term statistics; and the
+`matic_robot_cleaning_finished` event includes the finished session's rooms
+and per-room durations in its payload. Home Assistant's recorder retains
+enabled entity states according to the user's recorder settings. The local map
+camera renders room geometry and robot pose on demand; it contains no optical
+camera frames.
 
 The integration does not start camera or microphone recordings, request clip
 bytes or thumbnails, cache media, expose recording metadata, or send vendor
@@ -52,17 +62,16 @@ This section applies only when a user explicitly clicks **Download diagnostics**
 for the integration in Home Assistant. The integration does not generate,
 upload, or send a diagnostic report automatically.
 
-The user-downloaded report never includes the pairing passkey. It redacts the
-stored credential, host and hostname, IP addresses, serial number, and
-certificate fingerprint. It intentionally retains the user-assigned name,
-floor plan, room names/geometry, pose, current/previous areas, Wi-Fi SSIDs/scans,
-schedules, history, and decoded diagnostic state. That local context is often
-the evidence needed to diagnose firmware and mapping behavior. The report does
-not include recording metadata, thumbnails, clip bytes, pairing material,
-Wi-Fi passwords, account tokens, Matter codes, or packet captures.
+The user-downloaded report is constructed from an explicit safe-field allowlist,
+not a best-effort redaction denylist. It omits the pairing passkey, stored
+credential, host/hostname, addresses, serial number, certificate identity,
+user-assigned names, floor geometry, pose, current/previous areas, room data,
+Wi-Fi SSIDs/scans, schedule definitions, session details, and full plan history.
+It retains protocol/build versions, boolean/counter summaries, state/error codes,
+map availability/counts, payload-free endpoint health, and firmware-snapshot
+counts needed to diagnose compatibility.
 
-Treat a diagnostics download, log, or screenshot as private home data and
-inspect it before sharing publicly.
+Still inspect a diagnostics download, log, or screenshot before sharing it.
 
 ## Deauthorization
 

--- a/docs/release-notes-0.2.0.md
+++ b/docs/release-notes-0.2.0.md
@@ -1,0 +1,94 @@
+# Release notes — 0.2.0
+
+[Documentation home](README.md) · [Project overview](../README.md) ·
+[Get support](README.md#support)
+
+0.2.0 is a hardening and observability release. Read **Upgrading from 0.1.x**
+before updating: entity IDs migrate once, one action was renamed, and the
+recording model changed.
+
+## Fixed
+
+- **Entities cycling between unavailable and available.** Live robots
+  sometimes reset a Hermes collection stream on their side while the
+  integration is finishing a bounded read. The resulting raw `h2` protocol
+  error escaped the transport error mapping, failed the entire 30-second
+  poll, and marked every entity unavailable for one cycle. All `h2` errors
+  now map into the normal connection-error handling, stream cancellation is
+  best-effort, and telemetry collection reads moved to a five-minute tier —
+  reproduced, fixed, and verified against a real robot on firmware v168.11.
+  The `h2` package is now an explicit requirement.
+
+## What's new
+
+- **Firmware compatibility tracking.** A typed 40-endpoint Hermes registry
+  drives automatic, payload-free endpoint snapshots whenever new firmware is
+  observed. The Firmware compatibility sensor reports
+  `pending`/`baseline`/`compatible`/`regression`; a Repair appears only when
+  endpoint availability or transport behavior actually drifts, never for a
+  normal OTA. Transient sweep failures are retried instead of being recorded.
+- **Room statistics.** Two opt-in sensors per mapped room — last clean
+  duration (long-term statistics) and last cleaned timestamp — plus an
+  always-on `Last run duration` sensor, so cleaning time can be compared
+  across firmware updates. See
+  [Room statistics and the recorder](automation.md#room-statistics-and-the-recorder).
+- **New events.** `matic_robot_cleaning_finished` fires once per finished
+  session with duration, rooms, per-room durations, and firmware version.
+  `matic_robot_firmware_changed` fires on OTA changes. Both carry
+  `device_id`/`entry_id`.
+- **Update entity.** A read-only firmware update surface in Home Assistant's
+  update UI; installs remain robot-managed.
+- **Wi-Fi signal sensor** (disabled by default) with long-term statistics.
+- **Tiered polling.** Operational state and pose every 30 s, decoded telemetry
+  every 5 minutes, floor plan every 15 minutes, identity once; setting writes
+  force an immediate slow refresh. Map camera frames are cached per
+  plan/pose/size.
+- **Robot identity protection.** If the device at the configured address ever
+  presents a TLS certificate that does not match the pinned robot identity, the
+  integration blocks communication, logs an error, and raises a Repair that
+  clears automatically once the identity matches again.
+- **Command acknowledgment health.** Every sent command records whether the
+  robot's channel acknowledged it; diagnostics summarize acknowledgment
+  counts and failures alongside endpoint read health.
+- **Recorder privacy.** Home-context attributes (rooms, SSID, schedules,
+  session room detail, plan history) remain fully template-visible but are
+  excluded from the recorder database. The neighbor Wi-Fi scan list is no
+  longer exposed. Diagnostics use a strict safe-field allowlist.
+
+## Upgrading from 0.1.x
+
+- **Entity IDs migrate once.** The first start after upgrading renames
+  pre-0.2.0 registry entries to descriptive canonical IDs (for example
+  `vacuum.matic_3` → `vacuum.matic`) when the destination ID is free.
+  Dashboards and automations that reference old numbered IDs need a one-time
+  update; every rename is logged. The migration runs exactly once, so IDs you
+  rename afterwards are never touched again.
+- **Action renamed.** `matic_robot.fetch_hermes_collection` is now
+  `matic_robot.inspect_hermes_endpoint`. The `collection` field is now
+  `endpoint`, and the `include_payload`/`payload_format`/`max_bytes` options
+  are gone: inspection is hash-only, and raw payload bytes can no longer be
+  retrieved through Home Assistant.
+- **Attribute changes.** Previously recorded attributes are now live-only
+  (excluded from recorder history): vacuum `rooms`, rooms sensor
+  `room_names`/`segments`, Wi-Fi `ssid`, `schedules`, session
+  `latest_rooms`/`latest_room_durations`, plan/history detail, and software
+  `timezone`. Templates keep working; recorded attribute history stops
+  accumulating. The Wi-Fi `networks` neighbor list was removed entirely. The
+  active-plan and next-room sensors now nest their detail under single
+  `active` and `preview` attributes.
+- **Recorded room statistics are opt-in.** Enable the per-room sensors under
+  the device's entity list if you want per-room duration history; enabling
+  them stores room names in the recorder by design.
+- **Removing the integration now erases its stored firmware history** along
+  with the config entry.
+
+## Verification
+
+All release gates pass: full test suite at 100% coverage, Ruff, strict MyPy,
+the privacy/public-tree check, and the packaging/fresh-install gates. This
+build was installed on a production Home Assistant Yellow against a real
+robot on firmware v168.11: the one-time entity-ID migration, the automatic
+40-endpoint baseline snapshot (28 populated, 12 empty, 0 failed), the
+firmware compatibility sensor, per-room statistics sensors, saved-plan
+actions, and the h2 stream-reset fix were all verified live. See
+[Firmware compatibility](firmware-compatibility.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "matic-home-assistant"
-version = "0.1.2"
+version = "0.2.0"
 description = "Unofficial local-only Home Assistant integration for Matic robot vacuums"
 readme = "README.md"
 license = "MIT"
@@ -16,6 +16,7 @@ classifiers = [
 dependencies = [
   "cryptography>=44",
   "grpclib==0.4.9",
+  "h2>=4",
   "Pillow>=11",
   "protobuf>=6",
 ]

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -315,7 +315,7 @@ class FakeSendStream:
         self._requests.append(request)
 
     async def recv_message(self):
-        return SimpleNamespace()
+        return SimpleNamespace(ByteSize=lambda: 0)
 
 
 class FakeSendToChannel:

--- a/tests/test_api_paths.py
+++ b/tests/test_api_paths.py
@@ -28,6 +28,7 @@ from custom_components.matic_robot.client.exceptions import (
     AuthenticationRequiredError,
     CannotConnectError,
     CertificateMismatchError,
+    EndpointUnsupportedError,
     PairingModeRequiredError,
 )
 from custom_components.matic_robot.client.models import FloorPlan
@@ -530,12 +531,43 @@ async def test_get_collection_entries_stop_at_stream_end_without_cancel(
     assert not hasattr(stream, "cancelled")
 
 
+async def test_endpoint_inspection_routes_properties_collections_and_health() -> None:
+    client = MaticHermesClient("robot.invalid", 16320)
+    client.async_get_property = AsyncMock(return_value=b"version")
+    client.async_get_collection_entries = AsyncMock(
+        return_value=(SimpleNamespace(key=b"key", value=b"zone"),)
+    )
+
+    current = await client.async_inspect_endpoint("current_version")
+    zones = await client.async_inspect_endpoint("zones", limit=2)
+
+    assert current[0].key == b""
+    assert current[0].value == b"version"
+    assert zones[0].value == b"zone"
+    client.async_get_property.assert_awaited_once_with("current_version")
+    client.async_get_collection_entries.assert_awaited_once_with("zones", limit=2)
+    assert client.endpoint_health == {"current_version": "ok", "zones": "ok"}
+
+    client.async_get_property.side_effect = CannotConnectError("offline")
+    with pytest.raises(CannotConnectError):
+        await client.async_inspect_endpoint("current_version")
+    assert client.endpoint_health["current_version"] == "CannotConnectError"
+
+    health = client.endpoint_health
+    health.clear()
+    assert client.endpoint_health
+    with pytest.raises(ValueError, match="Unknown Hermes endpoint"):
+        await client.async_inspect_endpoint("unknown")
+
+
 async def test_get_collection_entries_translates_stream_errors(monkeypatch) -> None:
     client = MaticHermesClient("robot.invalid", 16320)
     client._channel = object()
     for error, error_type in (
         (GRPCError(Status.UNAUTHENTICATED, "auth"), AuthenticationRequiredError),
         (GRPCError(Status.INTERNAL, "failed"), CannotConnectError),
+        (GRPCError(Status.UNIMPLEMENTED, "gone"), EndpointUnsupportedError),
+        (GRPCError(Status.NOT_FOUND, "missing"), EndpointUnsupportedError),
     ):
         method = _OpenMethod(_Stream(error=error))
         monkeypatch.setattr(
@@ -544,6 +576,70 @@ async def test_get_collection_entries_translates_stream_errors(monkeypatch) -> N
         )
         with pytest.raises(error_type):
             await client.async_get_collection_entries("history")
+
+
+async def test_raw_h2_stream_errors_map_to_cannot_connect(monkeypatch) -> None:
+    from h2.exceptions import StreamClosedError
+
+    client = MaticHermesClient("robot.invalid", 16320)
+    client._channel = object()
+    method = _OpenMethod(_Stream(error=StreamClosedError(63)))
+    monkeypatch.setattr(
+        "custom_components.matic_robot.client.api.HermesStub",
+        lambda channel: SimpleNamespace(FetchCollection=method),
+    )
+    with pytest.raises(CannotConnectError, match="connection failed"):
+        await client.async_get_collection_entries("history")
+
+
+async def test_cancel_of_robot_closed_stream_keeps_collected_data(
+    monkeypatch,
+) -> None:
+    """Live robots reset streams once the reader stops; data must survive."""
+    from h2.exceptions import StreamClosedError
+
+    class _RobotClosedStream(_Stream):
+        async def cancel(self):
+            self.cancelled = True
+            raise StreamClosedError(63)
+
+    client = MaticHermesClient("robot.invalid", 16320)
+    client._channel = object()
+    stream = _RobotClosedStream(response=_collection_response(direct=b"payload"))
+    monkeypatch.setattr(
+        "custom_components.matic_robot.client.api.HermesStub",
+        lambda channel: SimpleNamespace(FetchCollection=_OpenMethod(stream)),
+    )
+
+    entries = await client.async_get_collection_entries("history", limit=1)
+
+    assert [entry.value for entry in entries] == [b"payload"]
+    assert stream.cancelled
+
+
+async def test_collection_reads_are_wall_clock_bounded(monkeypatch) -> None:
+    client = MaticHermesClient("robot.invalid", 16320)
+    client._channel = object()
+    clock = iter([0.0, 100.0, 0.0, 100.0])
+    monkeypatch.setattr(
+        "custom_components.matic_robot.client.api.monotonic", lambda: next(clock)
+    )
+
+    stream = _Stream(response=_collection_response(direct=b"payload"))
+    monkeypatch.setattr(
+        "custom_components.matic_robot.client.api.HermesStub",
+        lambda channel: SimpleNamespace(FetchCollection=_OpenMethod(stream)),
+    )
+    assert await client.async_get_collection_entries("history") == ()
+    assert stream.cancelled
+
+    stream = _Stream(response=_collection_response(direct=b"payload"))
+    monkeypatch.setattr(
+        "custom_components.matic_robot.client.api.HermesStub",
+        lambda channel: SimpleNamespace(FetchCollection=_OpenMethod(stream)),
+    )
+    assert await client.async_get_collection_count("history") == 0
+    assert stream.cancelled
 
 
 async def test_optional_telemetry_reads_fail_closed() -> None:
@@ -674,5 +770,32 @@ async def test_send_channel_payload_translates_stream_errors(monkeypatch) -> Non
         )
         with pytest.raises(error_type):
             await client._async_send_channel_payload("user_command", b"payload")
+        assert client.command_health["user_command"] == error_type.__name__
 
     assert MaticHermesClient("robot.invalid", 16320)._metadata is None
+
+
+async def test_send_channel_payload_records_acknowledgment_health(
+    monkeypatch,
+) -> None:
+    client = MaticHermesClient("robot.invalid", 16320, credential=_credential())
+    client._channel = object()
+
+    acknowledged = _Stream(response=SimpleNamespace(ByteSize=lambda: 4))
+    monkeypatch.setattr(
+        "custom_components.matic_robot.client.api.HermesStub",
+        lambda channel: SimpleNamespace(SendToChannel=_OpenMethod(acknowledged)),
+    )
+    await client._async_send_channel_payload("user_command", b"payload")
+    assert client.command_health == {"user_command": "acknowledged"}
+
+    silent = _Stream(response=None)
+    monkeypatch.setattr(
+        "custom_components.matic_robot.client.api.HermesStub",
+        lambda channel: SimpleNamespace(SendToChannel=_OpenMethod(silent)),
+    )
+    await client._async_send_channel_payload("voice_enabled_command", b"payload")
+    assert client.command_health == {
+        "user_command": "acknowledged",
+        "voice_enabled_command": "unacknowledged",
+    }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.exceptions import ConfigEntryAuthFailed
@@ -14,6 +15,7 @@ from custom_components.matic_robot.client.exceptions import (
     MaticError,
 )
 from custom_components.matic_robot.client.models import (
+    FloorPlan,
     RobotInfo,
     RobotOperationalState,
     RobotTelemetry,
@@ -44,9 +46,16 @@ def _client() -> AsyncMock:
     return client
 
 
+def _tracking_entry() -> SimpleNamespace:
+    entry = SimpleNamespace(async_on_unload=MagicMock(), entry_id="entry")
+    entry.async_create_background_task = lambda hass, target, name: (
+        hass.async_create_task(target, name)
+    )
+    return entry
+
+
 def _coordinator(hass, client) -> MaticCoordinator:
-    entry = SimpleNamespace(async_on_unload=MagicMock())
-    return MaticCoordinator(hass, client, config_entry=entry)
+    return MaticCoordinator(hass, client, config_entry=_tracking_entry())
 
 
 async def test_update_combines_required_and_optional_local_state(hass) -> None:
@@ -97,3 +106,248 @@ async def test_rejected_credential_starts_home_assistant_reauthentication(hass) 
 
     with pytest.raises(ConfigEntryAuthFailed, match="rejected"):
         await _coordinator(hass, client)._async_update_data()
+
+
+async def test_coordinator_caches_slow_reads_and_can_force_them(hass) -> None:
+    client = _client()
+    client.async_get_floor_plan.return_value = FloorPlan(1, "partition", b"", ())
+    coordinator = _coordinator(hass, client)
+
+    await coordinator._async_update_data()
+    await coordinator._async_update_data()
+
+    assert client.async_get_info.await_count == 1
+    assert client.async_get_floor_plan.await_count == 1
+    assert client.async_get_telemetry.await_count == 1
+    assert client.async_get_state.await_count == 2
+    assert client.async_get_pose.await_count == 2
+
+    coordinator.async_request_refresh = AsyncMock()
+    await coordinator.async_request_full_refresh()
+    coordinator.async_request_refresh.assert_awaited_once()
+    await coordinator._async_update_data()
+    assert client.async_get_floor_plan.await_count == 2
+    assert client.async_get_telemetry.await_count == 2
+
+
+async def test_slow_refresh_failure_retains_last_good_values(hass) -> None:
+    client = _client()
+    coordinator = _coordinator(hass, client)
+    first = await coordinator._async_update_data()
+    client.async_get_floor_plan.side_effect = MaticError("map drift")
+    client.async_get_telemetry.side_effect = MaticError("telemetry drift")
+    coordinator._force_full_refresh = True
+
+    second = await coordinator._async_update_data()
+
+    assert second.floor_plan is first.floor_plan
+    assert second.telemetry is first.telemetry
+
+
+async def test_coordinator_records_observed_firmware(hass) -> None:
+    client = _client()
+    client.async_get_telemetry.return_value = RobotTelemetry(
+        software_version="v168.11", protocol_version=25
+    )
+    client.async_get_state.return_value = replace(
+        client.async_get_state.return_value, software_version="fallback"
+    )
+    tracker = SimpleNamespace(
+        async_observe_version=AsyncMock(), needs_snapshot=MagicMock(return_value=False)
+    )
+    entry = _tracking_entry()
+    coordinator = MaticCoordinator(
+        hass, client, config_entry=entry, firmware_tracker=tracker
+    )
+
+    await coordinator._async_update_data()
+
+    tracker.async_observe_version.assert_awaited_once_with(
+        "entry", "v168.11", 25, device_id=None
+    )
+
+
+async def test_coordinator_snapshots_each_new_firmware_once_in_background(hass) -> None:
+    client = _client()
+    client.async_get_telemetry.return_value = RobotTelemetry(
+        software_version="v168.11", protocol_version=25
+    )
+    tracker = SimpleNamespace(
+        async_observe_version=AsyncMock(),
+        needs_snapshot=MagicMock(return_value=True),
+        async_record_snapshot=AsyncMock(),
+    )
+    coordinator = MaticCoordinator(
+        hass, client, config_entry=_tracking_entry(), firmware_tracker=tracker
+    )
+    snapshot = {
+        "firmware_version": "v168.11",
+        "endpoint_count": 40,
+        "failed_endpoints": 0,
+    }
+
+    with patch(
+        "custom_components.matic_robot.coordinator.async_build_firmware_snapshot",
+        AsyncMock(return_value=snapshot),
+    ) as build:
+        await coordinator._async_update_data()
+        await hass.async_block_till_done()
+
+    build.assert_awaited_once()
+    tracker.async_record_snapshot.assert_awaited_once_with("entry", snapshot)
+    assert coordinator._snapshot_versions_in_progress == set()
+    assert coordinator._snapshot_attempts == {}
+
+
+async def test_transient_sweep_failures_defer_then_record_degraded(hass) -> None:
+    client = _client()
+    client.async_get_telemetry.return_value = RobotTelemetry(
+        software_version="v168.11", protocol_version=25
+    )
+    tracker = SimpleNamespace(
+        async_observe_version=AsyncMock(),
+        needs_snapshot=MagicMock(return_value=True),
+        async_record_snapshot=AsyncMock(),
+    )
+    coordinator = MaticCoordinator(
+        hass, client, config_entry=_tracking_entry(), firmware_tracker=tracker
+    )
+    snapshot = {
+        "firmware_version": "v168.11",
+        "endpoint_count": 40,
+        "failed_endpoints": 40,
+    }
+
+    with patch(
+        "custom_components.matic_robot.coordinator.async_build_firmware_snapshot",
+        AsyncMock(return_value=snapshot),
+    ):
+        await coordinator._async_update_data()
+        await hass.async_block_till_done()
+        tracker.async_record_snapshot.assert_not_awaited()
+        assert coordinator._snapshot_attempts == {"v168.11": 1}
+
+        # The retry cooldown suppresses an immediate re-sweep.
+        await coordinator._async_update_data()
+        await hass.async_block_till_done()
+        assert coordinator._snapshot_attempts == {"v168.11": 1}
+
+        coordinator._snapshot_retry_after = 0.0
+        await coordinator._async_update_data()
+        await hass.async_block_till_done()
+        tracker.async_record_snapshot.assert_not_awaited()
+
+        coordinator._snapshot_retry_after = 0.0
+        await coordinator._async_update_data()
+        await hass.async_block_till_done()
+
+    tracker.async_record_snapshot.assert_awaited_once_with("entry", snapshot)
+    assert coordinator._snapshot_attempts == {}
+
+
+async def test_cleaning_finished_event_fires_once_per_new_session(hass) -> None:
+    from pytest_homeassistant_custom_component.common import async_capture_events
+
+    from custom_components.matic_robot.client.models import CleaningSession
+    from custom_components.matic_robot.const import EVENT_CLEANING_FINISHED
+
+    def _session(suffix: str) -> CleaningSession:
+        return CleaningSession(
+            started_at=f"2026-07-20T0{suffix}:00:00+00:00",
+            ended_at=f"2026-07-20T0{suffix}:30:00+00:00",
+            duration_seconds=1800,
+            rooms=("Study",),
+            room_durations=(("Study", 1800),),
+            completed=True,
+        )
+
+    client = _client()
+    events = async_capture_events(hass, EVENT_CLEANING_FINISHED)
+    coordinator = _coordinator(hass, client)
+
+    client.async_get_telemetry.return_value = RobotTelemetry(
+        software_version="v168.11", latest_session=_session("1")
+    )
+    await coordinator._async_update_data()
+    await hass.async_block_till_done()
+    assert not events
+
+    client.async_get_telemetry.return_value = RobotTelemetry(
+        software_version="v168.11", latest_session=_session("2")
+    )
+    coordinator._force_full_refresh = True
+    await coordinator._async_update_data()
+    coordinator._force_full_refresh = True
+    await coordinator._async_update_data()
+    await hass.async_block_till_done()
+
+    assert len(events) == 1
+    assert events[0].data["duration_seconds"] == 1800
+    assert events[0].data["room_durations"] == {"Study": 1800}
+    assert events[0].data["firmware_version"] == "v168.11"
+    assert events[0].data["entry_id"] == "entry"
+
+    client.async_get_telemetry.return_value = RobotTelemetry(
+        software_version="v168.11",
+        latest_session=CleaningSession(
+            started_at="2026-07-20T03:00:00+00:00",
+            ended_at=None,
+            duration_seconds=None,
+            rooms=(),
+            room_durations=(),
+            completed=False,
+        ),
+    )
+    coordinator._force_full_refresh = True
+    await coordinator._async_update_data()
+    await hass.async_block_till_done()
+    assert len(events) == 1
+
+
+async def test_identity_mismatch_raises_repair_until_recovery(hass) -> None:
+    from homeassistant.helpers import issue_registry as ir
+
+    from custom_components.matic_robot.client.exceptions import (
+        CertificateMismatchError,
+    )
+    from custom_components.matic_robot.const import DOMAIN
+
+    client = _client()
+    coordinator = _coordinator(hass, client)
+    client.async_get_state.side_effect = CertificateMismatchError("changed")
+
+    with pytest.raises(UpdateFailed, match="TLS identity"):
+        await coordinator._async_update_data()
+    with pytest.raises(UpdateFailed, match="TLS identity"):
+        await coordinator._async_update_data()
+
+    registry = ir.async_get(hass)
+    issue_id = "robot_identity_changed_entry"
+    assert registry.async_get_issue(DOMAIN, issue_id) is not None
+
+    client.async_get_state.side_effect = None
+    await coordinator._async_update_data()
+    assert registry.async_get_issue(DOMAIN, issue_id) is None
+    await coordinator._async_update_data()
+    assert registry.async_get_issue(DOMAIN, issue_id) is None
+
+
+async def test_coordinator_updates_device_registry_firmware_once(hass) -> None:
+    client = _client()
+    client.async_get_telemetry.return_value = RobotTelemetry(
+        software_version="v168.11", protocol_version=25
+    )
+    registry = SimpleNamespace(
+        async_get_device=MagicMock(return_value=SimpleNamespace(id="device")),
+        async_update_device=MagicMock(),
+    )
+    coordinator = _coordinator(hass, client)
+
+    with patch(
+        "custom_components.matic_robot.coordinator.dr.async_get",
+        return_value=registry,
+    ):
+        await coordinator._async_update_data()
+        await coordinator._async_update_data()
+
+    registry.async_update_device.assert_called_once_with("device", sw_version="v168.11")

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -35,7 +35,18 @@ async def test_diagnostics_redact_access_material_but_keep_local_context() -> No
             "certificate_fingerprint": "private-fingerprint",
             "hermes_credential": "private-credential",
         },
+        entry_id="synthetic-entry",
         runtime_data=SimpleNamespace(
+            client=SimpleNamespace(
+                endpoint_health={"current_version": "ok", "wifi_status": "failure"},
+                command_health={
+                    "user_command": "acknowledged",
+                    "voice_enabled_command": "unacknowledged",
+                },
+            ),
+            firmware_tracker=SimpleNamespace(
+                summary=lambda entry_id: {"observed_version": "test-version"}
+            ),
             coordinator=SimpleNamespace(
                 data=SimpleNamespace(
                     info=info,
@@ -55,7 +66,7 @@ async def test_diagnostics_redact_access_material_but_keep_local_context() -> No
                     telemetry=RobotTelemetry(software_version="test-version"),
                 ),
                 last_update_success=True,
-            )
+            ),
         ),
     )
 
@@ -71,8 +82,16 @@ async def test_diagnostics_redact_access_material_but_keep_local_context() -> No
         "private-credential",
     ):
         assert private_value not in rendered
-    assert diagnostics["robot"]["name"] == "Private robot name"
-    assert diagnostics["operational"]["current_area"] == "Private bedroom"
-    assert diagnostics["operational"]["previous_area"] == "Private bathroom"
     assert diagnostics["robot"]["hardware_revision"] == "synthetic-hardware"
     assert diagnostics["telemetry"]["software_version"] == "test-version"
+    assert diagnostics["endpoint_health"] == {
+        "observed": 2,
+        "healthy": 1,
+        "failures": {"wifi_status": "failure"},
+    }
+    assert diagnostics["command_health"] == {
+        "observed": 2,
+        "acknowledged": 1,
+        "failures": {"voice_enabled_command": "unacknowledged"},
+    }
+    assert diagnostics["firmware_tracking"]["observed_version"] == "test-version"

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,0 +1,24 @@
+"""Authoritative endpoint registry tests."""
+
+from custom_components.matic_robot.client.endpoints import (
+    HERMES_ENDPOINT_MAP,
+    HERMES_ENDPOINT_NAMES,
+    HERMES_ENDPOINTS,
+    HermesEndpointKind,
+    HermesEndpointSensitivity,
+)
+
+
+def test_endpoint_registry_is_unique_typed_and_excludes_credentials() -> None:
+    assert len(HERMES_ENDPOINTS) == 40
+    assert len(HERMES_ENDPOINT_MAP) == len(HERMES_ENDPOINTS)
+    assert HERMES_ENDPOINT_NAMES == tuple(HERMES_ENDPOINT_MAP)
+    assert HERMES_ENDPOINT_MAP["current_version"].kind is HermesEndpointKind.PROPERTY
+    assert HERMES_ENDPOINT_MAP["zones"].kind is HermesEndpointKind.COLLECTION
+    assert (
+        HERMES_ENDPOINT_MAP["current_version"].sensitivity
+        is HermesEndpointSensitivity.DIAGNOSTIC
+    )
+    assert not any(
+        "credential" in name or "token" in name for name in HERMES_ENDPOINT_NAMES
+    )

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -18,6 +18,7 @@ from custom_components.matic_robot import (
     select,
     sensor,
     switch,
+    update,
     vacuum,
 )
 from custom_components.matic_robot.client.commands import (
@@ -144,6 +145,8 @@ def _entry(*, paused: bool = False, idle: bool = False, with_floor_plan: bool = 
         cleaning_mode=CleaningMode.BOTH,
         coverage_setting=CoverageSetting.STANDARD,
         async_request_refresh=AsyncMock(),
+        async_request_full_refresh=AsyncMock(),
+        async_add_listener=MagicMock(return_value=MagicMock()),
         last_update_success=True,
     )
     history = SimpleNamespace(
@@ -187,14 +190,30 @@ def _entry(*, paused: bool = False, idle: bool = False, with_floor_plan: bool = 
         async_add_listener=MagicMock(return_value=MagicMock()),
         cancel=MagicMock(return_value=True),
     )
+    firmware = SimpleNamespace(
+        summary=MagicMock(
+            return_value={
+                "compatibility_status": "baseline",
+                "observed_version": "v-test",
+                "endpoint_count": 40,
+                "failed_endpoints": 0,
+            }
+        ),
+        async_add_listener=MagicMock(return_value=MagicMock()),
+    )
     return SimpleNamespace(
-        runtime_data=SimpleNamespace(coordinator=coordinator, cleaning_plans=history),
+        runtime_data=SimpleNamespace(
+            coordinator=coordinator,
+            cleaning_plans=history,
+            firmware_tracker=firmware,
+        ),
         options={},
         entry_id="entry",
+        async_on_unload=MagicMock(),
     )
 
 
-async def test_platform_setups_create_forty_four_entities(hass) -> None:
+async def test_platform_setups_create_the_full_entity_surface(hass) -> None:
     entry = _entry()
     entities: list[object] = []
     platform_counts: dict[str, int] = {}
@@ -212,25 +231,192 @@ async def test_platform_setups_create_forty_four_entities(hass) -> None:
     await add_platform("camera", camera.async_setup_entry)
     await add_platform("number", number.async_setup_entry)
     await add_platform("switch", switch.async_setup_entry)
+    await add_platform("update", update.async_setup_entry)
     await add_platform("vacuum", vacuum.async_setup_entry)
 
+    # 48 fixed entities plus two opt-in statistics sensors per mapped room.
     assert platform_counts == {
         "binary_sensor": 12,
         "button": 4,
         "camera": 1,
         "number": 1,
         "select": 3,
-        "sensor": 18,
+        "sensor": 25,
         "switch": 4,
+        "update": 1,
         "vacuum": 1,
     }
-    assert len(entities) == 44
-    assert len({entity.unique_id for entity in entities}) == 44
+    assert len(entities) == 52
+    assert len({entity.unique_id for entity in entities}) == 52
     assert all(entity.device_info["manufacturer"] == "Matic" for entity in entities)
+
+
+async def test_room_statistics_sensors_follow_floor_plan_growth(hass) -> None:
+    entry = _entry()
+    coordinator = entry.runtime_data.coordinator
+    added: list[object] = []
+
+    await sensor.async_setup_entry(hass, entry, lambda values: added.extend(values))
+
+    room_entities = [
+        entity
+        for entity in added
+        if isinstance(
+            entity, (sensor.MaticRoomDurationSensor, sensor.MaticRoomLastCleanedSensor)
+        )
+    ]
+    assert len(room_entities) == 4
+    assert all(
+        entity.entity_description.entity_registry_enabled_default is False
+        for entity in room_entities
+    )
+    assert room_entities[0].suggested_object_id == "kitchen_clean_duration"
+
+    # The coordinator listener adds sensors for rooms that appear later.
+    listener = coordinator.async_add_listener.call_args.args[0]
+    added.clear()
+    listener()
+    assert added == []
+
+    new_room = Room("room-3", "Hall", "protocol-3", b"three", ((2, 2), (3, 3)))
+    coordinator.data = replace(
+        coordinator.data,
+        floor_plan=replace(
+            coordinator.data.floor_plan,
+            rooms=(*coordinator.data.floor_plan.rooms, new_room),
+        ),
+    )
+    listener()
+    assert len(added) == 2
+
+
+async def test_room_sensors_wait_for_a_floor_plan(hass) -> None:
+    entry = _entry(with_floor_plan=False)
+    added: list[object] = []
+
+    await sensor.async_setup_entry(hass, entry, lambda values: added.extend(values))
+
+    assert not [
+        entity
+        for entity in added
+        if isinstance(
+            entity, (sensor.MaticRoomDurationSensor, sensor.MaticRoomLastCleanedSensor)
+        )
+    ]
+
+
+async def test_room_statistics_sensors_apply_and_restore_sessions() -> None:
+    entry = _entry()
+    kitchen = entry.runtime_data.coordinator.data.floor_plan.rooms[0]
+    study = entry.runtime_data.coordinator.data.floor_plan.rooms[1]
+
+    duration = sensor.MaticRoomDurationSensor(entry, kitchen)
+    last_cleaned = sensor.MaticRoomLastCleanedSensor(entry, kitchen)
+    with (
+        patch.object(MaticEntity, "async_added_to_hass", AsyncMock()),
+        patch.object(
+            sensor.MaticRoomDurationSensor,
+            "async_get_last_sensor_data",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            sensor.MaticRoomLastCleanedSensor,
+            "async_get_last_sensor_data",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        await duration.async_added_to_hass()
+        await last_cleaned.async_added_to_hass()
+
+    assert duration.available is True
+    assert duration.native_value == 600
+    assert last_cleaned.native_value is not None
+    assert last_cleaned.native_value.isoformat() == "2026-01-01T08:10:00+00:00"
+
+    # A room the latest session did not include keeps its restored value.
+    stored = SimpleNamespace(native_value=120)
+    stored_when = SimpleNamespace(
+        native_value=sensor.dt_util.parse_datetime("2025-12-31T10:00:00+00:00")
+    )
+    study_duration = sensor.MaticRoomDurationSensor(entry, study)
+    study_last = sensor.MaticRoomLastCleanedSensor(entry, study)
+    with (
+        patch.object(MaticEntity, "async_added_to_hass", AsyncMock()),
+        patch.object(
+            sensor.MaticRoomDurationSensor,
+            "async_get_last_sensor_data",
+            AsyncMock(return_value=stored),
+        ),
+        patch.object(
+            sensor.MaticRoomLastCleanedSensor,
+            "async_get_last_sensor_data",
+            AsyncMock(return_value=stored_when),
+        ),
+    ):
+        await study_duration.async_added_to_hass()
+        await study_last.async_added_to_hass()
+
+    assert study_duration.native_value == 120
+    assert study_last.native_value == stored_when.native_value
+
+    # Coordinator updates re-apply the latest session.
+    fresh = sensor.MaticRoomDurationSensor(entry, kitchen)
+    fresh.async_write_ha_state = MagicMock()
+    fresh._handle_coordinator_update()
+    assert fresh.native_value == 600
+
+
+def test_room_statistics_sensors_skip_unmatched_sessions() -> None:
+    entry = _entry(with_floor_plan=False)
+    room = _floor_plan().rooms[0]
+    assert sensor.MaticRoomDurationSensor(entry, room)._room_session_value() is None
+
+    entry = _entry()
+    coordinator = entry.runtime_data.coordinator
+    removed = replace(
+        coordinator.data,
+        floor_plan=replace(coordinator.data.floor_plan, rooms=()),
+    )
+    coordinator.data = removed
+    assert sensor.MaticRoomDurationSensor(entry, room)._room_session_value() is None
+
+    entry = _entry()
+    coordinator = entry.runtime_data.coordinator
+    coordinator.data = replace(
+        coordinator.data,
+        telemetry=replace(coordinator.data.telemetry, latest_session=None),
+    )
+    assert sensor.MaticRoomDurationSensor(entry, room)._room_session_value() is None
+
+    entry = _entry()
+    study = entry.runtime_data.coordinator.data.floor_plan.rooms[1]
+    entity = sensor.MaticRoomLastCleanedSensor(entry, study)
+    entity._async_apply_session()
+    assert entity.native_value is None
+
+
+async def test_update_entity_mirrors_robot_managed_ota_state() -> None:
+    entry = _entry()
+    entity = update.MaticFirmwareUpdate(entry)
+
+    assert entity.installed_version == "v-test"
+    assert entity.latest_version == "v-test"
+    assert entity.extra_state_attributes == {
+        "update_state": "idle",
+        "update_channel": "stable",
+    }
+
+    coordinator = entry.runtime_data.coordinator
+    coordinator.data = replace(
+        coordinator.data,
+        telemetry=replace(coordinator.data.telemetry, update_state="available"),
+    )
+    assert entity.latest_version is None
 
 
 def test_sensor_and_binary_sensor_values() -> None:
     entry = _entry()
+    assert MaticEntity(entry).suggested_object_id is None
     fully_charged = next(
         description
         for description in binary_sensor.DESCRIPTIONS
@@ -251,6 +437,7 @@ def test_sensor_and_binary_sensor_values() -> None:
         "test-hardware",
         2,
     ]
+    assert sensors[1].suggested_object_id == "battery"
     assert sensors[0].extra_state_attributes == {
         "hermes_state_codes": [1, 2],
         "hermes_error_codes": [],
@@ -262,16 +449,21 @@ def test_sensor_and_binary_sensor_values() -> None:
         "room_names": ["Kitchen", "Study"],
         "segments": {"room-1": "Kitchen", "room-2": "Study"},
     }
+    assert "room_names" in sensor.MaticRoomsSensor._unrecorded_attributes
     history = sensor.MaticCleaningHistorySensor(entry)
     assert history.available is True
     assert history.native_value == 0
-    assert history.extra_state_attributes["active_plan"] is None
+    assert history.extra_state_attributes["plan_running"] is False
+    assert history.extra_state_attributes["last_completed_by_room"] == {}
+    assert "plans" in sensor.MaticCleaningHistorySensor._unrecorded_attributes
     active_plan = sensor.MaticActiveCleaningPlanSensor(entry)
     next_room = sensor.MaticNextCleaningRoomSensor(entry)
     assert active_plan.native_value is None
     assert active_plan.extra_state_attributes is None
     assert next_room.native_value == "Kitchen"
-    assert next_room.extra_state_attributes["valid"] is True
+    next_preview = next_room.extra_state_attributes
+    assert next_preview is not None
+    assert next_preview["preview"]["rooms"][0]["name"] == "Kitchen"
     assert [
         binary_sensor.MaticBinarySensor(entry, description).is_on
         for description in binary_sensor.DESCRIPTIONS
@@ -289,12 +481,36 @@ def test_sensor_and_binary_sensor_values() -> None:
         None,
         None,
     ]
+    assert {
+        description.key
+        for description in sensor.STATE_DESCRIPTIONS
+        if description.entity_registry_enabled_default is False
+    } == {
+        "wifi_state",
+        "scheduled_cleanings",
+        "local_cleaning_sessions",
+        "dock_detections",
+        "sink_summon_locations",
+        "coverage_time",
+        "wifi_signal",
+    }
+    assert vacuum.MaticVacuum(entry).suggested_object_id is None
 
     no_map = sensor.MaticRoomsSensor(_entry(with_floor_plan=False))
     assert no_map.native_value is None
     assert no_map.extra_state_attributes is None
     no_map_next = sensor.MaticNextCleaningRoomSensor(_entry(with_floor_plan=False))
     assert no_map_next.native_value is None
+    no_map_schedules = sensor.MaticStateSensor(
+        _entry(with_floor_plan=False),
+        next(
+            description
+            for description in sensor.STATE_DESCRIPTIONS
+            if description.key == "scheduled_cleanings"
+        ),
+    ).extra_state_attributes
+    assert no_map_schedules is not None
+    assert no_map_schedules["schedules"][0]["rooms"] == []
 
     software = sensor.MaticSoftwareVersionSensor(entry)
     assert software.native_value == "v-test"
@@ -305,10 +521,14 @@ def test_sensor_and_binary_sensor_values() -> None:
         "supports_easter_event": True,
         "timezone": "Etc/UTC",
     }
+    compatibility = sensor.MaticFirmwareCompatibilitySensor(entry)
+    assert compatibility.native_value == "baseline"
+    assert compatibility.available is True
+    assert compatibility.extra_state_attributes["endpoint_count"] == 40
     assert [
         sensor.MaticStateSensor(entry, description).native_value
         for description in sensor.STATE_DESCRIPTIONS
-    ] == [25, None, "stable", "idle", "connected", 3, 7, 4, 1, 600]
+    ] == [25, None, "stable", "idle", "connected", 3, 7, 4, 1, 600, 600, -45]
 
     state_sensors = {
         description.key: sensor.MaticStateSensor(entry, description)
@@ -319,14 +539,29 @@ def test_sensor_and_binary_sensor_values() -> None:
     }
     wifi = state_sensors["wifi_state"].extra_state_attributes
     assert wifi is not None
-    assert wifi["ssid"] == "Test LAN"
     assert wifi["known_networks"] == 1
-    assert len(wifi["networks"]) == 2
+    assert wifi["ssid"] == "Test LAN"
+    assert "networks" not in wifi
+    assert "ssid" in sensor.MaticStateSensor._unrecorded_attributes
     schedules = state_sensors["scheduled_cleanings"].extra_state_attributes
-    assert schedules is not None
-    assert schedules["schedules"][0]["rooms"] == ["Kitchen"]
+    assert schedules == {
+        "schedules": [
+            {
+                "name": "Morning",
+                "weekdays": ["monday"],
+                "time": "08:30",
+                "timezone": "Etc/UTC",
+                "ordered": True,
+                "enabled": True,
+                "rooms": ["Kitchen"],
+                "room_ids": ["protocol-1"],
+            }
+        ]
+    }
     sessions = state_sensors["local_cleaning_sessions"].extra_state_attributes
     assert sessions is not None
+    assert sessions["latest_duration_seconds"] == 600
+    assert sessions["latest_rooms"] == ["Kitchen"]
     assert sessions["latest_room_durations"] == {"Kitchen": 600}
     assert state_sensors["protocol_version"].extra_state_attributes is None
 
@@ -384,6 +619,21 @@ async def test_storage_backed_sensors_track_history_and_stay_available() -> None
     assert plan_sensor.available is True
 
 
+async def test_firmware_sensor_tracks_background_snapshot_completion() -> None:
+    entry = _entry()
+    tracker = entry.runtime_data.firmware_tracker
+    entity = sensor.MaticFirmwareCompatibilitySensor(entry)
+    entity.async_write_ha_state = MagicMock()
+
+    with patch.object(MaticEntity, "async_added_to_hass", AsyncMock()):
+        await entity.async_added_to_hass()
+
+    robot_id, listener = tracker.async_add_listener.call_args.args
+    assert robot_id == "entry"
+    listener()
+    entity.async_write_ha_state.assert_called_once()
+
+
 async def test_verified_setting_entities_write_and_refresh() -> None:
     entry = _entry()
     coordinator = entry.runtime_data.coordinator
@@ -417,7 +667,7 @@ async def test_verified_setting_entities_write_and_refresh() -> None:
     assert water_flow.available is True
     await water_flow.async_set_native_value(1.4)
     coordinator.client.async_set_water_flow.assert_awaited_once_with(1.4)
-    assert coordinator.async_request_refresh.await_count == 5
+    assert coordinator.async_request_full_refresh.await_count == 5
 
 
 async def test_saved_plan_select_and_native_button() -> None:
@@ -553,8 +803,11 @@ async def test_camera_clamps_dimensions_and_renders_locally(hass) -> None:
         return_value=b"synthetic-png",
     ) as render:
         image = await entity.async_camera_image(width=1, height=9999)
+        cached = await entity.async_camera_image(width=1, height=9999)
 
     assert image == b"synthetic-png"
+    assert cached == image
+    assert render.call_count == 1
     assert render.call_args.kwargs == {"width": 256, "height": 2048}
 
 
@@ -662,6 +915,7 @@ async def test_vacuum_attributes_and_segments_survive_a_missing_floor_plan() -> 
         "problem": False,
         "rooms": {"room-1": "Kitchen", "room-2": "Study"},
     }
+    assert vacuum.MaticVacuum._unrecorded_attributes == frozenset({"rooms"})
 
     bare = vacuum.MaticVacuum(_entry(with_floor_plan=False))
     assert bare.extra_state_attributes == {

--- a/tests/test_firmware.py
+++ b/tests/test_firmware.py
@@ -1,0 +1,208 @@
+"""Firmware observation, comparison, and retention tests."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from custom_components.matic_robot.firmware import (
+    MAX_HISTORY,
+    FirmwareTracker,
+    _compare_snapshots,
+    _compatibility_status,
+    snapshot_timestamp,
+)
+
+
+def _snapshot(
+    version: str = "v168.11",
+    *,
+    status: str = "populated",
+    value_hash: str = "one",
+) -> dict[str, object]:
+    return {
+        "captured_at": "2026-07-20T00:00:00+00:00",
+        "firmware_version": version,
+        "protocol_version": 25,
+        "endpoint_count": 1,
+        "populated_endpoints": int(status == "populated"),
+        "empty_endpoints": int(status == "empty"),
+        "failed_endpoints": int(status == "error"),
+        "endpoints": [
+            {
+                "name": "current_version",
+                "kind": "property",
+                "status": status,
+                "entries": [{"value_sha256": value_hash}],
+            }
+        ],
+    }
+
+
+async def test_tracker_loads_observes_and_signals_version_changes(hass) -> None:
+    tracker = FirmwareTracker(hass)
+    tracker._store = SimpleNamespace(
+        async_load=AsyncMock(return_value=None), async_save=AsyncMock()
+    )
+    await tracker.async_load()
+
+    listener = MagicMock()
+    remove_listener = tracker.async_add_listener("entry", listener)
+    assert await tracker.async_observe_version("entry", None, None) is False
+    assert await tracker.async_observe_version("entry", "v168.11", 25) is False
+    assert await tracker.async_observe_version("entry", "v168.11", 25) is False
+    listener.assert_called_once()
+    remove_listener()
+
+    events = []
+    hass.bus.async_listen("matic_robot_firmware_changed", events.append)
+    assert (
+        await tracker.async_observe_version("entry", "v169.0", 26, device_id="device")
+        is True
+    )
+    await hass.async_block_till_done()
+
+    assert events[0].data == {
+        "entry_id": "entry",
+        "device_id": "device",
+        "previous_version": "v168.11",
+        "firmware_version": "v169.0",
+        "previous_protocol": 25,
+        "protocol_version": 26,
+    }
+
+
+async def test_tracker_persists_snapshots_caps_history_and_summarizes(hass) -> None:
+    stored = {"robots": {"entry": {"history": [_snapshot()] * MAX_HISTORY}}}
+    tracker = FirmwareTracker(hass)
+    tracker._store = SimpleNamespace(
+        async_load=AsyncMock(return_value=stored), async_save=AsyncMock()
+    )
+    await tracker.async_load()
+
+    with patch(
+        "custom_components.matic_robot.firmware.ir.async_delete_issue"
+    ) as delete_issue:
+        comparison = await tracker.async_record_snapshot("entry", _snapshot("v169.0"))
+
+    assert comparison["baseline"] is True
+    assert len(tracker._data["robots"]["entry"]["history"]) == MAX_HISTORY
+    assert tracker.summary("entry") == {
+        "observed_version": None,
+        "observed_protocol": None,
+        "compatibility_status": "baseline",
+        "last_snapshot_at": "2026-07-20T00:00:00+00:00",
+        "snapshot_count": MAX_HISTORY,
+        "endpoint_count": 1,
+        "populated_endpoints": 1,
+        "empty_endpoints": 0,
+        "failed_endpoints": 0,
+        "changed_endpoints": 0,
+        "content_changed_endpoints": 0,
+    }
+    assert tracker.summary("missing")["snapshot_count"] == 0
+    assert tracker.needs_snapshot("entry", "v169.0") is False
+    assert tracker.needs_snapshot("entry", "v170") is True
+    assert FirmwareTracker.issue_id("entry") == "firmware_changed_923fe53966c6"
+    delete_issue.assert_called_once()
+
+    with patch(
+        "custom_components.matic_robot.firmware.ir.async_create_issue"
+    ) as create_issue:
+        await tracker.async_record_snapshot("entry", _snapshot("v170", status="error"))
+    assert create_issue.call_args.kwargs["translation_key"] == "firmware_regression"
+    assert create_issue.call_args.kwargs["translation_placeholders"]["count"] == "1"
+    assert "entry" not in create_issue.call_args.args[2]
+
+    with patch(
+        "custom_components.matic_robot.firmware.ir.async_delete_issue"
+    ) as resolved:
+        await tracker.async_record_snapshot("entry", _snapshot("v170"))
+    resolved.assert_called_once()
+    assert tracker.summary("entry")["compatibility_status"] == "compatible"
+
+
+async def test_removed_robots_forget_history_and_withdraw_repairs(hass) -> None:
+    tracker = FirmwareTracker(hass)
+    tracker._store = SimpleNamespace(
+        async_load=AsyncMock(return_value={"robots": {"entry": {}}}),
+        async_save=AsyncMock(),
+    )
+    await tracker.async_load()
+
+    with patch(
+        "custom_components.matic_robot.firmware.ir.async_delete_issue"
+    ) as delete_issue:
+        await tracker.async_remove_robot("missing")
+        delete_issue.assert_not_called()
+        await tracker.async_remove_robot("entry")
+
+    delete_issue.assert_called_once()
+    assert tracker._data["robots"] == {}
+    tracker._store.async_save.assert_awaited_once()
+
+
+def test_activity_dependent_population_is_not_availability_drift() -> None:
+    populated = _snapshot()
+    empty = _snapshot("v169", status="empty")
+    comparison = _compare_snapshots(populated, empty)
+    assert comparison["firmware_changed"] is True
+    assert comparison["changed_endpoints"] == []
+    assert comparison["content_changed_endpoints"] == ["current_version"]
+
+
+def test_snapshot_comparison_separates_availability_from_content() -> None:
+    previous = _snapshot(value_hash="old")
+    content = _compare_snapshots(previous, _snapshot(value_hash="new"))
+    assert content["changed_endpoints"] == []
+    assert content["content_changed_endpoints"] == ["current_version"]
+
+    compatibility = _compare_snapshots(previous, _snapshot("v169", status="error"))
+    assert compatibility == {
+        "baseline": False,
+        "firmware_changed": True,
+        "protocol_changed": False,
+        "changed_endpoints": ["current_version"],
+        "content_changed_endpoints": ["current_version"],
+    }
+
+    added = _snapshot()
+    added["endpoints"] = [
+        *added["endpoints"],
+        {"name": "zones", "kind": "collection", "status": "empty", "entries": []},
+    ]
+    assert _compare_snapshots(previous, added)["changed_endpoints"] == ["zones"]
+
+    assert _compatibility_status(None, {"baseline": True}) == "baseline"
+    assert (
+        _compatibility_status(
+            "pending",
+            {
+                "baseline": False,
+                "firmware_changed": True,
+                "changed_endpoints": ["zones"],
+            },
+        )
+        == "regression"
+    )
+    clean = {
+        "baseline": False,
+        "firmware_changed": True,
+        "changed_endpoints": [],
+    }
+    assert _compatibility_status("pending", clean) == "compatible"
+    unchanged = {
+        "baseline": False,
+        "firmware_changed": False,
+        "changed_endpoints": [],
+    }
+    assert _compatibility_status("compatible", unchanged) == "compatible"
+    assert _compatibility_status(None, unchanged) == "current"
+
+
+def test_snapshot_timestamp_uses_home_assistant_utc_clock() -> None:
+    with patch(
+        "custom_components.matic_robot.firmware.dt_util.utcnow",
+        return_value=SimpleNamespace(isoformat=MagicMock(return_value="timestamp")),
+    ):
+        assert snapshot_timestamp() == "timestamp"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -10,6 +10,7 @@ import pytest
 from homeassistant.components import frontend
 
 from custom_components.matic_robot import (
+    async_remove_entry,
     async_setup,
     async_setup_entry,
     async_unload_entry,
@@ -19,6 +20,7 @@ from custom_components.matic_robot.const import (
     CONF_HERMES_CREDENTIAL,
     CONF_HOSTNAME,
     CONF_SERIAL_NUMBER,
+    DATA_FIRMWARE_TRACKER,
     DATA_PLAN_MANAGER,
     DOMAIN,
     PLATFORMS,
@@ -37,6 +39,7 @@ def _entry() -> SimpleNamespace:
         },
         options={},
         runtime_data=None,
+        entry_id="entry",
     )
 
 
@@ -48,13 +51,20 @@ async def test_setup_registers_services_without_media_view() -> None:
     )
 
     history = SimpleNamespace(async_load=AsyncMock())
-    with patch(
-        "custom_components.matic_robot.services.CleaningPlanManager",
-        return_value=history,
+    firmware = SimpleNamespace(async_load=AsyncMock())
+    with (
+        patch(
+            "custom_components.matic_robot.services.CleaningPlanManager",
+            return_value=history,
+        ),
+        patch(
+            "custom_components.matic_robot.services.FirmwareTracker",
+            return_value=firmware,
+        ),
     ):
         assert await async_setup(hass, {}) is True
 
-    assert hass.services.async_register.call_count == 15
+    assert hass.services.async_register.call_count == 16
     hass.http.register_view.assert_not_called()
     assert hass.data[DOMAIN][DATA_PLAN_MANAGER] is history
 
@@ -68,8 +78,12 @@ async def test_setup_registers_configuration_editor_when_frontend_is_loaded() ->
         data={frontend.DATA_EXTRA_MODULE_URL: set()},
     )
 
-    with patch("custom_components.matic_robot.services.CleaningPlanManager") as history:
+    with (
+        patch("custom_components.matic_robot.services.CleaningPlanManager") as history,
+        patch("custom_components.matic_robot.services.FirmwareTracker") as firmware,
+    ):
         history.return_value.async_load = AsyncMock()
+        firmware.return_value.async_load = AsyncMock()
         assert await async_setup(hass, {}) is True
 
     hass.http.async_register_static_paths.assert_awaited_once()
@@ -85,7 +99,12 @@ async def test_setup_refreshes_before_forwarding_platforms() -> None:
     hass = SimpleNamespace(
         config=SimpleNamespace(time_zone="America/Los_Angeles"),
         config_entries=SimpleNamespace(async_forward_entry_setups=AsyncMock()),
-        data={DOMAIN: {DATA_PLAN_MANAGER: MagicMock()}},
+        data={
+            DOMAIN: {
+                DATA_PLAN_MANAGER: MagicMock(),
+                DATA_FIRMWARE_TRACKER: MagicMock(),
+            }
+        },
     )
     entry = _entry()
     client = MagicMock()
@@ -111,13 +130,22 @@ async def test_setup_refreshes_before_forwarding_platforms() -> None:
         entry, PLATFORMS
     )
     assert entry.runtime_data.client is client
+    assert (
+        entry.runtime_data.firmware_tracker
+        is (hass.data[DOMAIN][DATA_FIRMWARE_TRACKER])
+    )
 
 
 async def test_setup_closes_client_when_first_refresh_fails() -> None:
     hass = SimpleNamespace(
         config=SimpleNamespace(time_zone="UTC"),
         config_entries=SimpleNamespace(async_forward_entry_setups=AsyncMock()),
-        data={DOMAIN: {DATA_PLAN_MANAGER: MagicMock()}},
+        data={
+            DOMAIN: {
+                DATA_PLAN_MANAGER: MagicMock(),
+                DATA_FIRMWARE_TRACKER: MagicMock(),
+            }
+        },
     )
     entry = _entry()
     entry.data.pop(CONF_HERMES_CREDENTIAL)
@@ -147,7 +175,12 @@ async def test_setup_closes_client_when_platform_forwarding_fails() -> None:
                 side_effect=RuntimeError("platform setup failed")
             )
         ),
-        data={DOMAIN: {DATA_PLAN_MANAGER: MagicMock()}},
+        data={
+            DOMAIN: {
+                DATA_PLAN_MANAGER: MagicMock(),
+                DATA_FIRMWARE_TRACKER: MagicMock(),
+            }
+        },
     )
     entry = _entry()
     client = MagicMock()
@@ -179,3 +212,16 @@ async def test_unload_closes_client_only_after_all_platforms_unload(unload_ok) -
 
     assert await async_unload_entry(hass, entry) is unload_ok
     assert client.close.called is unload_ok
+
+
+async def test_remove_entry_erases_firmware_history() -> None:
+    tracker = SimpleNamespace(async_remove_robot=AsyncMock())
+    hass = SimpleNamespace(data={DOMAIN: {DATA_FIRMWARE_TRACKER: tracker}})
+    entry = SimpleNamespace(entry_id="entry")
+
+    await async_remove_entry(hass, entry)
+
+    tracker.async_remove_robot.assert_awaited_once_with("entry")
+
+    bare = SimpleNamespace(data={})
+    await async_remove_entry(bare, entry)

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,137 @@
+"""Pre-1.0 entity identity migration tests."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from custom_components.matic_robot.migrations import async_migrate_entry
+
+
+def _entry(*, version: int = 1, minor_version: int = 1) -> SimpleNamespace:
+    return SimpleNamespace(
+        entry_id="entry",
+        version=version,
+        minor_version=minor_version,
+        data={"serial_number": "serial"},
+    )
+
+
+def _hass() -> SimpleNamespace:
+    return SimpleNamespace(
+        config_entries=SimpleNamespace(async_update_entry=MagicMock())
+    )
+
+
+async def test_entity_ids_migrate_once_to_descriptive_canonical_names() -> None:
+    registry = SimpleNamespace(async_get=MagicMock(), async_update_entity=MagicMock())
+    entries = [
+        SimpleNamespace(
+            unique_id="other_battery",
+            domain="sensor",
+            entity_id="sensor.ignore",
+        ),
+        SimpleNamespace(
+            unique_id="serial_battery",
+            domain="sensor",
+            entity_id="sensor.matic_battery",
+        ),
+        SimpleNamespace(
+            unique_id="serial_activity",
+            domain="sensor",
+            entity_id="sensor.matic_2",
+        ),
+        SimpleNamespace(
+            unique_id="serial_vacuum",
+            domain="vacuum",
+            entity_id="vacuum.matic_3",
+        ),
+    ]
+    registry.async_get.side_effect = [object(), None]
+    device_registry = SimpleNamespace(
+        async_get_device=MagicMock(return_value=SimpleNamespace(name="Matic"))
+    )
+    hass = _hass()
+    entry = _entry()
+
+    with (
+        patch(
+            "custom_components.matic_robot.migrations.er.async_get",
+            return_value=registry,
+        ),
+        patch(
+            "custom_components.matic_robot.migrations.er.async_entries_for_config_entry",
+            return_value=entries,
+        ),
+        patch(
+            "custom_components.matic_robot.migrations.dr.async_get",
+            return_value=device_registry,
+        ),
+    ):
+        assert await async_migrate_entry(hass, entry) is True  # type: ignore[arg-type]
+
+    registry.async_update_entity.assert_called_once_with(
+        "vacuum.matic_3", new_entity_id="vacuum.matic"
+    )
+    hass.config_entries.async_update_entry.assert_called_once_with(
+        entry, minor_version=2
+    )
+
+
+async def test_future_major_versions_refuse_to_downgrade() -> None:
+    hass = _hass()
+    assert await async_migrate_entry(hass, _entry(version=2)) is False  # type: ignore[arg-type]
+    hass.config_entries.async_update_entry.assert_not_called()
+
+
+async def test_current_minor_version_is_left_untouched() -> None:
+    hass = _hass()
+    with patch("custom_components.matic_robot.migrations.er.async_get") as registry_get:
+        assert await async_migrate_entry(hass, _entry(minor_version=2)) is True  # type: ignore[arg-type]
+    registry_get.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
+
+
+async def test_missing_serial_and_device_fall_back_safely() -> None:
+    registry = SimpleNamespace(
+        async_get=MagicMock(return_value=None), async_update_entity=MagicMock()
+    )
+    device_registry = SimpleNamespace(async_get_device=MagicMock(return_value=None))
+    hass = _hass()
+    entry = _entry()
+    entry.data = {}
+
+    with patch(
+        "custom_components.matic_robot.migrations.er.async_get",
+        return_value=registry,
+    ):
+        assert await async_migrate_entry(hass, entry) is True  # type: ignore[arg-type]
+    registry.async_update_entity.assert_not_called()
+
+    entries = [
+        SimpleNamespace(
+            unique_id="serial_battery",
+            domain="sensor",
+            entity_id="sensor.matic_2",
+        ),
+    ]
+    entry = _entry()
+    hass = _hass()
+    with (
+        patch(
+            "custom_components.matic_robot.migrations.er.async_get",
+            return_value=registry,
+        ),
+        patch(
+            "custom_components.matic_robot.migrations.er.async_entries_for_config_entry",
+            return_value=entries,
+        ),
+        patch(
+            "custom_components.matic_robot.migrations.dr.async_get",
+            return_value=device_registry,
+        ),
+    ):
+        assert await async_migrate_entry(hass, entry) is True  # type: ignore[arg-type]
+    registry.async_update_entity.assert_called_once_with(
+        "sensor.matic_2", new_entity_id="sensor.matic_battery"
+    )

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -25,6 +25,7 @@ IMPORT_ROOT_TO_DISTRIBUTION = {
     "dbus_fast": "dbus-fast",
     "google": "protobuf",
     "grpclib": "grpclib",
+    "h2": "h2",
     "voluptuous": "voluptuous",
     "zeroconf": "zeroconf",
 }
@@ -306,11 +307,16 @@ def test_user_copy_matches_pairing_and_plan_behavior() -> None:
         )
         assert "room map" in exceptions["room_plan_unavailable"]["message"]
         assert "reported an error" in exceptions["robot_error"]["message"]
+        inspection = services["inspect_hermes_endpoint"]
+        assert "payload-free" in inspection["description"]
+        assert set(inspection["fields"]) == {"endpoint", "limit"}
         assert (
-            "private device or home data"
-            in services["fetch_hermes_collection"]["fields"]["include_payload"][
-                "description"
-            ]
+            "weekly compatibility record"
+            in services["firmware_snapshot"]["description"]
+        )
+        assert (
+            "Review the **Firmware snapshot** response"
+            in translations["issues"]["firmware_regression"]["description"]
         )
 
 

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -9,7 +9,7 @@ from homeassistant.components.automation.config import AUTOMATION_BLUEPRINT_SCHE
 from homeassistant.components.blueprint.models import Blueprint
 from homeassistant.util.yaml import load_yaml
 
-from custom_components.matic_robot.const import HERMES_COLLECTIONS
+from custom_components.matic_robot.client.endpoints import HERMES_ENDPOINT_NAMES
 
 ROOT = Path(__file__).parents[1]
 INTEGRATION = ROOT / "custom_components" / "matic_robot"
@@ -28,7 +28,7 @@ def test_release_versions_and_links_are_consistent() -> None:
     hacs = json.loads((ROOT / "hacs.json").read_text())
     project = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]
 
-    assert manifest["version"] == "0.1.2"
+    assert manifest["version"] == "0.2.0"
     assert project["version"] == manifest["version"]
     assert hacs["homeassistant"] == "2026.7.0"
     assert manifest["documentation"].startswith("https://github.com/")
@@ -122,11 +122,11 @@ def test_integration_ships_local_brand_icons() -> None:
 
 
 def test_recording_boundary_has_no_runtime_surface() -> None:
-    """Keep externally consequential recording features out of the 0.1 surface."""
+    """Keep externally consequential recording features out of the public surface."""
     manifest = json.loads((INTEGRATION / "manifest.json").read_text())
     strings = json.loads((INTEGRATION / "strings.json").read_text())
     services = load_yaml(INTEGRATION / "services.yaml")
-    collection_options = services["fetch_hermes_collection"]["fields"]["collection"][
+    endpoint_options = services["inspect_hermes_endpoint"]["fields"]["endpoint"][
         "selector"
     ]["select"]["options"]
     entity_keys = {key for platform in strings["entity"].values() for key in platform}
@@ -155,8 +155,8 @@ def test_recording_boundary_has_no_runtime_surface() -> None:
     assert "review_recording" not in services
     assert "review_recording" not in strings["services"]
     assert entity_keys.isdisjoint(recording_entity_keys)
-    assert tuple(collection_options) == HERMES_COLLECTIONS
-    assert recording_collections.isdisjoint(HERMES_COLLECTIONS)
+    assert tuple(endpoint_options) == HERMES_ENDPOINT_NAMES
+    assert recording_collections.isdisjoint(HERMES_ENDPOINT_NAMES)
     assert recording_collections.isdisjoint(json.dumps(services).split('"'))
 
     handwritten_runtime = "\n".join(

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -9,7 +9,11 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import ServiceCall
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
-from custom_components.matic_robot.client.exceptions import MaticError
+from custom_components.matic_robot.client.endpoints import HERMES_ENDPOINTS
+from custom_components.matic_robot.client.exceptions import (
+    CannotConnectError,
+    MaticError,
+)
 from custom_components.matic_robot.client.models import HermesCollectionEntry
 from custom_components.matic_robot.const import DOMAIN
 from custom_components.matic_robot.plans import CleaningPlanManager, CleaningRoom
@@ -45,9 +49,21 @@ async def _registered_services(hass, manager=None):
     replacement = manager or SimpleNamespace(async_load=AsyncMock())
     if manager is not None:
         replacement.async_load = AsyncMock()
-    with patch(
-        "custom_components.matic_robot.services.CleaningPlanManager",
-        return_value=replacement,
+    firmware = SimpleNamespace(
+        async_load=AsyncMock(),
+        async_record_snapshot=AsyncMock(
+            return_value={"baseline": True, "changed_endpoints": []}
+        ),
+    )
+    with (
+        patch(
+            "custom_components.matic_robot.services.CleaningPlanManager",
+            return_value=replacement,
+        ),
+        patch(
+            "custom_components.matic_robot.services.FirmwareTracker",
+            return_value=firmware,
+        ),
     ):
         await async_register_services(hass)
     return services
@@ -476,17 +492,25 @@ async def test_room_crud_rejects_unknown_rooms_membership_and_positions(hass) ->
 
 
 def test_saved_plan_context_requires_one_robot_and_live_rooms() -> None:
+    """The room map must come from the coordinator, not published attributes.
+
+    0.2.0 removed the vacuum's ``rooms`` state attribute, so this seam
+    deliberately builds the context from the real coordinator floor plan.
+    """
     call = MagicMock()
-    state = SimpleNamespace(attributes={"rooms": {"one": "Kitchen"}})
-    hass = SimpleNamespace(states=SimpleNamespace(get=MagicMock(return_value=state)))
-    entry = SimpleNamespace(
-        runtime_data=SimpleNamespace(
-            coordinator=SimpleNamespace(
-                data=SimpleNamespace(
-                    info=SimpleNamespace(serial_number="synthetic-serial")
-                )
-            )
+    hass = SimpleNamespace(states=SimpleNamespace(get=MagicMock(return_value=None)))
+    floor_plan = SimpleNamespace(
+        rooms=(
+            SimpleNamespace(id="one", name="Kitchen"),
+            SimpleNamespace(id="two", name="Study"),
         )
+    )
+    data = SimpleNamespace(
+        info=SimpleNamespace(serial_number="synthetic-serial"),
+        floor_plan=floor_plan,
+    )
+    entry = SimpleNamespace(
+        runtime_data=SimpleNamespace(coordinator=SimpleNamespace(data=data))
     )
     with (
         patch(
@@ -500,11 +524,12 @@ def test_saved_plan_context_requires_one_robot_and_live_rooms() -> None:
     ):
         assert _saved_plan_context(hass, call)[2:] == (
             "synthetic-serial",
-            {"one": "Kitchen"},
+            {"one": "Kitchen", "two": "Study"},
         )
-        state.attributes["rooms"] = {}
+        data.floor_plan = None
         with pytest.raises(ServiceValidationError, match="room map"):
             _saved_plan_context(hass, call)
+        assert _saved_plan_context(hass, call, require_rooms=False)[3] == {}
     with (
         patch(
             "custom_components.matic_robot.services._resolve_loaded_matic_vacuums",
@@ -513,6 +538,36 @@ def test_saved_plan_context_requires_one_robot_and_live_rooms() -> None:
         pytest.raises(ServiceValidationError, match="exactly one"),
     ):
         _saved_plan_context(hass, call)
+
+
+async def test_saved_plan_context_reads_rooms_the_vacuum_actually_exposes() -> None:
+    """Guard the producer/consumer seam with the real vacuum entity.
+
+    The context and the vacuum entity must agree on the same coordinator
+    floor plan so a state-attribute change can never break plan services.
+    """
+    from custom_components.matic_robot import vacuum as vacuum_platform
+    from tests.test_entities import _entry as entity_entry
+
+    entry = entity_entry()
+    entity = vacuum_platform.MaticVacuum(entry)
+    call = MagicMock()
+    hass = SimpleNamespace(states=SimpleNamespace(get=MagicMock(return_value=None)))
+
+    with (
+        patch(
+            "custom_components.matic_robot.services._resolve_loaded_matic_vacuums",
+            return_value=["vacuum.test"],
+        ),
+        patch(
+            "custom_components.matic_robot.services._entry_for_entity",
+            return_value=entry,
+        ),
+    ):
+        room_map = _saved_plan_context(hass, call)[3]
+
+    assert room_map == entity.extra_state_attributes["rooms"]
+    assert room_map == {"room-1": "Kitchen", "room-2": "Study"}
 
 
 def _resolution_hass(*, loaded: bool = True, available: bool = True):
@@ -588,11 +643,11 @@ def test_action_target_resolution_rejects_non_matic_target() -> None:
         _resolve_loaded_matic_vacuums(hass, call)
 
 
-async def test_fetch_hermes_collection_returns_bounded_raw_snapshot() -> None:
+async def test_inspect_hermes_endpoint_returns_bounded_safe_snapshot() -> None:
     hass = SimpleNamespace(data={})
     services = await _registered_services(hass)
     client = SimpleNamespace(
-        async_get_collection_entries=AsyncMock(
+        async_inspect_endpoint=AsyncMock(
             return_value=(HermesCollectionEntry(b"key", b"payload"),)
         )
     )
@@ -600,14 +655,11 @@ async def test_fetch_hermes_collection_returns_bounded_raw_snapshot() -> None:
     call = ServiceCall(
         hass,
         DOMAIN,
-        "fetch_hermes_collection",
+        "inspect_hermes_endpoint",
         {
             "entity_id": ["vacuum.test"],
-            "collection": "wifi_status",
+            "endpoint": "wifi_status",
             "limit": 1,
-            "include_payload": True,
-            "payload_format": "hex",
-            "max_bytes": 4,
         },
     )
     with (
@@ -620,26 +672,25 @@ async def test_fetch_hermes_collection_returns_bounded_raw_snapshot() -> None:
             return_value=entry,
         ),
     ):
-        response = await _registered_handler(services, "fetch_hermes_collection")(call)
-    assert response["entries"][0]["key"] == "6b6579"
-    assert response["entries"][0]["value"] == "7061796c"
-    assert response["entries"][0]["value_truncated"] is True
+        response = await _registered_handler(services, "inspect_hermes_endpoint")(call)
+    assert response["kind"] == "property"
+    assert response["entries"][0]["key_size"] == 3
+    assert response["entries"][0]["value_size"] == 7
+    assert "key" not in response["entries"][0]
+    client.async_inspect_endpoint.assert_awaited_once_with("wifi_status", limit=1)
 
 
-async def test_fetch_hermes_collection_requires_exactly_one_robot() -> None:
+async def test_inspect_hermes_endpoint_requires_exactly_one_robot() -> None:
     hass = SimpleNamespace(data={})
     services = await _registered_services(hass)
     call = ServiceCall(
         hass,
         DOMAIN,
-        "fetch_hermes_collection",
+        "inspect_hermes_endpoint",
         {
             "entity_id": ["vacuum.one", "vacuum.two"],
-            "collection": "wifi_status",
+            "endpoint": "wifi_status",
             "limit": 1,
-            "include_payload": False,
-            "payload_format": "base64",
-            "max_bytes": 65536,
         },
     )
     with (
@@ -649,14 +700,14 @@ async def test_fetch_hermes_collection_requires_exactly_one_robot() -> None:
         ),
         pytest.raises(ServiceValidationError, match="exactly one"),
     ):
-        await _registered_handler(services, "fetch_hermes_collection")(call)
+        await _registered_handler(services, "inspect_hermes_endpoint")(call)
 
 
-async def test_fetch_hermes_collection_encodes_base64_payloads() -> None:
+async def test_inspect_hermes_endpoint_fingerprints_payloads() -> None:
     hass = SimpleNamespace(data={})
     services = await _registered_services(hass)
     client = SimpleNamespace(
-        async_get_collection_entries=AsyncMock(
+        async_inspect_endpoint=AsyncMock(
             return_value=(HermesCollectionEntry(b"key", b"payload"),)
         )
     )
@@ -664,14 +715,11 @@ async def test_fetch_hermes_collection_encodes_base64_payloads() -> None:
     call = ServiceCall(
         hass,
         DOMAIN,
-        "fetch_hermes_collection",
+        "inspect_hermes_endpoint",
         {
             "entity_id": ["vacuum.test"],
-            "collection": "wifi_status",
+            "endpoint": "wifi_status",
             "limit": 1,
-            "include_payload": True,
-            "payload_format": "base64",
-            "max_bytes": 64,
         },
     )
     with (
@@ -684,11 +732,88 @@ async def test_fetch_hermes_collection_encodes_base64_payloads() -> None:
             return_value=entry,
         ),
     ):
-        response = await _registered_handler(services, "fetch_hermes_collection")(call)
-    assert response["entries"][0]["key"] == "a2V5"
-    assert response["entries"][0]["value"] == "cGF5bG9hZA=="
-    assert response["entries"][0]["key_truncated"] is False
-    assert response["entries"][0]["value_truncated"] is False
+        response = await _registered_handler(services, "inspect_hermes_endpoint")(call)
+    assert response["entries"][0]["key_sha256"] == (
+        "2c70e12b7a0646f92279f427c7b38e7334d8e5389cff167a1dc30e73f826b683"
+    )
+    assert response["entries"][0]["value_sha256"] == (
+        "239f59ed55e737c77147cf55ad0c1b030b6d7ee748a7426952f9b852d5a935e5"
+    )
+
+
+async def test_firmware_snapshot_persists_safe_full_endpoint_sweep() -> None:
+    hass = SimpleNamespace(data={})
+    services = await _registered_services(hass)
+
+    async def inspect(name: str, *, limit: int):
+        assert limit == 1
+        if name == "zones":
+            return ()
+        if name == "map_integrated":
+            raise CannotConnectError("synthetic failure with private context")
+        return (HermesCollectionEntry(b"key", b"value"),)
+
+    client = SimpleNamespace(async_inspect_endpoint=AsyncMock(side_effect=inspect))
+    state = SimpleNamespace(
+        telemetry=SimpleNamespace(software_version="v168.11", protocol_version=25),
+        operational=SimpleNamespace(software_version="fallback"),
+    )
+    entry = SimpleNamespace(
+        entry_id="entry",
+        runtime_data=SimpleNamespace(
+            client=client, coordinator=SimpleNamespace(data=state)
+        ),
+    )
+    call = ServiceCall(
+        hass,
+        DOMAIN,
+        "firmware_snapshot",
+        {"entity_id": ["vacuum.test"]},
+    )
+    with (
+        patch(
+            "custom_components.matic_robot.services._resolve_loaded_matic_vacuums",
+            return_value=["vacuum.test"],
+        ),
+        patch(
+            "custom_components.matic_robot.services._entry_for_entity",
+            return_value=entry,
+        ),
+        patch(
+            "custom_components.matic_robot.firmware.snapshot_timestamp",
+            return_value="timestamp",
+        ),
+    ):
+        response = await _registered_handler(services, "firmware_snapshot")(call)
+
+    assert response["endpoint_count"] == len(HERMES_ENDPOINTS)
+    assert response["populated_endpoints"] == len(HERMES_ENDPOINTS) - 2
+    assert response["empty_endpoints"] == 1
+    assert response["failed_endpoints"] == 1
+    failed = next(item for item in response["endpoints"] if item["status"] == "error")
+    assert failed["error_type"] == "CannotConnectError"
+    assert "synthetic failure" not in repr(response)
+    tracker = hass.data[DOMAIN]["firmware_tracker"]
+    tracker.async_record_snapshot.assert_awaited_once()
+
+
+async def test_firmware_snapshot_requires_exactly_one_robot() -> None:
+    hass = SimpleNamespace(data={})
+    services = await _registered_services(hass)
+    call = ServiceCall(
+        hass,
+        DOMAIN,
+        "firmware_snapshot",
+        {"entity_id": ["vacuum.one", "vacuum.two"]},
+    )
+    with (
+        patch(
+            "custom_components.matic_robot.services._resolve_loaded_matic_vacuums",
+            return_value=["vacuum.one", "vacuum.two"],
+        ),
+        pytest.raises(ServiceValidationError, match="exactly one"),
+    ):
+        await _registered_handler(services, "firmware_snapshot")(call)
 
 
 async def test_plan_runs_reject_disabled_plans_and_unknown_selection(hass) -> None:

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -199,6 +199,8 @@ def test_decode_wifi_schedule_and_history() -> None:
 def test_decode_auxiliary_states() -> None:
     assert _decode_uploader_state(_bfield(1, b"")) is False
     assert _decode_uploader_state(_bfield(2, _vfield(1, 1))) is True
+    assert _decode_uploader_state(_vfield(2, 1)) is True
+    assert _decode_uploader_state(_vfield(2, 0)) is False
     assert _decode_uploader_state(b"tombstone-value!") is False
     assert _decode_coverage_time(_bfield(3, _vfield(1, 321))) == 321
     assert _decode_coverage_time(b"tombstone-value!") is None


### PR DESCRIPTION
## Summary

0.2.0 hardening and observability release. Full release notes: docs/release-notes-0.2.0.md.

- Firmware compatibility tracking: typed 40-endpoint Hermes registry, automatic payload-free snapshots on new firmware, compatibility sensor, regression-only Repairs with transient-failure retry
- Per-room cleaning statistics (opt-in duration + last-cleaned sensors per room), always-on last-run duration, Wi-Fi signal sensor
- Read-only firmware update entity; matic_robot_cleaning_finished and matic_robot_firmware_changed events with device context
- Tiered polling (30 s state, 5 min telemetry, 15 min map, identity once) with write-triggered refresh
- One-shot entity ID migration to descriptive canonical IDs (config entry minor version 2)
- Recorder privacy: home-context attributes stay template-visible but unrecorded; hash-only endpoint inspection replaces raw payload retrieval
- Robot TLS identity mismatch raises a distinct self-clearing Repair; collection reads wall-clock bounded; command acknowledgment health in diagnostics
- Fixes entities cycling unavailable: robot-side h2 stream resets now map into normal connection handling (reproduced and verified fixed on a real robot, v168.11)

## Testing

- 434 tests, 100% coverage; Ruff check/format; strict MyPy; privacy/public-tree check; sdist/wheel + release-artifact + fresh-install gates
- Live-verified on HA Yellow (Core 2026.7.2) against a real robot on v168.11: entity ID migration, 40-endpoint baseline sweep (28 populated / 12 empty / 0 failed), compatibility sensor, saved-plan actions, room statistics sensors, update entity, h2 fix