### PR TITLE
Release v0.2.1

### DIFF
--- a/custom_components/matic_robot/manifest.json
+++ b/custom_components/matic_robot/manifest.json
@@ -22,7 +22,7 @@
     "h2>=4",
     "protobuf>=6"
   ],
-  "version": "0.2.0",
+  "version": "0.2.1",
   "zeroconf": [
     "_matic_hermes._tcp.local."
   ]

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,8 +17,8 @@ the integration so instructions and behavior stay aligned with each release.
   discovery, passkey, room-mapping, firmware, and Bluetooth constraints.
 - [Firmware compatibility](firmware-compatibility.md) — Track observed robot
   versions, validation status, regressions, and newly discovered capabilities.
-- [Release notes — 0.2.0](release-notes-0.2.0.md) — What's new and what to
-  check when upgrading from 0.1.x.
+- [Release notes — 0.2.1](release-notes-0.2.1.md) — Plan-editor reliability
+  fixes and configurable finish-current-room stopping.
 
 ## Use and automate
 

--- a/docs/release-notes-0.2.1.md
+++ b/docs/release-notes-0.2.1.md
@@ -1,0 +1,47 @@
+# Release notes — 0.2.1
+
+[Documentation home](README.md) · [Project overview](../README.md) ·
+[Get support](README.md#support)
+
+0.2.1 fixes the saved-plan editor and adds an opt-in way to finish a nearly
+complete room when a plan is stopped, without continuing through the plan.
+
+## Fixed
+
+- **Room settings no longer turn rooms off.** Cleaning-mode and coverage
+  dropdown events stay inside the room editor, so changing a setting can no
+  longer replace the complete room list with one scalar value.
+- **Dropdowns stay open and clickable.** Routine Home Assistant state updates
+  no longer rebuild the editor DOM, and room-list styling no longer clips
+  menus near the bottom of the plan.
+- **Frontend updates bypass stale browser caches.** The editor URL now includes
+  a digest of its JavaScript content as well as the integration version.
+
+## Finish the current room when stopping
+
+Each saved plan now has **Finish the current room when stopping** and a
+configurable **Finish-room progress threshold** from 0–100%.
+
+- Below the threshold, the robot stops immediately and the room remains due.
+- At or above the threshold, the active room completes, no next room starts,
+  and the robot docks.
+- Until the integration has learned a matching successful room duration,
+  enabling the policy finishes the current room. Set the threshold to `0%` to
+  always finish it.
+- Immediate stopping remains the default for existing and newly created plans.
+
+The robot does not expose a trustworthy live mapped-area percentage. The
+integration therefore estimates progress from elapsed time against successful
+managed runs of the same room with the same cleaning mode and coverage. A
+settings change clears the learned duration for that room.
+
+## Upgrade
+
+Update through HACS, restart Home Assistant, then open **Settings → Devices &
+services → Matic (Unofficial) → Configure** to edit the new plan options. No
+configuration migration or re-pairing is required.
+
+## Verification
+
+The release passes 442 tests at 100% coverage, Ruff, strict MyPy, the
+privacy/public-tree check, Hassfest, and HACS validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "matic-home-assistant"
-version = "0.2.0"
+version = "0.2.1"
 description = "Unofficial local-only Home Assistant integration for Matic robot vacuums"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -28,7 +28,7 @@ def test_release_versions_and_links_are_consistent() -> None:
     hacs = json.loads((ROOT / "hacs.json").read_text())
     project = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]
 
-    assert manifest["version"] == "0.2.0"
+    assert manifest["version"] == "0.2.1"
     assert project["version"] == manifest["version"]
     assert hacs["homeassistant"] == "2026.7.0"
     assert manifest["documentation"].startswith("https://github.com/")


### PR DESCRIPTION
## Summary

- bump the integration and package version to 0.2.1
- publish release notes for the plan-editor fixes and configurable finish-current-room stop policy
- point the documentation index at the new release

## Validation

- 442 tests passed at 100% coverage
- Ruff check and format
- strict MyPy
- public-tree privacy check
- wheel and sdist content verification
- clean fresh-install import from the built wheel
- PR #10 already passed test, Hassfest, and HACS validation
