### PR TITLE
Record the 0.2.0 live verification in firmware docs

### DIFF
--- a/docs/firmware-compatibility.md
+++ b/docs/firmware-compatibility.md
@@ -21,7 +21,7 @@ separates an observed update from verified compatibility.
 
 | Firmware | First observed | Integration | Status | Evidence | Changes or capabilities |
 | --- | --- | --- | --- | --- | --- |
-| [v168.11](firmware-versions/v168.md) | 2026-07-20 | 0.1.1 | Core read verified | Live on HA 2026.7.2; protocol 25; 40-name sweep complete | Core surfaces healthy; uploader-state decoder drift fixed in tree |
+| [v168.11](firmware-versions/v168.md) | 2026-07-20 | 0.2.0 | Core read verified | Live on HA 2026.7.2; protocol 25; automatic baseline snapshot 28 populated / 12 empty / 0 failed | Uploader-state decoder fix released and live-confirmed; robot-side stream resets handled as transport noise |
 
 An empty or pending entry is not a compatibility claim. Synthetic tests show
 that the integration handles the documented protocol shapes; only real-robot

--- a/docs/firmware-versions/v168.md
+++ b/docs/firmware-versions/v168.md
@@ -3,9 +3,9 @@
 [Endpoint map](../firmware-endpoint-map.md) ·
 [Firmware ledger](../firmware-compatibility.md)
 
-status: core read verified / optional decoder fixed / control validation pending  
+status: core read verified / decoder fix released and live-confirmed / control validation pending  
 first_observed_pacific: 2026-07-20  
-integration_version: 0.1.1  
+integration_version: 0.1.1 (first check); 0.2.0 (release verification 2026-07-21)  
 home_assistant_version: 2026.7.2  
 protocol_version: 25
 
@@ -41,6 +41,19 @@ protocol_version: 25
   older installed value, so the integration page is used as authority here.
 - No new endpoint, payload shape, or capability was established by this check.
 
+## 0.2.0 release verification (2026-07-21)
+
+- Integration 0.2.0 installed live via HACS on the same robot and firmware.
+- The automatic typed-registry snapshot covered all 40 endpoints with
+  **28 populated, 12 empty, 0 failed**; the 8 names that rejected the generic
+  stream path in the manual sweep are now read through their evidence-backed
+  property shapes. Compatibility status recorded as `baseline`.
+- The diagnostic-upload binary sensor resolved from `unknown` to the
+  robot-reported boolean, confirming the released dual-form decoder.
+- Robot-side stream resets during bounded collection reads were observed
+  live (`h2` StreamClosedError) and are handled as normal transport noise
+  in 0.2.0; they previously failed whole poll cycles on 0.1.x.
+
 ## Hash-only endpoint sweep
 
 Every allowlisted name was queried with `include_payload: false`, `limit: 1`,
@@ -75,7 +88,8 @@ and tests before any Home Assistant entity or attribute is added.
 - [x] Confirm authenticated coordinator refresh and core decoded read groups.
 - [x] Run a hash-only availability sweep of the exploratory allowlist.
 - [x] Review privacy-safe entity state for unknown state/error codes and missing fields.
-- [ ] Compare availability and decoded shapes with the preceding snapshot.
+- [x] Compare availability and decoded shapes with the preceding snapshot —
+  the 0.2.0 baseline snapshot is recorded; future OTAs compare automatically.
 - [ ] Deliberately exercise supported writes; record partial coverage honestly.
 - [x] Record new candidates and distinguish transport-path failures from
   endpoint regressions; payload evidence and fixtures remain pending.


### PR DESCRIPTION
Updates the firmware ledger row and the v168 version record with the 0.2.0 release verification: automatic baseline snapshot (28 populated / 12 empty / 0 failed), the uploader-state decoder fix live-confirmed, and robot-side h2 stream resets now handled as transport noise.