### PR TITLE
Fix plan editor and add graceful room stops

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ The integration adds Home Assistant-native planning and automation:
 
 - **Saved cleaning plans.** Named, reusable plans with a per-room cleaning
   mode and coverage level, include toggles, and drag-orderable room lists,
-  managed in one Configure screen with live preview.
+  managed in one Configure screen with live preview. Each plan can stop
+  immediately or finish a sufficiently progressed current room without
+  starting the next one.
 - **Least-recently-cleaned rotation.** A plan run can start with the rooms
   that have waited longest, using the saved order to break ties — no manual
   bookkeeping of what was cleaned last.

--- a/custom_components/matic_robot/config_flow.py
+++ b/custom_components/matic_robot/config_flow.py
@@ -1102,6 +1102,32 @@ class MaticRobotOptionsFlow(config_entries.OptionsFlow):
             ] = selector.BooleanSelector()
         schema[
             vol.Required(
+                "finish_current_room",
+                default=defaults.get(
+                    "finish_current_room",
+                    (plan or {}).get("finish_current_room", False),
+                ),
+            )
+        ] = selector.BooleanSelector()
+        schema[
+            vol.Required(
+                "finish_current_room_threshold",
+                default=defaults.get(
+                    "finish_current_room_threshold",
+                    (plan or {}).get("finish_current_room_threshold", 50),
+                ),
+            )
+        ] = selector.NumberSelector(
+            selector.NumberSelectorConfig(
+                min=0,
+                max=100,
+                step=5,
+                mode=selector.NumberSelectorMode.BOX,
+                unit_of_measurement="%",
+            )
+        )
+        schema[
+            vol.Required(
                 "return_to_base",
                 default=defaults.get(
                     "return_to_base", (plan or {}).get("return_to_base", True)
@@ -1246,6 +1272,12 @@ class MaticRobotOptionsFlow(config_entries.OptionsFlow):
                                 str(room["room_id"])
                                 for room in user_input["room_editor"]
                             ],
+                            "finish_current_room": bool(
+                                user_input.get("finish_current_room", False)
+                            ),
+                            "finish_current_room_threshold": int(
+                                user_input.get("finish_current_room_threshold", 50)
+                            ),
                             "return_to_base": user_input["return_to_base"],
                             "start_timeout": 120,
                             "completion_timeout": 21600,
@@ -1281,6 +1313,18 @@ class MaticRobotOptionsFlow(config_entries.OptionsFlow):
                     "room_order": [
                         str(room["room_id"]) for room in user_input["room_editor"]
                     ],
+                    "finish_current_room": bool(
+                        user_input.get(
+                            "finish_current_room",
+                            plan.get("finish_current_room", False),
+                        )
+                    ),
+                    "finish_current_room_threshold": int(
+                        user_input.get(
+                            "finish_current_room_threshold",
+                            plan.get("finish_current_room_threshold", 50),
+                        )
+                    ),
                     "return_to_base": user_input["return_to_base"],
                 }
                 updated.pop("id", None)

--- a/custom_components/matic_robot/frontend.py
+++ b/custom_components/matic_robot/frontend.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from hashlib import sha256
 from pathlib import Path
 
 from homeassistant.components import frontend
@@ -11,11 +12,14 @@ from homeassistant.core import HomeAssistant
 
 ROOM_PLAN_EDITOR_PATH = "/matic_robot/room-plan-editor.js"
 
-# Tie the cache-buster to the packaged manifest so it can never drift from the
-# shipped version. Loaded once at import time, off the event loop.
+# Include both the packaged version and the editor content in the cache-buster.
+# Both are loaded once at import time, off the event loop.
 MANIFEST_VERSION = json.loads(
     Path(__file__).with_name("manifest.json").read_text(encoding="utf-8")
 )["version"]
+ROOM_PLAN_EDITOR_VERSION = sha256(
+    Path(__file__).with_name("room_plan_editor.js").read_bytes()
+).hexdigest()[:12]
 
 
 async def async_register_room_plan_editor(hass: HomeAssistant) -> None:
@@ -26,4 +30,7 @@ async def async_register_room_plan_editor(hass: HomeAssistant) -> None:
     await hass.http.async_register_static_paths(
         [StaticPathConfig(ROOM_PLAN_EDITOR_PATH, str(path), cache_headers=True)]
     )
-    frontend.add_extra_js_url(hass, f"{ROOM_PLAN_EDITOR_PATH}?v={MANIFEST_VERSION}")
+    frontend.add_extra_js_url(
+        hass,
+        f"{ROOM_PLAN_EDITOR_PATH}?v={MANIFEST_VERSION}-{ROOM_PLAN_EDITOR_VERSION}",
+    )

--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -6,7 +6,8 @@ import asyncio
 from collections.abc import Callable, Iterable, Mapping
 from copy import deepcopy
 from dataclasses import asdict, dataclass
-from typing import Any, cast
+from datetime import datetime
+from typing import Any, Literal, cast
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.storage import Store
@@ -28,6 +29,15 @@ class CleaningRoom:
     coverage_setting: str
 
 
+@dataclass(frozen=True, slots=True)
+class PlanStopDecision:
+    """How an active managed plan should respond to a stop request."""
+
+    behavior: Literal["not_running", "immediate", "after_room"]
+    estimated_progress: int | None = None
+    threshold: int | None = None
+
+
 class CleaningPlanManager:
     """Persist room-native plans, outcomes, selection, and recovery state."""
 
@@ -38,6 +48,7 @@ class CleaningPlanManager:
         self._listeners: dict[str, set[Callable[[], None]]] = {}
         self._locks: dict[str, asyncio.Lock] = {}
         self._cancel_events: dict[str, asyncio.Event] = {}
+        self._finish_room_events: dict[str, asyncio.Event] = {}
 
     @staticmethod
     def _empty_data() -> dict[str, Any]:
@@ -80,11 +91,16 @@ class CleaningPlanManager:
         """Return the cancellation signal for the current managed run."""
         return self._cancel_events.setdefault(serial_number, asyncio.Event())
 
+    def finish_room_event(self, serial_number: str) -> asyncio.Event:
+        """Return the graceful-stop signal for the current managed run."""
+        return self._finish_room_events.setdefault(serial_number, asyncio.Event())
+
     @callback
     def prepare_run(self, serial_number: str) -> asyncio.Event:
         """Clear and return the cancellation signal for a new managed run."""
         event = self.cancellation_event(serial_number)
         event.clear()
+        self.finish_room_event(serial_number).clear()
         return event
 
     @callback
@@ -92,8 +108,47 @@ class CleaningPlanManager:
         """Request cancellation and report whether a plan is active."""
         if not self.lock(serial_number).locked():
             return False
+        self.finish_room_event(serial_number).clear()
         self.cancellation_event(serial_number).set()
         return True
+
+    @callback
+    def request_stop(self, serial_number: str) -> PlanStopDecision:
+        """Apply the active plan's immediate-or-after-room stop policy."""
+        if not self.lock(serial_number).locked():
+            return PlanStopDecision("not_running")
+
+        robot = self._robot(serial_number)
+        active = robot.get("active_plan")
+        if active is None:
+            self.cancel(serial_number)
+            return PlanStopDecision("immediate")
+        plan = robot["plans"].get(active["plan_id"], {})
+        if not plan.get("finish_current_room", False):
+            self.cancel(serial_number)
+            return PlanStopDecision("immediate")
+
+        try:
+            threshold = max(
+                0, min(100, int(plan.get("finish_current_room_threshold", 50)))
+            )
+        except TypeError, ValueError:
+            threshold = 50
+        record = (
+            robot["rotations"]
+            .get(active["plan_id"], {})
+            .get("rooms", {})
+            .get(active["room_id"], {})
+        )
+        expected = record.get("average_duration_seconds")
+        progress = _estimated_progress(active.get("started"), expected)
+        if progress is not None and progress < threshold:
+            self.cancel(serial_number)
+            return PlanStopDecision("immediate", progress, threshold)
+
+        self.cancellation_event(serial_number).clear()
+        self.finish_room_event(serial_number).set()
+        return PlanStopDecision("after_room", progress, threshold)
 
     @callback
     def async_add_listener(
@@ -202,6 +257,10 @@ class CleaningPlanManager:
             "rooms": [asdict(room) for room in chosen],
             "room_count": len(chosen),
             "return_to_base": bool(plan.get("return_to_base", True)),
+            "finish_current_room": bool(plan.get("finish_current_room", False)),
+            "finish_current_room_threshold": int(
+                plan.get("finish_current_room_threshold", 50)
+            ),
             "start_timeout": int(plan.get("start_timeout", 120)),
             "completion_timeout": int(plan.get("completion_timeout", 21600)),
         }
@@ -247,8 +306,25 @@ class CleaningPlanManager:
         self, serial_number: str, plan_id: str, room: CleaningRoom
     ) -> None:
         """Advance room history only after the room finishes."""
-        now = dt_util.utcnow().isoformat()
+        now_value = dt_util.utcnow()
+        now = now_value.isoformat()
         record = self._room(serial_number, plan_id, room)
+        active = self._robot(serial_number).get("active_plan")
+        duration = (
+            _elapsed_seconds(active.get("started"), now_value)
+            if active is not None
+            and active.get("plan_id") == plan_id
+            and active.get("room_id") == room.room_id
+            else None
+        )
+        if duration is not None:
+            samples = int(record.get("duration_samples", 0))
+            average = float(record.get("average_duration_seconds", duration))
+            record["last_duration_seconds"] = duration
+            record["average_duration_seconds"] = round(
+                ((average * samples) + duration) / (samples + 1)
+            )
+            record["duration_samples"] = samples + 1
         record["last_completed"] = now
         record["last_result"] = "completed"
         record["completed_runs"] = int(record.get("completed_runs", 0)) + 1
@@ -371,6 +447,16 @@ class CleaningPlanManager:
     ) -> dict[str, Any]:
         records = self._rotation(serial_number, plan_id)["rooms"]
         record = records.setdefault(room.room_id, {})
+        if any(
+            record.get(key) is not None and record.get(key) != getattr(room, key)
+            for key in ("cleaning_mode", "coverage_setting")
+        ):
+            for key in (
+                "last_duration_seconds",
+                "average_duration_seconds",
+                "duration_samples",
+            ):
+                record.pop(key, None)
         record.update(asdict(room))
         return cast(dict[str, Any], record)
 
@@ -378,6 +464,26 @@ class CleaningPlanManager:
         await self._store.async_save(self._data)
         for listener in tuple(self._listeners.get(serial_number, ())):
             listener()
+
+
+def _elapsed_seconds(started: object, now: datetime) -> int | None:
+    """Return positive elapsed wall-clock seconds from a stored ISO timestamp."""
+    if not isinstance(started, str):
+        return None
+    parsed = dt_util.parse_datetime(started)
+    if parsed is None:
+        return None
+    return max(1, round((now - parsed).total_seconds()))
+
+
+def _estimated_progress(started: object, expected: object) -> int | None:
+    """Estimate current room completion from its learned successful duration."""
+    if not isinstance(expected, int | float) or expected <= 0:
+        return None
+    elapsed = _elapsed_seconds(started, dt_util.utcnow())
+    if elapsed is None:
+        return None
+    return max(0, min(100, round((elapsed / expected) * 100)))
 
 
 def resolve_rooms(

--- a/custom_components/matic_robot/room_plan_editor.js
+++ b/custom_components/matic_robot/room_plan_editor.js
@@ -8,8 +8,18 @@ class MaticRoomPlanEditor extends HTMLElement {
   }
 
   set hass(value) {
+    const hadHass = this._hass !== undefined;
+    const previousLanguage = this._hass?.locale?.language;
     this._hass = value;
-    this._render();
+    const languageChanged =
+      hadHass && previousLanguage !== value?.locale?.language;
+    if (!hadHass || languageChanged || !this.shadowRoot?.hasChildNodes()) {
+      this._render();
+      return;
+    }
+    this.shadowRoot.querySelectorAll("ha-selector").forEach((field) => {
+      field.hass = value;
+    });
   }
 
   set selector(value) {
@@ -123,9 +133,13 @@ class MaticRoomPlanEditor extends HTMLElement {
     field.selector = { select: { options, mode: "dropdown" } };
     field.value = value;
     field.disabled = this._disabled;
-    field.addEventListener("value-changed", (event) =>
-      onChange(event.detail.value),
-    );
+    field.addEventListener("value-changed", (event) => {
+      // The config form also listens for this generic event. Let only the
+      // editor's list-valued event escape or the scalar selection replaces the
+      // entire room list and makes every room appear excluded.
+      event.stopPropagation();
+      onChange(event.detail.value);
+    });
     return field;
   }
 
@@ -160,8 +174,11 @@ class MaticRoomPlanEditor extends HTMLElement {
       <style>
         :host { display: block; }
         .intro { color: var(--secondary-text-color); margin: 4px 0 12px; }
-        .list { border: 1px solid var(--divider-color); border-radius: 16px; overflow: hidden; }
+        .list { border: 1px solid var(--divider-color); border-radius: 16px; }
         .room { padding: 14px 12px; background: var(--card-background-color); transition: background .15s ease; }
+        .room:first-child { border-radius: 15px 15px 0 0; }
+        .room:last-child { border-radius: 0 0 15px 15px; }
+        .room:only-child { border-radius: 15px; }
         .room:hover { background: var(--secondary-background-color); }
         .room + .room { border-top: 1px solid var(--divider-color); }
         .room.dragging { opacity: .55; }

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -121,6 +121,10 @@ SAVE_PLAN_SCHEMA = cv.make_entity_service_schema(
             cv.ensure_list, [SAVED_ROOM_SCHEMA], vol.Length(min=1, max=100)
         ),
         vol.Optional("return_to_base", default=True): cv.boolean,
+        vol.Optional("finish_current_room", default=False): cv.boolean,
+        vol.Optional("finish_current_room_threshold", default=50): vol.All(
+            vol.Coerce(int), vol.Range(min=0, max=100)
+        ),
         vol.Optional("start_timeout", default=120): vol.All(
             vol.Coerce(int), vol.Range(min=10, max=600)
         ),
@@ -324,12 +328,15 @@ async def async_register_services(hass: HomeAssistant) -> None:
     )
 
     async def async_stop_intelligent_cleaning(call: ServiceCall) -> None:
-        """Stop the active managed run and send the robot home."""
+        """Apply the active plan's stop policy and send the robot home."""
         entity_id, _entry, serial_number, _room_map = _saved_plan_context(hass, call)
-        if not manager.cancel(serial_number):
+        decision = manager.request_stop(serial_number)
+        if decision.behavior == "not_running":
             raise _validation_error(
                 "No managed Matic cleaning plan is running", "plan_not_running"
             )
+        if decision.behavior == "after_room":
+            return
         await hass.services.async_call(
             VACUUM_DOMAIN,
             "return_to_base",
@@ -407,6 +414,8 @@ async def async_register_services(hass: HomeAssistant) -> None:
             "rooms": rooms,
             "room_order": [room["room_id"] for room in rooms],
             "return_to_base": call.data["return_to_base"],
+            "finish_current_room": call.data["finish_current_room"],
+            "finish_current_room_threshold": call.data["finish_current_room_threshold"],
             "start_timeout": call.data["start_timeout"],
             "completion_timeout": call.data["completion_timeout"],
         }
@@ -780,6 +789,7 @@ async def _async_execute_rooms(
         )
     async with lock:
         cancel_event = manager.prepare_run(serial_number)
+        finish_room_event = manager.finish_room_event(serial_number)
         chosen = (
             manager.choose(serial_number, call.data["plan_id"], rooms)
             if intelligent
@@ -798,10 +808,12 @@ async def _async_execute_rooms(
                     room,
                     cancel_event,
                 )
+                if finish_room_event.is_set():
+                    break
         except PlanCancelledError:
             return
         if (
-            call.data["return_to_base"]
+            (call.data["return_to_base"] or finish_room_event.is_set())
             and (current := hass.states.get(entity_id)) is not None
             and current.state not in {"docked", "returning"}
         ):

--- a/custom_components/matic_robot/services.yaml
+++ b/custom_components/matic_robot/services.yaml
@@ -95,6 +95,19 @@ save_plan:
       default: true
       selector:
         boolean:
+    finish_current_room:
+      default: false
+      selector:
+        boolean:
+    finish_current_room_threshold:
+      default: 50
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 5
+          unit_of_measurement: "%"
+          mode: box
     select:
       default: true
       selector:

--- a/custom_components/matic_robot/strings.json
+++ b/custom_components/matic_robot/strings.json
@@ -151,12 +151,16 @@
           "name": "Plan name",
           "run_behavior": "Cleaning order",
           "room_editor": "Rooms",
+          "finish_current_room": "Finish the current room when stopping",
+          "finish_current_room_threshold": "Finish-room progress threshold",
           "return_to_base": "Return to dock when finished"
         },
         "data_description": {
           "name": "Shown in dashboards and automations — for example Away, Weekdays, or Deep clean.",
           "run_behavior": "Intelligent rotation favors rooms that have waited longest and suits short runs. Saved order always runs from top to bottom.",
           "room_editor": "Turn on a room to include it and set its options. The list is the exact order for Run all and saved-order cleaning.",
+          "finish_current_room": "When enabled, stopping the plan may let the active room finish, but never starts the next room.",
+          "finish_current_room_threshold": "Estimated progress uses successful managed runs of this room with the same settings. Below this percentage the room stops immediately; at or above it the room finishes. Until a duration is learned, the room finishes. Set 0% to always finish.",
           "return_to_base": "Dock the robot after the plan finishes."
         }
       },
@@ -168,6 +172,8 @@
           "run_behavior": "Cleaning order",
           "room_editor": "Rooms",
           "enabled": "Plan enabled",
+          "finish_current_room": "Finish the current room when stopping",
+          "finish_current_room_threshold": "Finish-room progress threshold",
           "return_to_base": "Return to dock when finished"
         },
         "data_description": {
@@ -175,6 +181,8 @@
           "run_behavior": "Intelligent rotation favors rooms that have waited longest and suits short runs. Saved order always runs from top to bottom.",
           "room_editor": "Turn on a room to include it and set its options. The list is the exact order for Run all and saved-order cleaning.",
           "enabled": "Disabled plans stay saved but cannot start.",
+          "finish_current_room": "When enabled, stopping the plan may let the active room finish, but never starts the next room.",
+          "finish_current_room_threshold": "Estimated progress uses successful managed runs of this room with the same settings. Below this percentage the room stops immediately; at or above it the room finishes. Until a duration is learned, the room finishes. Set 0% to always finish.",
           "return_to_base": "Dock the robot after the plan finishes."
         }
       },
@@ -575,7 +583,7 @@
     },
     "stop_intelligent_cleaning": {
       "name": "Stop cleaning plan",
-      "description": "Stops the plan, leaves the current room due, and sends the robot to its dock.",
+      "description": "Stops the plan using its saved finish-current-room policy, never starts another room, and sends the robot to its dock.",
       "fields": {}
     },
     "reset_plan_history": {
@@ -624,6 +632,14 @@
         "return_to_base": {
           "name": "Return to dock when finished",
           "description": "Send the robot to its dock after all selected rooms finish successfully."
+        },
+        "finish_current_room": {
+          "name": "Finish the current room when stopping",
+          "description": "Allow the active room to finish when its estimated progress meets the threshold. The next room never starts."
+        },
+        "finish_current_room_threshold": {
+          "name": "Finish-room progress threshold",
+          "description": "Below this estimated percentage, stop immediately. At or above it, finish the room. The estimate learns from successful managed runs with the same room settings."
         },
         "select": {
           "name": "Use as default plan",

--- a/custom_components/matic_robot/translations/en.json
+++ b/custom_components/matic_robot/translations/en.json
@@ -151,12 +151,16 @@
           "name": "Plan name",
           "run_behavior": "Cleaning order",
           "room_editor": "Rooms",
+          "finish_current_room": "Finish the current room when stopping",
+          "finish_current_room_threshold": "Finish-room progress threshold",
           "return_to_base": "Return to dock when finished"
         },
         "data_description": {
           "name": "Shown in dashboards and automations — for example Away, Weekdays, or Deep clean.",
           "run_behavior": "Intelligent rotation favors rooms that have waited longest and suits short runs. Saved order always runs from top to bottom.",
           "room_editor": "Turn on a room to include it and set its options. The list is the exact order for Run all and saved-order cleaning.",
+          "finish_current_room": "When enabled, stopping the plan may let the active room finish, but never starts the next room.",
+          "finish_current_room_threshold": "Estimated progress uses successful managed runs of this room with the same settings. Below this percentage the room stops immediately; at or above it the room finishes. Until a duration is learned, the room finishes. Set 0% to always finish.",
           "return_to_base": "Dock the robot after the plan finishes."
         }
       },
@@ -168,6 +172,8 @@
           "run_behavior": "Cleaning order",
           "room_editor": "Rooms",
           "enabled": "Plan enabled",
+          "finish_current_room": "Finish the current room when stopping",
+          "finish_current_room_threshold": "Finish-room progress threshold",
           "return_to_base": "Return to dock when finished"
         },
         "data_description": {
@@ -175,6 +181,8 @@
           "run_behavior": "Intelligent rotation favors rooms that have waited longest and suits short runs. Saved order always runs from top to bottom.",
           "room_editor": "Turn on a room to include it and set its options. The list is the exact order for Run all and saved-order cleaning.",
           "enabled": "Disabled plans stay saved but cannot start.",
+          "finish_current_room": "When enabled, stopping the plan may let the active room finish, but never starts the next room.",
+          "finish_current_room_threshold": "Estimated progress uses successful managed runs of this room with the same settings. Below this percentage the room stops immediately; at or above it the room finishes. Until a duration is learned, the room finishes. Set 0% to always finish.",
           "return_to_base": "Dock the robot after the plan finishes."
         }
       },
@@ -575,7 +583,7 @@
     },
     "stop_intelligent_cleaning": {
       "name": "Stop cleaning plan",
-      "description": "Stops the plan, leaves the current room due, and sends the robot to its dock.",
+      "description": "Stops the plan using its saved finish-current-room policy, never starts another room, and sends the robot to its dock.",
       "fields": {}
     },
     "reset_plan_history": {
@@ -624,6 +632,14 @@
         "return_to_base": {
           "name": "Return to dock when finished",
           "description": "Send the robot to its dock after all selected rooms finish successfully."
+        },
+        "finish_current_room": {
+          "name": "Finish the current room when stopping",
+          "description": "Allow the active room to finish when its estimated progress meets the threshold. The next room never starts."
+        },
+        "finish_current_room_threshold": {
+          "name": "Finish-room progress threshold",
+          "description": "Below this estimated percentage, stop immediately. At or above it, finish the room. The estimate learns from successful managed runs with the same room settings."
         },
         "select": {
           "name": "Use as default plan",

--- a/custom_components/matic_robot/vacuum.py
+++ b/custom_components/matic_robot/vacuum.py
@@ -152,8 +152,10 @@ class MaticVacuum(MaticEntity, StateVacuumEntity):
         await self._async_command(UserCommand.PAUSE)
 
     async def async_stop(self, **kwargs: object) -> None:
-        """Stop the current task and any managed plan driving it."""
-        self._async_cancel_managed_plan()
+        """Stop now or finish the active room according to the plan policy."""
+        decision = self._plans.request_stop(self.coordinator.data.info.serial_number)
+        if decision.behavior == "after_room":
+            return
         await self._async_command(UserCommand.STOP)
 
     async def async_return_to_base(self, **kwargs: object) -> None:
@@ -233,12 +235,15 @@ class MaticVacuum(MaticEntity, StateVacuumEntity):
     ) -> None:
         """Expose safe named commands for scripts and advanced dashboards."""
         normalized = command.strip().lower().replace("-", "_").replace(" ", "_")
+        if normalized == "stop":
+            await self.async_stop()
+            return
+        if normalized in {"dock", "return_home"}:
+            await self.async_return_to_base()
+            return
         simple_commands = {
             "pause": UserCommand.PAUSE,
             "resume": UserCommand.RESUME,
-            "stop": UserCommand.STOP,
-            "dock": UserCommand.DOCK,
-            "return_home": UserCommand.DOCK,
         }
         if normalized in simple_commands:
             await self._async_command(simple_commands[normalized])

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -79,7 +79,9 @@ rooms are selected until the user chooses them:
 3. Leave unwanted rooms off; turn on rooms to reveal mode and coverage
    dropdowns, defaulting to Vacuum and Standard.
 4. Drag rooms or use arrow buttons to save the exact top-to-bottom order.
-5. Submit once; the same screen edits every room and plan setting later.
+5. Optionally enable **Finish the current room when stopping** and choose its
+   estimated progress threshold.
+6. Submit once; the same screen edits every room and plan setting later.
 
 A plan defines **what** to clean. Home Assistant schedules, presence
 automations, buttons, and scripts decide **when** it runs.
@@ -93,6 +95,15 @@ saved room order breaks ties. Failed, cancelled, timed-out, or
 restart-interrupted rooms remain due because history advances only after
 verified completion.
 
+The finish-current-room policy estimates progress from elapsed time versus
+successful managed runs of the same room with the same cleaning settings. A
+stop below the configured threshold remains immediate; at or above it, the
+current room completes, the next room is never started, and the robot docks.
+Until the plan has learned a duration for that room, enabling the policy means
+the current room finishes. Set the threshold to `0%` to always finish it. This
+is a time-based estimate because the robot does not expose live mapped-area
+completion percentage.
+
 Use **Run all — top to bottom** when every selected room should always clean in
 the visible saved order regardless of history.
 
@@ -104,7 +115,8 @@ the visible saved order regardless of history.
   override.
 - `matic_robot.clean_entire_plan`: clean every selected room in saved order as a
   per-run override.
-- `matic_robot.stop_intelligent_cleaning`: leave the active room due and dock.
+- `matic_robot.stop_intelligent_cleaning`: apply the plan's immediate-or-finish
+  stop policy, never start another room, and dock.
 - `matic_robot.preview_plan`: return the exact next order and per-room settings
   without sending a robot command or changing history.
 - `matic_robot.reset_plan_history`: clear successful-room tracking without

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -941,6 +941,8 @@ async def test_options_flow_manages_mapped_rooms_and_individual_settings(hass) -
         "name",
         "run_behavior",
         "room_editor",
+        "finish_current_room",
+        "finish_current_room_threshold",
         "return_to_base",
     ]
     room_marker = list(result["data_schema"].schema)[2]
@@ -967,6 +969,8 @@ async def test_options_flow_manages_mapped_rooms_and_individual_settings(hass) -
                 ("room-1", True, "vacuum_and_mop", "standard"),
                 ("room-2", False, "vacuum", "standard"),
             ),
+            "finish_current_room": True,
+            "finish_current_room_threshold": 50,
             "return_to_base": True,
         },
     )
@@ -983,6 +987,12 @@ async def test_options_flow_manages_mapped_rooms_and_individual_settings(hass) -
         "room-1",
         "room-2",
     ]
+    assert (
+        manager.plan("synthetic-serial", "away_cleaning")[
+            "finish_current_room_threshold"
+        ]
+        == 50
+    )
 
     result = await _select_menu_step(hass, result, "edit_plan")
     assert [marker.schema for marker in result["data_schema"].schema] == [
@@ -990,6 +1000,8 @@ async def test_options_flow_manages_mapped_rooms_and_individual_settings(hass) -
         "run_behavior",
         "room_editor",
         "enabled",
+        "finish_current_room",
+        "finish_current_room_threshold",
         "return_to_base",
     ]
     assert list(result["data_schema"].schema)[2].default()[0]["room_id"] == "room-1"
@@ -1003,6 +1015,8 @@ async def test_options_flow_manages_mapped_rooms_and_individual_settings(hass) -
                 ("room-1", False, "vacuum", "standard"),
             ),
             "enabled": True,
+            "finish_current_room": True,
+            "finish_current_room_threshold": 75,
             "return_to_base": False,
         },
     )
@@ -1010,6 +1024,8 @@ async def test_options_flow_manages_mapped_rooms_and_individual_settings(hass) -
     updated = manager.plan("synthetic-serial", "away_cleaning")
     assert updated["return_to_base"] is False
     assert updated["run_behavior"] == "ordered"
+    assert updated["finish_current_room"] is True
+    assert updated["finish_current_room_threshold"] == 75
     assert updated["room_order"] == ["room-2", "room-1"]
     assert updated["rooms"] == [
         {

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -39,6 +39,7 @@ from custom_components.matic_robot.client.models import (
     WifiNetwork,
 )
 from custom_components.matic_robot.entity import MaticEntity
+from custom_components.matic_robot.plans import PlanStopDecision
 
 
 def _state(
@@ -189,6 +190,7 @@ def _entry(*, paused: bool = False, idle: bool = False, with_floor_plan: bool = 
         async_select_plan=AsyncMock(),
         async_add_listener=MagicMock(return_value=MagicMock()),
         cancel=MagicMock(return_value=True),
+        request_stop=MagicMock(return_value=PlanStopDecision("not_running")),
     )
     firmware = SimpleNamespace(
         summary=MagicMock(
@@ -840,7 +842,8 @@ async def test_vacuum_controls_refresh_and_preserve_room_order() -> None:
     ]
     # A user stop or dock ends the managed plan instead of letting the
     # runner treat the docked robot as a finished room and continue.
-    assert plans.cancel.call_count == 2
+    assert plans.request_stop.call_count == 1
+    assert plans.cancel.call_count == 1
 
     await entity.async_clean_segments(["room-2"])
     coverage_call = coordinator.client.async_start_coverage.await_args
@@ -851,6 +854,19 @@ async def test_vacuum_controls_refresh_and_preserve_room_order() -> None:
         "ordered": False,
     }
     assert coordinator.async_request_refresh.await_count == 5
+
+
+async def test_vacuum_stop_can_leave_the_current_managed_room_running() -> None:
+    entry = _entry()
+    entity = vacuum.MaticVacuum(entry)
+    plans = entry.runtime_data.cleaning_plans
+    plans.request_stop.return_value = PlanStopDecision("after_room", 75, 50)
+
+    await entity.async_stop()
+    await entity.async_send_command("stop")
+
+    assert plans.request_stop.call_count == 2
+    entry.runtime_data.coordinator.client.async_send_user_command.assert_not_awaited()
 
 
 async def test_vacuum_start_resumes_or_cleans_all_rooms() -> None:
@@ -957,6 +973,8 @@ async def test_vacuum_named_commands_and_validation() -> None:
     entity = vacuum.MaticVacuum(entry)
 
     await entity.async_send_command("return home")
+    await entity.async_send_command("pause")
+    await entity.async_send_command("resume")
     await entity.async_send_command(
         "clean_rooms",
         {

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -87,10 +87,13 @@ async def test_setup_registers_configuration_editor_when_frontend_is_loaded() ->
         assert await async_setup(hass, {}) is True
 
     hass.http.async_register_static_paths.assert_awaited_once()
-    from custom_components.matic_robot.frontend import MANIFEST_VERSION
+    from custom_components.matic_robot.frontend import (
+        MANIFEST_VERSION,
+        ROOM_PLAN_EDITOR_VERSION,
+    )
 
     assert (
-        f"/matic_robot/room-plan-editor.js?v={MANIFEST_VERSION}"
+        f"/matic_robot/room-plan-editor.js?v={MANIFEST_VERSION}-{ROOM_PLAN_EDITOR_VERSION}"
         in hass.data[frontend.DATA_EXTRA_MODULE_URL]
     )
 

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -1,17 +1,22 @@
 """Durable intelligent cleaning behavior."""
 
 import asyncio
+from datetime import timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.core import ServiceCall
 from homeassistant.exceptions import ServiceValidationError
+from homeassistant.util import dt as dt_util
 
 from custom_components.matic_robot.const import DOMAIN
 from custom_components.matic_robot.plans import (
     CleaningPlanManager,
     CleaningRoom,
+    PlanStopDecision,
+    _elapsed_seconds,
+    _estimated_progress,
     resolve_rooms,
 )
 from custom_components.matic_robot.services import (
@@ -182,6 +187,93 @@ async def test_listener_lock_and_cancel_lifecycle(hass) -> None:
         "serial", "away", _room("Kitchen", "one"), "cancelled"
     )
     listener.assert_called_once()
+
+
+async def test_stop_policy_learns_room_duration_and_applies_threshold(hass) -> None:
+    """A stop finishes only rooms at or above the plan's learned threshold."""
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    await manager.async_save_plan(
+        "serial",
+        "away",
+        {
+            "name": "Away",
+            "enabled": True,
+            "finish_current_room": True,
+            "finish_current_room_threshold": 50,
+            "rooms": [],
+        },
+    )
+    room = _room("Kitchen", "room-kitchen")
+    lock = manager.lock("serial")
+    await lock.acquire()
+    try:
+        manager.prepare_run("serial")
+        await manager.async_mark_started("serial", "away", room)
+        manager._data["robots"]["serial"]["plans"]["away"]["finish_current_room"] = (
+            False
+        )
+        assert manager.request_stop("serial") == PlanStopDecision("immediate")
+
+        manager.prepare_run("serial")
+        await manager.async_mark_started("serial", "away", room)
+        plan = manager._data["robots"]["serial"]["plans"]["away"]
+        plan["finish_current_room"] = True
+        plan["finish_current_room_threshold"] = "invalid"
+        assert manager.request_stop("serial") == PlanStopDecision(
+            "after_room", None, 50
+        )
+        plan["finish_current_room_threshold"] = 50
+
+        manager.prepare_run("serial")
+        await manager.async_mark_started("serial", "away", room)
+        assert manager.request_stop("serial") == PlanStopDecision(
+            "after_room", None, 50
+        )
+
+        manager.prepare_run("serial")
+        await manager.async_mark_started("serial", "away", room)
+        manager._data["robots"]["serial"]["active_plan"]["started"] = (
+            dt_util.utcnow() - timedelta(seconds=100)
+        ).isoformat()
+        await manager.async_mark_completed("serial", "away", room)
+        record = manager.snapshot("serial")["plan_history"]["away"]["rooms"][
+            "room-kitchen"
+        ]
+        assert record["average_duration_seconds"] == 100
+
+        manager.prepare_run("serial")
+        await manager.async_mark_started("serial", "away", room)
+        manager._data["robots"]["serial"]["active_plan"]["started"] = (
+            dt_util.utcnow() - timedelta(seconds=40)
+        ).isoformat()
+        assert manager.request_stop("serial") == PlanStopDecision("immediate", 40, 50)
+        assert manager.cancellation_event("serial").is_set()
+
+        manager.prepare_run("serial")
+        await manager.async_mark_started("serial", "away", room)
+        manager._data["robots"]["serial"]["active_plan"]["started"] = (
+            dt_util.utcnow() - timedelta(seconds=60)
+        ).isoformat()
+        assert manager.request_stop("serial") == PlanStopDecision("after_room", 60, 50)
+        assert manager.finish_room_event("serial").is_set()
+        assert not manager.cancellation_event("serial").is_set()
+
+        changed = CleaningRoom("room-kitchen", "Kitchen", "mop", "standard")
+        await manager.async_mark_started("serial", "away", changed)
+        changed_record = manager.snapshot("serial")["plan_history"]["away"]["rooms"][
+            "room-kitchen"
+        ]
+        assert "average_duration_seconds" not in changed_record
+    finally:
+        lock.release()
+
+
+def test_progress_estimate_rejects_missing_and_malformed_start_times() -> None:
+    now = dt_util.utcnow()
+    assert _elapsed_seconds(None, now) is None
+    assert _elapsed_seconds("not-a-timestamp", now) is None
+    assert _estimated_progress("not-a-timestamp", 100) is None
 
 
 async def test_room_native_plan_lifecycle_preview_selection_and_reset(hass) -> None:
@@ -403,6 +495,46 @@ async def test_execute_rooms_rejects_overlap_handles_cancel_and_returns_home(
             [room],
             intelligent=False,
         )
+    run.assert_awaited_once()
+    service_call.assert_awaited_once_with(
+        "vacuum",
+        "return_to_base",
+        {"entity_id": "vacuum.matic"},
+        blocking=True,
+        context=call.context,
+    )
+
+
+async def test_execute_rooms_finishes_current_room_then_stops_and_docks(hass) -> None:
+    """A graceful stop never dispatches the next room and always returns home."""
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    service_call = AsyncMock()
+    fake_hass = SimpleNamespace(
+        services=SimpleNamespace(async_call=service_call),
+        states=SimpleNamespace(
+            get=MagicMock(return_value=SimpleNamespace(state="idle"))
+        ),
+    )
+    call = _call(fake_hass, return_to_base=False)
+
+    async def finish_then_stop(*_args, **_kwargs) -> None:
+        manager.finish_room_event("serial").set()
+
+    with patch(
+        "custom_components.matic_robot.services._async_run_room",
+        AsyncMock(side_effect=finish_then_stop),
+    ) as run:
+        await _async_execute_rooms(
+            fake_hass,
+            call,
+            manager,
+            "vacuum.matic",
+            "serial",
+            [_room("Kitchen", "one"), _room("Study", "two")],
+            intelligent=False,
+        )
+
     run.assert_awaited_once()
     service_call.assert_awaited_once_with(
         "vacuum",

--- a/tests/test_room_plan_editor.py
+++ b/tests/test_room_plan_editor.py
@@ -14,6 +14,7 @@ import json
 import re
 import shutil
 import subprocess
+from hashlib import sha256
 from pathlib import Path
 
 import pytest
@@ -102,6 +103,39 @@ def test_static_path_serves_the_editor_file() -> None:
     """The registered static path must point at this exact module file."""
     assert frontend.ROOM_PLAN_EDITOR_PATH.endswith(".js")
     assert Path(frontend.__file__).with_name("room_plan_editor.js") == _EDITOR_PATH
+
+
+def test_nested_select_change_does_not_escape_as_the_editor_value() -> None:
+    """A scalar dropdown event must not replace the form's full room list."""
+    listener = _JS[_JS.index('field.addEventListener("value-changed"') :]
+    listener = listener[: listener.index("return field;")]
+    assert listener.index("event.stopPropagation();") < listener.index(
+        "onChange(event.detail.value);"
+    )
+
+
+def test_hass_refresh_does_not_rebuild_an_open_editor() -> None:
+    """Routine HA state refreshes must not destroy an open dropdown's DOM."""
+    setter = _JS[_JS.index("set hass(value)") : _JS.index("set selector(value)")]
+    assert "previousLanguage" in setter
+    assert "languageChanged" in setter
+    assert "if (!hadHass || languageChanged" in setter
+    assert 'querySelectorAll("ha-selector")' in setter
+    assert setter.count("this._render();") == 1
+
+
+def test_room_list_does_not_clip_dropdown_menus() -> None:
+    """Room list styling must leave nested selector popups visible."""
+    styles = _JS[_JS.index("<style>") : _JS.index("</style>")]
+    list_rule = styles[styles.index(".list {") :]
+    list_rule = list_rule[: list_rule.index("}")]
+    assert "overflow: hidden" not in list_rule
+
+
+def test_editor_cache_buster_tracks_javascript_content() -> None:
+    """A frontend-only fix must load even before the next version bump."""
+    expected = sha256(_EDITOR_PATH.read_bytes()).hexdigest()[:12]
+    assert frontend.ROOM_PLAN_EDITOR_VERSION == expected
 
 
 def test_node_syntax_check() -> None:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -207,6 +207,30 @@ async def test_intelligent_exact_preview_stop_and_reset_actions(hass) -> None:
         context=stop.context,
     )
 
+    plan = manager.plan("serial", "upstairs")
+    plan_id = plan.pop("id")
+    plan["finish_current_room"] = True
+    plan["finish_current_room_threshold"] = 50
+    await manager.async_save_plan("serial", plan_id, plan, select=False)
+    services.async_call.reset_mock()
+    await lock.acquire()
+    manager.prepare_run("serial")
+    await manager.async_mark_started(
+        "serial",
+        "upstairs",
+        CleaningRoom("room-study", "Study", "vacuum", "quick"),
+    )
+    try:
+        with patch(
+            "custom_components.matic_robot.services._saved_plan_context",
+            return_value=context,
+        ):
+            await _registered_handler(services, "stop_intelligent_cleaning")(stop)
+        services.async_call.assert_not_awaited()
+        assert manager.finish_room_event("serial").is_set()
+    finally:
+        lock.release()
+
     reset = ServiceCall(
         hass,
         DOMAIN,
@@ -1068,6 +1092,7 @@ async def test_execute_rooms_skips_every_room_once_cancellation_is_set() -> None
     manager = SimpleNamespace(
         lock=MagicMock(return_value=asyncio.Lock()),
         prepare_run=MagicMock(return_value=cancel_event),
+        finish_room_event=MagicMock(return_value=asyncio.Event()),
     )
     hass = SimpleNamespace()
     call = ServiceCall(


### PR DESCRIPTION
## What changed

- prevent nested room dropdown events from replacing the complete plan-editor value
- keep dropdowns open across routine Home Assistant state refreshes and avoid clipping their menus
- cache-bust frontend-only changes by JavaScript content
- add an opt-in finish-current-room stop policy with a configurable 0–100% learned progress threshold
- stop before dispatching the next room and dock after a graceful room finish
- document the time-based estimate and no-history fallback

## Why

The custom room editor leaked scalar `value-changed` events to the parent form, which could reset all rooms when changing coverage or cleaning mode. It also rebuilt its DOM on every `hass` refresh and clipped nested dropdowns. Plans also had only immediate cancellation, so users could not finish a sufficiently progressed current room without running the rest of the plan.

## User impact

Room dropdowns now save reliably. Plans keep immediate stop as the default, or can be configured to finish the current room when its elapsed-time estimate meets a threshold. The next room is never started. Until a matching successful duration is learned, the enabled policy finishes the current room.

## Validation

- 442 tests passed
- 100% coverage
- Ruff check and format
- strict MyPy
- public-tree privacy check
