### PR TITLE
Fix Matic runtime reliability

### DIFF
--- a/custom_components/matic_robot/camera.py
+++ b/custom_components/matic_robot/camera.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import MaticConfigEntry
-from .client.floor_plan import render_floor_plan
+from .client.floor_plan import render_floor_plan, resolve_robot_map_position
 from .entity import MaticEntity
 
 PARALLEL_UPDATES = 0
@@ -53,6 +53,7 @@ class MaticMapCamera(MaticEntity, Camera):
         cache_key = (
             id(data.floor_plan),
             data.pose,
+            data.operational.current_area,
             requested_width,
             requested_height,
         )
@@ -63,6 +64,7 @@ class MaticMapCamera(MaticEntity, Camera):
                 render_floor_plan,
                 data.floor_plan,
                 data.pose,
+                data.operational.current_area,
                 width=requested_width,
                 height=requested_height,
             )
@@ -70,3 +72,16 @@ class MaticMapCamera(MaticEntity, Camera):
         self._cached_image_key = cache_key
         self._cached_image = image
         return image
+
+    @property
+    def extra_state_attributes(self) -> dict[str, object]:
+        """Expose whether the marker is exact or a room-level fallback."""
+        data = self.coordinator.data
+        position = resolve_robot_map_position(
+            data.floor_plan, data.pose, data.operational.current_area
+        )
+        return {
+            "robot_location_source": position[2]
+            if position is not None
+            else "unavailable"
+        }

--- a/custom_components/matic_robot/client/api.py
+++ b/custom_components/matic_robot/client/api.py
@@ -308,6 +308,18 @@ class MaticHermesClient(AbstractAsyncContextManager["MaticHermesClient"]):
             self._channel.close()
             self._channel = None
 
+    async def _async_reconnect_after_read_failure(
+        self, failed_channel: Channel | None
+    ) -> None:
+        """Replace one failed read channel without racing concurrent readers."""
+        async with self._connect_lock:
+            # Another concurrent read may already have replaced the failed
+            # channel. Reuse that fresh pinned session instead of closing it.
+            if self._channel is not failed_channel and self._channel is not None:
+                return
+            self.close()
+            await self._async_connect_locked()
+
     @asynccontextmanager
     async def _map_stream_errors(self, description: str) -> AsyncIterator[None]:
         """Map every transport failure onto the Matic error hierarchy.
@@ -420,7 +432,18 @@ class MaticHermesClient(AbstractAsyncContextManager["MaticHermesClient"]):
 
     async def async_get_state(self) -> RobotOperationalState:
         """Read one authenticated snapshot from the ``kabuki_state`` property."""
-        payload = await self.async_get_property("kabuki_state")
+        # The robot closes an otherwise healthy long-lived HTTP/2 session about
+        # once an hour. grpclib reports that closure on the next stream read;
+        # replace the pinned channel and retry this idempotent snapshot once so
+        # a routine transport rollover does not mark every HA entity unavailable.
+        await self.async_connect()
+        failed_channel = self._channel
+        try:
+            payload = await self.async_get_property("kabuki_state")
+        except CannotConnectError:
+            _LOGGER.debug("Retrying Hermes state read on a fresh pinned channel")
+            await self._async_reconnect_after_read_failure(failed_channel)
+            payload = await self.async_get_property("kabuki_state")
 
         try:
             return _decode_operational_state(payload)

--- a/custom_components/matic_robot/client/floor_plan.py
+++ b/custom_components/matic_robot/client/floor_plan.py
@@ -15,6 +15,7 @@ from PIL import Image, ImageChops, ImageDraw, ImageFilter, ImageFont
 from .models import FloorPlan, RobotPose, Room
 from .wire import (
     bytes_fields,
+    decode_fields,
     first_bytes,
     first_varint,
     packed_floats,
@@ -105,16 +106,52 @@ def decode_floor_plan(payload: bytes) -> FloorPlan:
 
 
 def decode_pose(payload: bytes) -> RobotPose:
-    """Decode the latest local robot translation."""
-    add_message = first_bytes(payload, 2)
-    pose_info = first_bytes(add_message, 1)
-    translation = packed_floats(first_bytes(pose_info, 1), 3)
+    """Decode the latest local robot translation across verified layouts."""
+    try:
+        add_message = first_bytes(payload, 2)
+        pose_info = first_bytes(add_message, 1)
+        translation = packed_floats(first_bytes(pose_info, 1), 3)
+    except DecodeError:
+        # Current v168 firmware stores the same three-float translation under
+        # field 5 -> field 1. Keep the original layout for older fixtures and
+        # accept only this second live-verified path rather than scanning for a
+        # plausible vector and risking a quaternion or unrelated map value.
+        pose_info = first_bytes(payload, 5)
+        translation = packed_floats(first_bytes(pose_info, 1), 3)
     return RobotPose(x=translation[0], y=translation[1], z=translation[2])
+
+
+def pose_vector_paths(
+    payload: bytes, *, max_depth: int = 8
+) -> tuple[tuple[int, ...], ...]:
+    """Return schema paths to finite packed three-float vectors, without values."""
+    paths: list[tuple[int, ...]] = []
+
+    def walk(data: bytes, path: tuple[int, ...], depth: int) -> None:
+        if depth > max_depth:
+            return
+        try:
+            fields = decode_fields(data)
+        except DecodeError:
+            return
+        for field in fields:
+            if field.wire_type != 2 or not isinstance(field.value, bytes):
+                continue
+            field_path = (*path, field.number)
+            if len(field.value) == 12:
+                values = packed_floats(field.value, 3)
+                if all(math.isfinite(value) for value in values):
+                    paths.append(field_path)
+            walk(field.value, field_path, depth + 1)
+
+    walk(payload, (), 0)
+    return tuple(paths)
 
 
 def render_floor_plan(
     floor_plan: FloorPlan | None,
     pose: RobotPose | None,
+    current_area: str | None = None,
     *,
     width: int = 1024,
     height: int = 1024,
@@ -203,10 +240,11 @@ def render_floor_plan(
         )
     image = Image.alpha_composite(image, labels_layer)
 
-    if pose is not None and all(math.isfinite(value) for value in (pose.x, pose.y)):
+    robot_position = resolve_robot_map_position(floor_plan, pose, current_area)
+    if robot_position is not None:
         robot_layer = Image.new("RGBA", (width, height), (0, 0, 0, 0))
         robot_draw = ImageDraw.Draw(robot_layer)
-        robot_x, robot_y = project((pose.x, pose.y))
+        robot_x, robot_y = project((robot_position[0], robot_position[1]))
         radius = max(8, min(width, height) // 60)
         robot_draw.ellipse(
             (
@@ -224,7 +262,7 @@ def render_floor_plan(
                 robot_x + radius,
                 robot_y + radius,
             ),
-            fill="#FFFFFF",
+            fill="#FFFFFF" if robot_position[2] == "exact_pose" else "#F6C85F",
             outline="#10151D",
             width=3,
         )
@@ -240,6 +278,47 @@ def render_floor_plan(
         )
         image = Image.alpha_composite(image, robot_layer)
     return _png(image)
+
+
+def resolve_robot_map_position(
+    floor_plan: FloorPlan | None,
+    pose: RobotPose | None,
+    current_area: str | None,
+) -> tuple[float, float, str] | None:
+    """Return an exact pose or a truthful room-level fallback for the map."""
+    if floor_plan is None or not floor_plan.rooms:
+        return None
+    all_points = [point for room in floor_plan.rooms for point in room.boundary]
+    min_x = min(point[0] for point in all_points)
+    max_x = max(point[0] for point in all_points)
+    min_y = min(point[1] for point in all_points)
+    max_y = max(point[1] for point in all_points)
+    if (
+        pose is not None
+        and all(math.isfinite(value) for value in (pose.x, pose.y))
+        and min_x <= pose.x <= max_x
+        and min_y <= pose.y <= max_y
+    ):
+        return pose.x, pose.y, "exact_pose"
+    area_key = _room_name_key(current_area)
+    if area_key is None:
+        return None
+    room = next(
+        (item for item in floor_plan.rooms if _room_name_key(item.name) == area_key),
+        None,
+    )
+    if room is None:
+        return None
+    x, y = _polygon_center(room.boundary)
+    return x, y, "current_area"
+
+
+def _room_name_key(value: str | None) -> str | None:
+    """Normalize the article and spacing used by the firmware's area phrase."""
+    if value is None:
+        return None
+    normalized = " ".join(value.strip().casefold().split()).removeprefix("the ")
+    return normalized or None
 
 
 def _layout_room_labels(

--- a/custom_components/matic_robot/client/models.py
+++ b/custom_components/matic_robot/client/models.py
@@ -34,65 +34,6 @@ class RobotActivity(StrEnum):
     READY = "ready"
 
 
-KABUKI_ERROR_NAMES = (
-    "agent_missing",
-    "bag_full",
-    "bag_missing",
-    "battery_overtemperature",
-    "bms_permanent_failure",
-    "brush_roll_dislodged",
-    "brush_roll_jammed",
-    "brush_roll_maintenance",
-    "brush_roll_missing",
-    "bucha_daemon_missing",
-    "calibration_timeout",
-    "camera_fault",
-    "cant_undock",
-    "charger_ic_error",
-    "destination_unreachable",
-    "disk_full",
-    "dock_not_found",
-    "dock_not_reachable",
-    "docking_approach_failed",
-    "duct_clog",
-    "duct_flap_stuck_closed",
-    "duct_flap_stuck_open",
-    "guid_missing",
-    "head_actuation_failure",
-    "imu_fault",
-    "insufficient_solvent",
-    "lid_malfunction",
-    "lid_not_sealed",
-    "lid_open",
-    "lifted",
-    "lifted_uncleared",
-    "lost",
-    "lost_during_coverage",
-    "low_charge_docking_failed",
-    "mcu_failure",
-    "mop_roll_detached",
-    "mop_roll_jammed",
-    "mop_roll_malfunction",
-    "mop_roll_worn_out",
-    "no_path_found",
-    "path_blocked",
-    "pump_malfunction",
-    "side_brush_malfunction",
-    "snorkel_clog",
-    "solvent_descaling_needed",
-    "solvent_low",
-    "solvent_unavailable",
-    "stuck_critical",
-    "stuck_once",
-    "tilted",
-    "tilted_uncleared",
-    "unknown_error",
-    "vacuum_filter_clogged",
-    "vacuum_filter_missing",
-    "wet_lid",
-)
-
-
 @dataclass(frozen=True, slots=True)
 class RobotOperationalState:
     """Verified fields from the local ``kabuki_state`` property."""
@@ -141,13 +82,13 @@ class RobotOperationalState:
 
     @property
     def error_names(self) -> tuple[str, ...]:
-        """Return stable official names while preserving unknown future codes."""
-        return tuple(
-            KABUKI_ERROR_NAMES[code]
-            if 0 <= code < len(KABUKI_ERROR_NAMES)
-            else f"unknown_{code}"
-            for code in self.error_codes
-        )
+        """Return truthful automation-safe labels for raw robot error codes.
+
+        The app's public enum ordering is not the numeric Hermes wire mapping;
+        live firmware uses values such as 207 and 304. Preserve those values
+        without guessing a human meaning until a numeric mapping is verified.
+        """
+        return tuple(f"error_code_{code}" for code in self.error_codes)
 
 
 @dataclass(frozen=True, slots=True)

--- a/custom_components/matic_robot/coordinator.py
+++ b/custom_components/matic_robot/coordinator.py
@@ -4,15 +4,20 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import timedelta
+from dataclasses import replace
+from datetime import datetime, timedelta
+from functools import partial
 from time import monotonic
+from typing import Any, cast
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
 from .client.api import MaticHermesClient
 from .client.commands import CleaningMode, CoverageSetting
@@ -22,7 +27,14 @@ from .client.exceptions import (
     InvalidRobotCertificateError,
     MaticError,
 )
-from .client.models import FloorPlan, RobotInfo, RobotPose, RobotState, RobotTelemetry
+from .client.models import (
+    FloorPlan,
+    RobotInfo,
+    RobotOperationalState,
+    RobotPose,
+    RobotState,
+    RobotTelemetry,
+)
 from .const import (
     DOMAIN,
     EVENT_CLEANING_FINISHED,
@@ -31,6 +43,7 @@ from .const import (
     UPDATE_INTERVAL_SECONDS,
 )
 from .firmware import FirmwareTracker, async_build_firmware_snapshot
+from .session_tracking import CleaningSessionTracker
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,6 +52,7 @@ _LOGGER = logging.getLogger(__name__)
 SNAPSHOT_FAILURE_THRESHOLD = 8
 SNAPSHOT_RETRY_SECONDS = 900
 SNAPSHOT_MAX_ATTEMPTS = 3
+ERROR_CONFIRMATION_POLLS = 2
 
 
 class MaticCoordinator(DataUpdateCoordinator[RobotState]):
@@ -79,6 +93,10 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
         self._snapshot_retry_after = 0.0
         self._device_software_version: str | None = None
         self._last_session_key: tuple[str | None, str] | None = None
+        self._session_tracker = CleaningSessionTracker()
+        self._session_history_recovered = False
+        self._pending_error_codes: tuple[int, ...] = ()
+        self._pending_error_polls = 0
         self._identity_issue_active = False
 
     async def _async_update_data(self) -> RobotState:
@@ -90,6 +108,7 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
                 self._async_optional_pose(),
                 self._async_optional_telemetry(),
             )
+            operational = self._async_confirm_robot_errors(operational)
             state = RobotState(
                 info=info,
                 operational=operational,
@@ -97,6 +116,7 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
                 pose=pose,
                 telemetry=telemetry,
             )
+            state = await self._async_track_cleaning_session(state)
             version = telemetry.software_version or operational.software_version
             if version is not None:
                 self._async_update_device_software(version, info.serial_number)
@@ -140,6 +160,94 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
             raise UpdateFailed(str(err)) from err
         finally:
             self._force_full_refresh = False
+
+    @callback
+    def _async_confirm_robot_errors(
+        self, state: RobotOperationalState
+    ) -> RobotOperationalState:
+        """Suppress one-poll firmware error pulses while preserving real faults."""
+        codes = state.error_codes
+        if not codes:
+            self._pending_error_codes = ()
+            self._pending_error_polls = 0
+            return state
+        if codes != self._pending_error_codes:
+            self._pending_error_codes = codes
+            self._pending_error_polls = 1
+        else:
+            self._pending_error_polls += 1
+        if self._pending_error_polls < ERROR_CONFIRMATION_POLLS:
+            _LOGGER.debug(
+                "Waiting for a second poll before exposing robot error codes %s",
+                codes,
+            )
+            return replace(state, error_codes=())
+        return state
+
+    async def _async_track_cleaning_session(self, state: RobotState) -> RobotState:
+        """Merge fresh HA-side run tracking with robot-native session history."""
+        room_names = (
+            tuple(room.name for room in state.floor_plan.rooms)
+            if state.floor_plan is not None
+            else ()
+        )
+        now = dt_util.utcnow()
+        if not self._session_history_recovered:
+            self._session_history_recovered = True
+            await self._async_recover_session_history(
+                state.info.serial_number, room_names, now
+            )
+        self._session_tracker.update(
+            cleaning=state.operational.cleaning,
+            current_area=state.operational.current_area,
+            room_names=room_names,
+            now=now,
+        )
+        latest = self._session_tracker.preferred_session(state.telemetry.latest_session)
+        if latest is state.telemetry.latest_session:
+            return state
+        return replace(state, telemetry=replace(state.telemetry, latest_session=latest))
+
+    async def _async_recover_session_history(
+        self,
+        serial_number: str,
+        room_names: tuple[str, ...],
+        now: datetime,
+    ) -> None:
+        """Recover the most recent local run from retained Recorder states."""
+        registry = er.async_get(self.hass)
+        cleaning_entity = registry.async_get_entity_id(
+            "binary_sensor", DOMAIN, f"{serial_number}_cleaning"
+        )
+        area_entity = registry.async_get_entity_id(
+            "sensor", DOMAIN, f"{serial_number}_current_area"
+        )
+        if cleaning_entity is None or area_entity is None:
+            return
+        try:
+            from homeassistant.components.recorder import history
+
+            states = await self.hass.async_add_executor_job(
+                partial(
+                    history.get_significant_states,
+                    self.hass,
+                    now - timedelta(days=7),
+                    now,
+                    [cleaning_entity, area_entity],
+                    include_start_time_state=True,
+                    significant_changes_only=False,
+                    no_attributes=True,
+                )
+            )
+        except Exception as err:  # Recorder is optional and may not be ready yet.
+            _LOGGER.debug("Unable to recover Matic cleaning history: %s", err)
+            return
+        self._session_tracker.recover(
+            cast(Any, states.get(cleaning_entity, [])),
+            cast(Any, states.get(area_entity, [])),
+            room_names,
+            now=now,
+        )
 
     async def _async_info(self) -> RobotInfo:
         """Read immutable identity once per coordinator lifetime."""

--- a/custom_components/matic_robot/coordinator.py
+++ b/custom_components/matic_robot/coordinator.py
@@ -226,8 +226,9 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
             return
         try:
             from homeassistant.components.recorder import history
+            from homeassistant.helpers.recorder import get_instance
 
-            states = await self.hass.async_add_executor_job(
+            states = await get_instance(self.hass).async_add_executor_job(
                 partial(
                     history.get_significant_states,
                     self.hass,

--- a/custom_components/matic_robot/manifest.json
+++ b/custom_components/matic_robot/manifest.json
@@ -22,7 +22,7 @@
     "h2>=4",
     "protobuf>=6"
   ],
-  "version": "0.2.1",
+  "version": "0.2.2",
   "zeroconf": [
     "_matic_hermes._tcp.local."
   ]

--- a/custom_components/matic_robot/manifest.json
+++ b/custom_components/matic_robot/manifest.json
@@ -2,7 +2,8 @@
   "domain": "matic_robot",
   "name": "Matic (Unofficial)",
   "after_dependencies": [
-    "frontend"
+    "frontend",
+    "recorder"
   ],
   "codeowners": [
     "@ProspectOre"

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -35,6 +35,7 @@ from homeassistant.util import slugify
 from .client.commands import CleaningMode, CoverageSetting
 from .client.endpoints import HERMES_ENDPOINT_MAP, HERMES_ENDPOINT_NAMES
 from .client.exceptions import MaticError
+from .client.floor_plan import pose_vector_paths
 from .const import (
     DATA_FIRMWARE_TRACKER,
     DATA_PLAN_MANAGER,
@@ -581,7 +582,7 @@ async def async_register_services(hass: HomeAssistant) -> None:
         values = await entry.runtime_data.client.async_inspect_endpoint(
             endpoint_name, limit=call.data["limit"]
         )
-        return {
+        response: dict[str, Any] = {
             "endpoint": endpoint_name,
             "kind": endpoint.kind,
             "sensitivity": endpoint.sensitivity,
@@ -589,6 +590,13 @@ async def async_register_services(hass: HomeAssistant) -> None:
             "limit": call.data["limit"],
             "entries": [fingerprint_entry(value) for value in values],
         }
+        if endpoint_name == "latest_pose":
+            response["pose_vector_paths"] = [
+                list(path)
+                for value in values
+                for path in pose_vector_paths(value.value)
+            ]
+        return response
 
     hass.services.async_register(
         DOMAIN,

--- a/custom_components/matic_robot/session_tracking.py
+++ b/custom_components/matic_robot/session_tracking.py
@@ -1,0 +1,247 @@
+"""Home Assistant-side cleaning session tracking.
+
+The robot's local ``coverage_session_history`` collection is not updated on
+all firmware builds.  Track the verified cleaning/current-area state locally
+so room statistics remain useful without relying on that stale collection.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Protocol
+
+from .client.models import CleaningSession
+
+
+class _HistoryState(Protocol):
+    """The small part of a recorder State used for recovery."""
+
+    state: str
+    last_updated: datetime
+
+
+@dataclass(slots=True)
+class CleaningSessionTracker:
+    """Build completed sessions from live or recorded HA entity states."""
+
+    latest_session: CleaningSession | None = None
+    _started_at: datetime | None = None
+    _current_room: str | None = None
+    _room_started_at: datetime | None = None
+    _room_durations: dict[str, float] = field(default_factory=dict)
+    _rooms: list[str] = field(default_factory=list)
+
+    def recover(
+        self,
+        cleaning_states: list[_HistoryState],
+        area_states: list[_HistoryState],
+        room_names: tuple[str, ...],
+        *,
+        now: datetime,
+    ) -> None:
+        """Recover the latest completed or active run from Recorder history."""
+        active_start: datetime | None = None
+        last_completed: tuple[datetime, datetime] | None = None
+        for state in sorted(cleaning_states, key=lambda item: item.last_updated):
+            if state.state == "on" and active_start is None:
+                active_start = state.last_updated
+            elif state.state == "off" and active_start is not None:
+                last_completed = (active_start, state.last_updated)
+                active_start = None
+
+        if active_start is not None:
+            self._restore_active(active_start, now, area_states, room_names)
+        elif last_completed is not None:
+            started_at, ended_at = last_completed
+            durations, rooms, _, _ = _room_timeline(
+                started_at, ended_at, area_states, room_names
+            )
+            self.latest_session = _build_session(started_at, ended_at, durations, rooms)
+
+    def update(
+        self,
+        *,
+        cleaning: bool,
+        current_area: str | None,
+        room_names: tuple[str, ...],
+        now: datetime,
+    ) -> CleaningSession | None:
+        """Observe one coordinator update and return the newest finished run."""
+        room = _canonical_room(current_area, room_names)
+        if cleaning:
+            if self._started_at is None:
+                self._started_at = now
+                self._current_room = room
+                self._room_started_at = now
+                if room is not None:
+                    self._rooms.append(room)
+            elif room != self._current_room:
+                self._finish_room(now)
+                self._current_room = room
+                self._room_started_at = now
+                if room is not None and room not in self._rooms:
+                    self._rooms.append(room)
+            return self.latest_session
+
+        if self._started_at is None:
+            return self.latest_session
+
+        self._finish_room(now)
+        self.latest_session = _build_session(
+            self._started_at, now, self._room_durations, self._rooms
+        )
+        self._reset_active()
+        return self.latest_session
+
+    def preferred_session(
+        self, native_session: CleaningSession | None
+    ) -> CleaningSession | None:
+        """Prefer whichever robot-native or locally tracked session is newer."""
+        tracked = self.latest_session
+        if tracked is None:
+            return native_session
+        if native_session is None:
+            return tracked
+        native_started = _parse_timestamp(native_session.started_at)
+        tracked_started = _parse_timestamp(tracked.started_at)
+        if native_started > tracked_started:
+            return native_session
+        if (
+            native_started == tracked_started
+            and native_session.room_durations
+            and not tracked.room_durations
+        ):
+            return native_session
+        return tracked
+
+    def _restore_active(
+        self,
+        started_at: datetime,
+        now: datetime,
+        area_states: list[_HistoryState],
+        room_names: tuple[str, ...],
+    ) -> None:
+        """Restore an in-progress session across an integration or HA restart."""
+        durations, rooms, current_room, room_started_at = _room_timeline(
+            started_at, now, area_states, room_names
+        )
+        if current_room is not None:
+            durations[current_room] = max(
+                0.0,
+                durations.get(current_room, 0.0)
+                - (now - room_started_at).total_seconds(),
+            )
+        self._started_at = started_at
+        self._current_room = current_room
+        self._room_started_at = room_started_at
+        self._room_durations = durations
+        self._rooms = rooms
+
+    def _finish_room(self, ended_at: datetime) -> None:
+        """Accumulate the currently observed room segment."""
+        if self._current_room is not None and self._room_started_at is not None:
+            elapsed = max(0.0, (ended_at - self._room_started_at).total_seconds())
+            self._room_durations[self._current_room] = (
+                self._room_durations.get(self._current_room, 0.0) + elapsed
+            )
+
+    def _reset_active(self) -> None:
+        """Clear the live accumulator after publishing a completed session."""
+        self._started_at = None
+        self._current_room = None
+        self._room_started_at = None
+        self._room_durations = {}
+        self._rooms = []
+
+
+def _room_timeline(
+    started_at: datetime,
+    ended_at: datetime,
+    area_states: list[_HistoryState],
+    room_names: tuple[str, ...],
+) -> tuple[dict[str, float], list[str], str | None, datetime]:
+    """Integrate room occupancy across one recorded cleaning interval."""
+    current_room: str | None = None
+    cursor = started_at
+    durations: dict[str, float] = {}
+    rooms: list[str] = []
+    events = sorted(area_states, key=lambda item: item.last_updated)
+    for state in events:
+        if state.last_updated <= started_at:
+            candidate = _canonical_room(state.state, room_names)
+            if candidate is not None:
+                current_room = candidate
+            continue
+        if state.last_updated > ended_at:
+            break
+        candidate = _canonical_room(state.state, room_names)
+        if candidate is None or candidate == current_room:
+            continue
+        if current_room is not None:
+            durations[current_room] = durations.get(current_room, 0.0) + max(
+                0.0, (state.last_updated - cursor).total_seconds()
+            )
+            if current_room not in rooms:
+                rooms.append(current_room)
+        current_room = candidate
+        cursor = state.last_updated
+
+    if current_room is not None:
+        durations[current_room] = durations.get(current_room, 0.0) + max(
+            0.0, (ended_at - cursor).total_seconds()
+        )
+        if current_room not in rooms:
+            rooms.append(current_room)
+    return durations, rooms, current_room, cursor
+
+
+def _canonical_room(value: str | None, room_names: tuple[str, ...]) -> str | None:
+    """Map firmware phrases such as ``the Living Room`` to plan room names."""
+    if value is None or value in {"unknown", "unavailable"}:
+        return None
+    normalized = _room_key(value)
+    for name in room_names:
+        if _room_key(name) == normalized:
+            return name
+    return None
+
+
+def _room_key(value: str) -> str:
+    """Return a comparison key for one firmware-provided area name."""
+    normalized = " ".join(value.strip().casefold().split())
+    return normalized.removeprefix("the ")
+
+
+def _build_session(
+    started_at: datetime,
+    ended_at: datetime,
+    durations: dict[str, float],
+    rooms: list[str],
+) -> CleaningSession:
+    """Create one immutable public session from local tracking values."""
+    return CleaningSession(
+        started_at=started_at.isoformat(),
+        ended_at=ended_at.isoformat(),
+        duration_seconds=max(0, round((ended_at - started_at).total_seconds())),
+        rooms=tuple(rooms),
+        room_durations=tuple(
+            (room, max(0, round(durations[room])))
+            for room in rooms
+            if room in durations
+        ),
+        completed=True,
+    )
+
+
+def _parse_timestamp(value: str | None) -> datetime:
+    """Parse an optional session timestamp for deterministic comparison."""
+    if value is None:
+        return datetime.min.replace(tzinfo=UTC)
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return datetime.min.replace(tzinfo=UTC)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,8 @@ the integration so instructions and behavior stay aligned with each release.
   discovery, passkey, room-mapping, firmware, and Bluetooth constraints.
 - [Firmware compatibility](firmware-compatibility.md) — Track observed robot
   versions, validation status, regressions, and newly discovered capabilities.
+- [Release notes — 0.2.2](release-notes-0.2.2.md) — Connection, session-history,
+  Activity, and map reliability
 - [Release notes — 0.2.1](release-notes-0.2.1.md) — Plan-editor reliability
   fixes and configurable finish-current-room stopping.
 

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -181,7 +181,12 @@ Template-visible attributes and recorded history follow one deliberate model:
   entity list when you want durable per-room trends.
 - **Always-recorded run metrics.** The `Last run duration` sensor records
   numeric long-term statistics for every session without any room context, so
-  whole-run OTA comparisons work out of the box.
+  whole-run OTA comparisons work out of the box. Some robot firmware leaves
+  its native session-history collection stale; the integration therefore
+  reconstructs newer runs from the verified Cleaning and Current area states.
+  Brief disconnects are ignored, firmware phrases such as `the Living Room`
+  are matched to the mapped room name, and an active run is recovered from
+  Recorder after an integration or Home Assistant restart.
 
 ## Events and observability
 
@@ -217,7 +222,9 @@ Each blueprint calls the saved-plan actions and can be edited after import.
 ## Fault semantics
 
 The Activity sensor preserves numeric `hermes_state_codes` and
-`hermes_error_codes` while also exposing normalized snake-case `errors` and
-`primary_error` attributes such as `bag_full`, `brush_roll_jammed`,
-`mop_roll_worn_out`, `solvent_low`, or `vacuum_filter_clogged`. Unknown future
-codes remain available as `unknown_<code>` instead of being dropped.
+`hermes_error_codes` while also exposing automation-safe `errors` and
+`primary_error` attributes such as `error_code_207`. These labels preserve the
+exact robot value without guessing a meaning from the app's unrelated enum
+ordering. A code must appear in two consecutive 30-second polls before the
+Activity and Problem entities expose it; one-poll firmware pulses stay in debug
+logs instead of creating misleading Logbook error entries.

--- a/docs/firmware-endpoint-map.md
+++ b/docs/firmware-endpoint-map.md
@@ -24,14 +24,14 @@ real robot actually returned after an OTA.
 | --- | --- | --- |
 | `kabuki_state` | Battery, state/error codes, activity, firmware fallback, channel/profile, current/previous area | Vacuum; activity, battery and current-area sensors; seven operational binary sensors; attributes |
 | `coverage_plan` | Mission, partition, named room IDs and geometry | Rooms sensor, map camera, vacuum segments/Areas, cleaning target |
-| `latest_pose` | Robot position and heading | Map camera |
+| `latest_pose` | Robot position and heading across both verified wire layouts; payload-free vector paths in endpoint inspection | Map camera |
 | `current_version` | Software/profile, protocol version, feature flag | Software and protocol sensors; software attributes |
 | `update_config` | Update channel | Update-channel sensor |
 | `update_state` | Update lifecycle | Update-state sensor and update-available binary sensor |
 | `wifi_status` | State, SSID, signal and visible/known networks | Wi-Fi state/signal/count summary; identities excluded from attributes |
 | `time_zone` | Robot timezone | Internal decoded telemetry; excluded from recorder attributes |
 | `schedule_events` | Local schedules, weekdays, time, rooms, ordering and enabled state | Scheduled-cleanings count; definitions excluded from attributes |
-| `coverage_session_history` | Local session count and latest session summary | Local-cleaning-session count and non-room summary |
+| `coverage_session_history` | Local session count and native latest-session summary | Local-cleaning-session count; newer stale-firmware sessions are reconstructed from verified HA cleaning/area history |
 | `dock_detections` | Collection count | Dock-detections sensor |
 | `sink_summon_locations` | Collection count | Sink-summon-locations sensor |
 | `coverage_time` | Accumulated coverage seconds | Coverage-time sensor |

--- a/docs/release-notes-0.2.2.md
+++ b/docs/release-notes-0.2.2.md
@@ -1,0 +1,58 @@
+# Release notes — 0.2.2
+
+Released: 2026-07-21
+
+## Summary
+
+0.2.2 hardens long-running local connections, fixes cleaning history on
+firmware that leaves its native history stale, and restores exact robot map
+position across both verified pose layouts. It also prevents one-poll firmware
+error pulses from creating misleading Activity and Problem entries.
+
+## Connection reliability
+
+- A robot-initiated HTTP/2 rollover no longer makes every entity unavailable.
+  The integration closes the stale pinned channel, performs a fresh verified
+  connection and handshake, and retries the idempotent state read once.
+- Concurrent reads reuse a channel another task has already replaced instead
+  of closing that fresh connection.
+- TLS identity validation and certificate pinning remain mandatory on every
+  replacement channel.
+
+## Activity and fault semantics
+
+- Raw Hermes error integers are exposed truthfully as `error_code_<raw>`;
+  values are no longer indexed into the app's unrelated enum ordering.
+- A code must be present for two consecutive 30-second polls before Activity
+  changes to Error or the Problem entity turns on. Brief self-clearing firmware
+  pulses remain available in debug logs without spamming Logbook.
+- Persistent errors still surface with their exact raw code.
+
+## Cleaning history and room statistics
+
+- When the robot's native coverage-session collection is stale, the integration
+  reconstructs the newest run from Home Assistant's verified Cleaning and
+  Current area history.
+- Active runs survive an integration or Home Assistant restart through Recorder
+  recovery.
+- Firmware phrases such as `the Living Room` are normalized to mapped room
+  names, and brief unavailable gaps do not split a run.
+- Last run duration, per-room duration, per-room last cleaned, session
+  attributes, and the cleaning-finished event now use the newest native or
+  locally reconstructed session.
+
+## Map position
+
+- `latest_pose` supports the original `2 → 1 → 1` translation path and the
+  live-verified v168 `5 → 1` path.
+- Exact in-bounds pose is shown while the robot is on the mapped floor. If the
+  dock is outside the room polygons or pose is unavailable, an amber room-level
+  marker is used instead of hiding the robot or claiming false precision.
+- Payload-free endpoint inspection reports only candidate vector field paths;
+  it never returns coordinates or raw home-context payloads.
+
+## Upgrading from 0.2.1
+
+Install 0.2.2 through HACS and restart Home Assistant. No re-pairing, entity-ID
+migration, or plan recreation is required. Existing restored room statistics
+and saved plans are preserved.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "matic-home-assistant"
-version = "0.2.1"
+version = "0.2.2"
 description = "Unofficial local-only Home Assistant integration for Matic robot vacuums"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_api_paths.py
+++ b/tests/test_api_paths.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import call as mock_call
 
 import pytest
 from google.protobuf.message import DecodeError
@@ -31,8 +32,9 @@ from custom_components.matic_robot.client.exceptions import (
     EndpointUnsupportedError,
     PairingModeRequiredError,
 )
-from custom_components.matic_robot.client.models import FloorPlan
+from custom_components.matic_robot.client.models import FloorPlan, RobotActivity
 from custom_components.matic_robot.client.proto.hermes_auth_pb2 import TokenRequest
+from custom_components.matic_robot.client.proto.hermes_pb2 import KabukiOutputWire
 from tests.wire_builders import _bfield, _fixed64, _vfield
 
 
@@ -356,6 +358,48 @@ async def test_handshake_guards_and_errors(monkeypatch) -> None:
             await client._async_handshake()
 
 
+async def test_state_read_reconnects_and_retries_stale_channel() -> None:
+    client = MaticHermesClient("robot.invalid", 16320)
+    failed_channel = SimpleNamespace(close=MagicMock())
+    fresh_channel = object()
+    client._channel = failed_channel
+
+    async def connect_fresh_channel() -> None:
+        client._channel = fresh_channel
+
+    client._async_connect_locked = AsyncMock(side_effect=connect_fresh_channel)
+    payload = KabukiOutputWire(states=[106]).SerializeToString()
+    client.async_get_property = AsyncMock(
+        side_effect=[CannotConnectError("stale stream"), payload]
+    )
+
+    state = await client.async_get_state()
+
+    assert state.activity is RobotActivity.DOCKED
+    assert client._channel is fresh_channel
+    assert client.async_get_property.await_args_list == [
+        mock_call("kabuki_state"),
+        mock_call("kabuki_state"),
+    ]
+    client._async_connect_locked.assert_awaited_once_with()
+    failed_channel.close.assert_called_once_with()
+
+
+async def test_stale_reader_reuses_channel_replaced_by_concurrent_reader() -> None:
+    client = MaticHermesClient("robot.invalid", 16320)
+    failed_channel = SimpleNamespace(close=MagicMock())
+    fresh_channel = SimpleNamespace(close=MagicMock())
+    client._channel = fresh_channel
+    client._async_connect_locked = AsyncMock()
+
+    await client._async_reconnect_after_read_failure(failed_channel)
+
+    assert client._channel is fresh_channel
+    client._async_connect_locked.assert_not_awaited()
+    failed_channel.close.assert_not_called()
+    fresh_channel.close.assert_not_called()
+
+
 @pytest.mark.parametrize(
     ("response", "expected"),
     [
@@ -659,6 +703,7 @@ async def test_optional_telemetry_reads_fail_closed() -> None:
 
 async def test_decode_wrappers_translate_malformed_payloads(monkeypatch) -> None:
     client = MaticHermesClient("robot.invalid", 16320)
+    client._channel = object()
     client.async_get_property = AsyncMock(return_value=b"bad")
 
     monkeypatch.setattr(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from custom_components.matic_robot.client.exceptions import (
@@ -15,10 +17,12 @@ from custom_components.matic_robot.client.exceptions import (
     MaticError,
 )
 from custom_components.matic_robot.client.models import (
+    CleaningSession,
     FloorPlan,
     RobotInfo,
     RobotOperationalState,
     RobotTelemetry,
+    Room,
 )
 from custom_components.matic_robot.coordinator import MaticCoordinator
 
@@ -98,6 +102,25 @@ async def test_optional_telemetry_failure_does_not_hide_core_state(hass) -> None
 
     assert state.info.name == "Test"
     assert state.telemetry == RobotTelemetry()
+
+
+async def test_transient_robot_errors_require_two_consecutive_polls(hass) -> None:
+    client = _client()
+    fault = replace(client.async_get_state.return_value, error_codes=(207,))
+    client.async_get_state.return_value = fault
+    coordinator = _coordinator(hass, client)
+
+    first = await coordinator._async_update_data()
+    second = await coordinator._async_update_data()
+    client.async_get_state.return_value = replace(fault, error_codes=())
+    cleared = await coordinator._async_update_data()
+    client.async_get_state.return_value = fault
+    repeated_once = await coordinator._async_update_data()
+
+    assert first.operational.error_codes == ()
+    assert second.operational.error_codes == (207,)
+    assert cleared.operational.error_codes == ()
+    assert repeated_once.operational.error_codes == ()
 
 
 async def test_rejected_credential_starts_home_assistant_reauthentication(hass) -> None:
@@ -248,7 +271,6 @@ async def test_transient_sweep_failures_defer_then_record_degraded(hass) -> None
 async def test_cleaning_finished_event_fires_once_per_new_session(hass) -> None:
     from pytest_homeassistant_custom_component.common import async_capture_events
 
-    from custom_components.matic_robot.client.models import CleaningSession
     from custom_components.matic_robot.const import EVENT_CLEANING_FINISHED
 
     def _session(suffix: str) -> CleaningSession:
@@ -302,6 +324,74 @@ async def test_cleaning_finished_event_fires_once_per_new_session(hass) -> None:
     await coordinator._async_update_data()
     await hass.async_block_till_done()
     assert len(events) == 1
+
+
+async def test_coordinator_recovers_newer_session_from_recorder(hass) -> None:
+    client = _client()
+    room = Room("room", "Living Room", "protocol", b"room", ())
+    client.async_get_floor_plan.return_value = FloorPlan(
+        1, "partition", b"partition", (room,)
+    )
+    old_session = CleaningSession(
+        "2026-07-14T01:00:00+00:00",
+        "2026-07-14T01:01:00+00:00",
+        60,
+        ("Living Room",),
+        (),
+        True,
+    )
+    client.async_get_telemetry.return_value = RobotTelemetry(latest_session=old_session)
+    registry = er.async_get(hass)
+    cleaning_entity = registry.async_get_or_create(
+        "binary_sensor", "matic_robot", "synthetic_cleaning"
+    ).entity_id
+    area_entity = registry.async_get_or_create(
+        "sensor", "matic_robot", "synthetic_current_area"
+    ).entity_id
+    start = datetime(2026, 7, 21, 4, tzinfo=UTC)
+    recorded = {
+        cleaning_entity: [
+            SimpleNamespace(state="on", last_updated=start),
+            SimpleNamespace(state="off", last_updated=start + timedelta(minutes=5)),
+        ],
+        area_entity: [
+            SimpleNamespace(
+                state="the Living Room", last_updated=start - timedelta(seconds=1)
+            )
+        ],
+    }
+
+    with (
+        patch(
+            "custom_components.matic_robot.coordinator.dt_util.utcnow",
+            return_value=start + timedelta(minutes=10),
+        ),
+        patch(
+            "homeassistant.components.recorder.history.get_significant_states",
+            return_value=recorded,
+        ) as get_history,
+    ):
+        state = await _coordinator(hass, client)._async_update_data()
+
+    assert state.telemetry.latest_session is not None
+    assert state.telemetry.latest_session.started_at == start.isoformat()
+    assert state.telemetry.latest_session.room_durations == (("Living Room", 300),)
+    get_history.assert_called_once()
+
+
+async def test_recorder_recovery_failure_does_not_break_updates(hass) -> None:
+    client = _client()
+    registry = er.async_get(hass)
+    registry.async_get_or_create("binary_sensor", "matic_robot", "synthetic_cleaning")
+    registry.async_get_or_create("sensor", "matic_robot", "synthetic_current_area")
+
+    with patch(
+        "homeassistant.components.recorder.history.get_significant_states",
+        side_effect=RuntimeError("recorder unavailable"),
+    ):
+        state = await _coordinator(hass, client)._async_update_data()
+
+    assert state.info.serial_number == "synthetic"
 
 
 async def test_identity_mismatch_raises_repair_until_recovery(hass) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -360,6 +360,9 @@ async def test_coordinator_recovers_newer_session_from_recorder(hass) -> None:
             )
         ],
     }
+    recorder = SimpleNamespace(
+        async_add_executor_job=AsyncMock(side_effect=lambda target: target())
+    )
 
     with (
         patch(
@@ -370,6 +373,10 @@ async def test_coordinator_recovers_newer_session_from_recorder(hass) -> None:
             "homeassistant.components.recorder.history.get_significant_states",
             return_value=recorded,
         ) as get_history,
+        patch(
+            "homeassistant.helpers.recorder.get_instance",
+            return_value=recorder,
+        ),
     ):
         state = await _coordinator(hass, client)._async_update_data()
 
@@ -377,6 +384,7 @@ async def test_coordinator_recovers_newer_session_from_recorder(hass) -> None:
     assert state.telemetry.latest_session.started_at == start.isoformat()
     assert state.telemetry.latest_session.room_durations == (("Living Room", 300),)
     get_history.assert_called_once()
+    recorder.async_add_executor_job.assert_awaited_once()
 
 
 async def test_recorder_recovery_failure_does_not_break_updates(hass) -> None:
@@ -386,7 +394,7 @@ async def test_recorder_recovery_failure_does_not_break_updates(hass) -> None:
     registry.async_get_or_create("sensor", "matic_robot", "synthetic_current_area")
 
     with patch(
-        "homeassistant.components.recorder.history.get_significant_states",
+        "homeassistant.helpers.recorder.get_instance",
         side_effect=RuntimeError("recorder unavailable"),
     ):
         state = await _coordinator(hass, client)._async_update_data()

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -811,6 +811,7 @@ async def test_camera_clamps_dimensions_and_renders_locally(hass) -> None:
     assert cached == image
     assert render.call_count == 1
     assert render.call_args.kwargs == {"width": 256, "height": 2048}
+    assert entity.extra_state_attributes == {"robot_location_source": "exact_pose"}
 
 
 async def test_vacuum_controls_refresh_and_preserve_room_order() -> None:

--- a/tests/test_floor_plan.py
+++ b/tests/test_floor_plan.py
@@ -21,8 +21,11 @@ from custom_components.matic_robot.client.floor_plan import (
     _polygon_center,
     decode_floor_plan,
     decode_pose,
+    pose_vector_paths,
     render_floor_plan,
+    resolve_robot_map_position,
 )
+from custom_components.matic_robot.client.models import FloorPlan, RobotPose
 from tests.wire_builders import _field, _fixed32, _fixed64, _varint_field
 
 PARTITION_ID = UUID("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
@@ -84,9 +87,55 @@ def test_decode_pose_and_render_local_png() -> None:
     )
 
     assert (pose.x, pose.y, pose.z) == (2.0, 1.0, 0.0)
+    assert pose_vector_paths(pose_payload) == ((2, 1, 1),)
     with Image.open(BytesIO(image_bytes)) as image:
         assert image.format == "PNG"
         assert image.size == (512, 384)
+
+    current_payload = _field(5, _field(1, struct.pack("<3f", 3, 2, 1)))
+    assert decode_pose(current_payload) == RobotPose(3, 2, 1)
+
+
+def test_pose_vector_path_inspection_is_bounded_and_ignores_invalid_data() -> None:
+    too_deep = struct.pack("<3f", 1, 2, 3)
+    for _ in range(10):
+        too_deep = _field(1, too_deep)
+    payload = (
+        _varint_field(4, 1)
+        + _field(1, b"bad")
+        + _field(2, struct.pack("<3f", float("nan"), 2, 3))
+        + _field(3, too_deep)
+    )
+
+    assert pose_vector_paths(payload) == ()
+
+
+def test_robot_position_falls_back_to_the_current_room() -> None:
+    floor_plan = decode_floor_plan(_floor_plan_payload())
+
+    assert resolve_robot_map_position(floor_plan, RobotPose(2, 1, 0), "Test room") == (
+        2,
+        1,
+        "exact_pose",
+    )
+    fallback = resolve_robot_map_position(
+        floor_plan, RobotPose(float("nan"), 999, 0), "the  Test room"
+    )
+    assert fallback is not None
+    assert fallback[2] == "current_area"
+    assert resolve_robot_map_position(floor_plan, None, "Garage") is None
+    assert resolve_robot_map_position(floor_plan, None, "   ") is None
+    assert resolve_robot_map_position(None, None, "Test room") is None
+    assert (
+        resolve_robot_map_position(FloorPlan(1, "partition", b"", ()), None, None)
+        is None
+    )
+
+    without_marker = render_floor_plan(floor_plan, None, width=256, height=256)
+    fallback_marker = render_floor_plan(
+        floor_plan, None, "the Test room", width=256, height=256
+    )
+    assert fallback_marker != without_marker
 
 
 def test_decode_rejects_plan_without_standard_partition() -> None:

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -42,7 +42,7 @@ def test_subscription_config_preserves_verified_uint64_field() -> None:
 def test_decode_verified_kabuki_state_fields() -> None:
     payload = KabukiOutputWire(
         states=[106, 120, 206],
-        errors=[7],
+        errors=[207],
         battery_fraction=0.734,
     ).SerializeToString()
 
@@ -50,7 +50,7 @@ def test_decode_verified_kabuki_state_fields() -> None:
 
     assert state.battery_percentage == 73
     assert state.state_codes == (106, 120, 206)
-    assert state.error_codes == (7,)
+    assert state.error_codes == (207,)
     assert state.charging_idle is True
     assert state.charging is False
     assert state.low_charge is True
@@ -58,7 +58,7 @@ def test_decode_verified_kabuki_state_fields() -> None:
     assert state.cleaning is False
     assert state.returning is False
     assert state.activity is RobotActivity.ERROR
-    assert state.error_names == ("brush_roll_maintenance",)
+    assert state.error_names == ("error_code_207",)
 
 
 def test_decode_absent_or_non_finite_battery_as_unknown() -> None:
@@ -119,12 +119,16 @@ def test_decode_verified_build_and_area_fields() -> None:
     assert state.is_fully_charged is True
 
 
-def test_unknown_error_codes_remain_automation_safe() -> None:
+def test_live_and_future_error_codes_remain_truthful_and_automation_safe() -> None:
     state = _decode_operational_state(
-        KabukiOutputWire(errors=[1, 54, 999]).SerializeToString()
+        KabukiOutputWire(errors=[207, 304, 999]).SerializeToString()
     )
 
-    assert state.error_names == ("bag_full", "wet_lid", "unknown_999")
+    assert state.error_names == (
+        "error_code_207",
+        "error_code_304",
+        "error_code_999",
+    )
 
 
 def test_schedule_without_minute_of_day_has_no_wall_clock_time() -> None:

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -28,7 +28,7 @@ def test_release_versions_and_links_are_consistent() -> None:
     hacs = json.loads((ROOT / "hacs.json").read_text())
     project = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]
 
-    assert manifest["version"] == "0.2.1"
+    assert manifest["version"] == "0.2.2"
     assert project["version"] == manifest["version"]
     assert hacs["homeassistant"] == "2026.7.0"
     assert manifest["documentation"].startswith("https://github.com/")

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -35,7 +35,7 @@ def test_release_versions_and_links_are_consistent() -> None:
     assert manifest["issue_tracker"].endswith("/issues")
     assert manifest["codeowners"]
     assert manifest["dependencies"] == ["bluetooth_adapters", "http", "zeroconf"]
-    assert "frontend" in manifest["after_dependencies"]
+    assert manifest["after_dependencies"] == ["frontend", "recorder"]
 
 
 def test_github_validation_runs_hacs_and_hassfest() -> None:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -765,6 +765,44 @@ async def test_inspect_hermes_endpoint_fingerprints_payloads() -> None:
     )
 
 
+async def test_inspect_pose_endpoint_returns_only_safe_vector_paths() -> None:
+    hass = SimpleNamespace(data={})
+    services = await _registered_services(hass)
+    client = SimpleNamespace(
+        async_inspect_endpoint=AsyncMock(
+            return_value=(HermesCollectionEntry(b"", b"synthetic"),)
+        )
+    )
+    entry = SimpleNamespace(runtime_data=SimpleNamespace(client=client))
+    call = ServiceCall(
+        hass,
+        DOMAIN,
+        "inspect_hermes_endpoint",
+        {
+            "entity_id": ["vacuum.test"],
+            "endpoint": "latest_pose",
+            "limit": 1,
+        },
+    )
+    with (
+        patch(
+            "custom_components.matic_robot.services._resolve_loaded_matic_vacuums",
+            return_value=["vacuum.test"],
+        ),
+        patch(
+            "custom_components.matic_robot.services._entry_for_entity",
+            return_value=entry,
+        ),
+        patch(
+            "custom_components.matic_robot.services.pose_vector_paths",
+            return_value=((2, 1, 1),),
+        ),
+    ):
+        response = await _registered_handler(services, "inspect_hermes_endpoint")(call)
+
+    assert response["pose_vector_paths"] == [[2, 1, 1]]
+
+
 async def test_firmware_snapshot_persists_safe_full_endpoint_sweep() -> None:
     hass = SimpleNamespace(data={})
     services = await _registered_services(hass)

--- a/tests/test_session_tracking.py
+++ b/tests/test_session_tracking.py
@@ -1,0 +1,184 @@
+"""Tests for HA-side cleaning session tracking and recovery."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+from custom_components.matic_robot.client.models import CleaningSession
+from custom_components.matic_robot.session_tracking import (
+    CleaningSessionTracker,
+    _build_session,
+    _canonical_room,
+    _parse_timestamp,
+)
+
+
+def _state(state: str, when: datetime) -> SimpleNamespace:
+    return SimpleNamespace(state=state, last_updated=when)
+
+
+def test_recovers_latest_completed_run_and_normalizes_room_names() -> None:
+    start = datetime(2026, 7, 21, 1, tzinfo=UTC)
+    tracker = CleaningSessionTracker()
+
+    tracker.recover(
+        [
+            _state("off", start - timedelta(minutes=1)),
+            _state("on", start),
+            _state("unavailable", start + timedelta(minutes=2)),
+            _state("on", start + timedelta(minutes=3)),
+            _state("off", start + timedelta(minutes=10)),
+        ],
+        [
+            _state("Office", start - timedelta(minutes=1)),
+            _state("unavailable", start + timedelta(minutes=1)),
+            _state("the Living   Room", start + timedelta(minutes=4)),
+            _state("the Living Room", start + timedelta(minutes=5)),
+            _state("the Kitchen", start + timedelta(minutes=8)),
+            _state("Office", start + timedelta(minutes=11)),
+        ],
+        ("Office", "Living Room", "Kitchen"),
+        now=start + timedelta(minutes=12),
+    )
+
+    assert tracker.latest_session == CleaningSession(
+        started_at=start.isoformat(),
+        ended_at=(start + timedelta(minutes=10)).isoformat(),
+        duration_seconds=600,
+        rooms=("Office", "Living Room", "Kitchen"),
+        room_durations=(("Office", 240), ("Living Room", 240), ("Kitchen", 120)),
+        completed=True,
+    )
+
+
+def test_live_tracking_handles_room_changes_and_idle_updates() -> None:
+    start = datetime(2026, 7, 21, 2, tzinfo=UTC)
+    tracker = CleaningSessionTracker()
+
+    assert (
+        tracker.update(
+            cleaning=False,
+            current_area="Office",
+            room_names=("Office", "Living Room"),
+            now=start,
+        )
+        is None
+    )
+    tracker.update(
+        cleaning=True,
+        current_area="Office",
+        room_names=("Office", "Living Room"),
+        now=start,
+    )
+    tracker.update(
+        cleaning=True,
+        current_area="the Living Room",
+        room_names=("Office", "Living Room"),
+        now=start + timedelta(minutes=2),
+    )
+    tracker.update(
+        cleaning=True,
+        current_area="the Living Room",
+        room_names=("Office", "Living Room"),
+        now=start + timedelta(minutes=3),
+    )
+    result = tracker.update(
+        cleaning=False,
+        current_area="the Living Room",
+        room_names=("Office", "Living Room"),
+        now=start + timedelta(minutes=5),
+    )
+
+    assert result is not None
+    assert result.duration_seconds == 300
+    assert dict(result.room_durations) == {"Office": 120, "Living Room": 180}
+    assert (
+        tracker.update(
+            cleaning=False,
+            current_area=None,
+            room_names=("Office",),
+            now=start + timedelta(minutes=6),
+        )
+        is result
+    )
+
+
+def test_recovers_active_run_across_restart_without_double_counting() -> None:
+    start = datetime(2026, 7, 21, 3, tzinfo=UTC)
+    tracker = CleaningSessionTracker()
+    tracker.recover(
+        [_state("on", start)],
+        [
+            _state("Office", start - timedelta(seconds=1)),
+            _state("the Kitchen", start + timedelta(minutes=2)),
+        ],
+        ("Office", "Kitchen"),
+        now=start + timedelta(minutes=4),
+    )
+
+    result = tracker.update(
+        cleaning=False,
+        current_area="the Kitchen",
+        room_names=("Office", "Kitchen"),
+        now=start + timedelta(minutes=5),
+    )
+
+    assert result is not None
+    assert dict(result.room_durations) == {"Office": 120, "Kitchen": 180}
+
+
+def test_session_preference_uses_newest_and_richer_source() -> None:
+    tracked = CleaningSession(
+        "2026-07-21T04:00:00+00:00",
+        "2026-07-21T04:10:00+00:00",
+        600,
+        (),
+        (),
+        True,
+    )
+    older = CleaningSession("not-a-time", "2026-07-20T04:10:00+00:00", 10, (), (), True)
+    richer_same_time = CleaningSession(
+        tracked.started_at,
+        tracked.ended_at,
+        600,
+        ("Office",),
+        (("Office", 600),),
+        True,
+    )
+    newer = CleaningSession(
+        "2026-07-21T05:00:00+00:00",
+        "2026-07-21T05:01:00+00:00",
+        60,
+        (),
+        (),
+        True,
+    )
+    tracker = CleaningSessionTracker(latest_session=tracked)
+
+    assert tracker.preferred_session(None) is tracked
+    assert tracker.preferred_session(older) is tracked
+    assert tracker.preferred_session(richer_same_time) is richer_same_time
+    assert tracker.preferred_session(newer) is newer
+    assert CleaningSessionTracker().preferred_session(newer) is newer
+
+
+def test_helpers_reject_non_rooms_and_handle_timestamp_edges() -> None:
+    assert _canonical_room(None, ("Office",)) is None
+    assert _canonical_room("unknown", ("Office",)) is None
+    assert _canonical_room("Garage", ("Office",)) is None
+    assert _parse_timestamp(None) == datetime.min.replace(tzinfo=UTC)
+    assert _parse_timestamp("bad") == datetime.min.replace(tzinfo=UTC)
+    assert _parse_timestamp("2026-01-01T00:00:00") == datetime(2026, 1, 1, tzinfo=UTC)
+    assert _parse_timestamp("2025-12-31T16:00:00-08:00") == datetime(
+        2026, 1, 1, tzinfo=UTC
+    )
+
+    reversed_session = _build_session(
+        datetime(2026, 1, 2, tzinfo=UTC),
+        datetime(2026, 1, 1, tzinfo=UTC),
+        {"Office": -1},
+        ["Office", "Missing"],
+    )
+    assert reversed_session.duration_seconds == 0
+    assert reversed_session.room_durations == (("Office", 0),)


### PR DESCRIPTION
## What changed

- reconnect and retry once when the robot rolls over its pinned HTTP/2 channel
- expose raw Hermes faults truthfully and require two consecutive polls before surfacing a problem
- reconstruct cleaning runs, room durations, and last-cleaned times from Recorder when firmware history is stale
- decode the live-verified v168 pose layout and retain a distinct room-level fallback
- package the fixes as 0.2.2

## Why

Long-running sessions could become unavailable after robot-side connection rollover. Current firmware can also leave native cleaning history stale, emit brief fault pulses, and encode pose at a different verified field path.

## Validation

- 455 tests, 100% coverage
- Ruff format and lint
- strict MyPy
- privacy/public-tree check
- packaging and release metadata checks
- live Home Assistant plan round trip preserved all 12 rooms and per-room settings
- live targeted run produced exact map position and a 72-second reconstructed run

Final sustained-connection soak is running while CI completes.