### PR TITLE
Release Matic plan reliability fixes in 0.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ The integration adds Home Assistant-native planning and automation:
   mode and coverage level, include toggles, and drag-orderable room lists,
   managed in one Configure screen with live preview. Each plan can stop
   immediately or finish a sufficiently progressed current room without
-  starting the next one.
+  starting the next one. During an uninterrupted plan, the next room starts
+  as soon as the current room finishes; the robot docks only after the final
+  room.
 - **Least-recently-cleaned rotation.** A plan run can start with the rooms
   that have waited longest, using the saved order to break ties — no manual
   bookkeeping of what was cleaned last.

--- a/custom_components/matic_robot/binary_sensor.py
+++ b/custom_components/matic_robot/binary_sensor.py
@@ -90,7 +90,11 @@ DESCRIPTIONS = (
         key="active_cleaning_session",
         translation_key="active_cleaning_session",
         device_class=BinarySensorDeviceClass.RUNNING,
-        value_fn=lambda state: state.telemetry.active_cleaning_session,
+        value_fn=lambda state: (
+            state.operational.cleaning
+            or state.operational.paused
+            or state.operational.returning
+        ),
     ),
     MaticBinarySensorDescription(
         key="ssh_tunnel_permission",

--- a/custom_components/matic_robot/client/models.py
+++ b/custom_components/matic_robot/client/models.py
@@ -60,10 +60,10 @@ class RobotOperationalState:
             return RobotActivity.ERROR
         if self.paused:
             return RobotActivity.PAUSED
-        if self.cleaning:
-            return RobotActivity.CLEANING
         if self.returning:
             return RobotActivity.RETURNING
+        if self.cleaning:
+            return RobotActivity.CLEANING
         if self.charging:
             return RobotActivity.CHARGING
         if self.charging_idle:

--- a/custom_components/matic_robot/coordinator.py
+++ b/custom_components/matic_robot/coordinator.py
@@ -208,6 +208,11 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
             return state
         return replace(state, telemetry=replace(state.telemetry, latest_session=latest))
 
+    @callback
+    def async_discard_current_room(self) -> None:
+        """Keep an interrupted room out of local completed-room statistics."""
+        self._session_tracker.discard_current_room()
+
     async def _async_recover_session_history(
         self,
         serial_number: str,

--- a/custom_components/matic_robot/manifest.json
+++ b/custom_components/matic_robot/manifest.json
@@ -23,7 +23,7 @@
     "h2>=4",
     "protobuf>=6"
   ],
-  "version": "0.2.2",
+  "version": "0.2.3",
   "zeroconf": [
     "_matic_hermes._tcp.local."
   ]

--- a/custom_components/matic_robot/sensor.py
+++ b/custom_components/matic_robot/sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any
 
 from homeassistant.components.sensor import (
@@ -649,6 +649,8 @@ class _MaticRoomStatisticsSensor(MaticEntity, RestoreSensor):
     def __init__(self, entry: MaticConfigEntry, room: Room) -> None:
         super().__init__(entry)
         self._room_id = room.id
+        self._history = entry.runtime_data.cleaning_plans
+        self._serial_number = self.coordinator.data.info.serial_number
         self._attr_translation_placeholders = {"room": room.name}
         self._suggested_suffix = room.name
 
@@ -665,20 +667,32 @@ class _MaticRoomStatisticsSensor(MaticEntity, RestoreSensor):
 
     def _room_session_value(self) -> tuple[str, int] | None:
         """Return this room's (ended_at, seconds) from the latest session."""
+        return self._room_session_result()[1]
+
+    def _room_session_result(self) -> tuple[bool, tuple[str, int] | None]:
+        """Return whether a managed run owns the session and its room result."""
         state = self.coordinator.data
         session = state.telemetry.latest_session
         if session is None or session.ended_at is None or state.floor_plan is None:
-            return None
+            return False, None
         room = next(
             (item for item in state.floor_plan.rooms if item.id == self._room_id),
             None,
         )
         if room is None:
-            return None
+            return False, None
+        managed, managed_value = _managed_room_session_value(
+            self._history.snapshot(self._serial_number),
+            self._room_id,
+            session.started_at,
+            session.ended_at,
+        )
+        if managed:
+            return True, managed_value
         durations = dict(session.room_durations)
         if room.name not in durations:
-            return None
-        return session.ended_at, durations[room.name]
+            return False, None
+        return False, (session.ended_at, durations[room.name])
 
     @callback
     def _async_apply_session(self) -> None:
@@ -710,8 +724,11 @@ class MaticRoomDurationSensor(_MaticRoomStatisticsSensor):
     @callback
     def _async_apply_session(self) -> None:
         """Apply the latest finished session that included this room."""
-        if (value := self._room_session_value()) is not None:
+        managed, value = self._room_session_result()
+        if value is not None:
             self._attr_native_value = value[1]
+        elif managed:
+            self._attr_native_value = None
 
 
 class MaticRoomLastCleanedSensor(_MaticRoomStatisticsSensor):
@@ -734,7 +751,63 @@ class MaticRoomLastCleanedSensor(_MaticRoomStatisticsSensor):
     @callback
     def _async_apply_session(self) -> None:
         """Apply the latest finished session that included this room."""
-        if (value := self._room_session_value()) is not None:
+        managed, value = self._room_session_result()
+        if value is not None:
             ended_at = dt_util.parse_datetime(value[0])
             if ended_at is not None:
                 self._attr_native_value = dt_util.as_utc(ended_at)
+        elif managed:
+            self._attr_native_value = None
+
+
+def _managed_room_session_value(
+    snapshot: dict[str, Any],
+    room_id: str,
+    started_at: str | None,
+    ended_at: str,
+) -> tuple[bool, tuple[str, int] | None]:
+    """Use exact plan outcomes when a managed run overlaps the session."""
+    started = dt_util.parse_datetime(started_at) if started_at is not None else None
+    ended = dt_util.parse_datetime(ended_at)
+    if started is None or ended is None:
+        return False, None
+
+    records: list[dict[str, Any]] = []
+    relevant: list[dict[str, Any]] = []
+    for rotation in snapshot.get("plan_history", {}).values():
+        for record in rotation.get("rooms", {}).values():
+            records.append(record)
+            raw_started = record.get("last_started")
+            room_started = (
+                dt_util.parse_datetime(raw_started)
+                if isinstance(raw_started, str)
+                else None
+            )
+            if (
+                room_started is not None
+                and started - timedelta(seconds=120) <= room_started <= ended
+            ):
+                relevant.append(record)
+    if not relevant:
+        return False, None
+
+    matching = [record for record in relevant if record.get("room_id") == room_id]
+    if matching:
+        record = max(matching, key=lambda item: str(item.get("last_started", "")))
+        duration = record.get("last_duration_seconds")
+        completed = record.get("last_completed")
+        if (
+            record.get("last_result") == "completed"
+            and isinstance(completed, str)
+            and isinstance(duration, int | float)
+        ):
+            return True, (completed, max(0, round(duration)))
+
+    historical = [
+        (completed, max(0, round(duration)))
+        for record in records
+        if record.get("room_id") == room_id
+        and isinstance((completed := record.get("last_completed")), str)
+        and isinstance((duration := record.get("last_duration_seconds")), int | float)
+    ]
+    return True, max(historical, default=None, key=lambda item: item[0])

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Awaitable, Callable
 from copy import deepcopy
 from typing import Any
 
@@ -71,6 +72,7 @@ TARGET_KEYS = (
     ATTR_FLOOR_ID,
     ATTR_LABEL_ID,
 )
+ROOM_STATUS_REFRESH_SECONDS = 5
 
 CLEAN_SERVICE_SCHEMA = cv.make_entity_service_schema(
     {
@@ -222,7 +224,7 @@ async def async_register_services(hass: HomeAssistant) -> None:
 
     async def async_run_saved_plan(call: ServiceCall, *, intelligent: bool) -> None:
         """Resolve and run every room in a saved plan."""
-        entity_id, _entry, serial_number, room_map = _saved_plan_context(hass, call)
+        entity_id, entry, serial_number, room_map = _saved_plan_context(hass, call)
         try:
             plan, rooms = manager.rooms_for_plan(
                 serial_number, room_map, call.data.get("plan")
@@ -254,6 +256,7 @@ async def async_register_services(hass: HomeAssistant) -> None:
             serial_number,
             rooms,
             intelligent=intelligent,
+            refresh=entry.runtime_data.coordinator.async_request_refresh,
         )
 
     async def async_intelligent_clean(call: ServiceCall) -> None:
@@ -330,14 +333,13 @@ async def async_register_services(hass: HomeAssistant) -> None:
 
     async def async_stop_intelligent_cleaning(call: ServiceCall) -> None:
         """Apply the active plan's stop policy and send the robot home."""
-        entity_id, _entry, serial_number, _room_map = _saved_plan_context(hass, call)
+        entity_id, entry, serial_number, _room_map = _saved_plan_context(hass, call)
         decision = manager.request_stop(serial_number)
         if decision.behavior == "not_running":
-            raise _validation_error(
-                "No managed Matic cleaning plan is running", "plan_not_running"
-            )
+            return
         if decision.behavior == "after_room":
             return
+        entry.runtime_data.coordinator.async_discard_current_room()
         await hass.services.async_call(
             VACUUM_DOMAIN,
             "return_to_base",
@@ -639,6 +641,7 @@ async def _async_run_room(
     serial_number: str,
     room: CleaningRoom,
     cancel_event: asyncio.Event | None = None,
+    refresh: Callable[[], Awaitable[None]] | None = None,
 ) -> None:
     """Run one mapped room and advance history only after completion."""
     event_data = {
@@ -675,13 +678,23 @@ async def _async_run_room(
             call.data["start_timeout"],
             cancel_event,
         )
-        await _async_wait_for_vacuum_state(
-            hass,
-            entity_id,
-            {"docked", "idle"},
-            call.data["completion_timeout"],
-            cancel_event,
+        refresh_task = (
+            asyncio.create_task(_async_periodic_refresh(refresh))
+            if refresh is not None
+            else None
         )
+        try:
+            await _async_wait_for_vacuum_state(
+                hass,
+                entity_id,
+                {"returning", "docked", "idle"},
+                call.data["completion_timeout"],
+                cancel_event,
+            )
+        finally:
+            if refresh_task is not None:
+                refresh_task.cancel()
+                await asyncio.gather(refresh_task, return_exceptions=True)
     except PlanCancelledError:
         await manager.async_mark_cancelled(serial_number, call.data["plan_id"], room)
         hass.bus.async_fire(
@@ -709,6 +722,15 @@ async def _async_run_room(
 
     await manager.async_mark_completed(serial_number, call.data["plan_id"], room)
     hass.bus.async_fire(f"{DOMAIN}_room_completed", event_data, context=call.context)
+
+
+async def _async_periodic_refresh(
+    refresh: Callable[[], Awaitable[None]],
+) -> None:
+    """Poll operational state quickly enough to intercept a return to dock."""
+    while True:
+        await asyncio.sleep(ROOM_STATUS_REFRESH_SECONDS)
+        await refresh()
 
 
 async def _async_wait_for_vacuum_state(
@@ -788,6 +810,7 @@ async def _async_execute_rooms(
     rooms: list[CleaningRoom],
     *,
     intelligent: bool,
+    refresh: Callable[[], Awaitable[None]] | None = None,
 ) -> None:
     """Execute every resolved room with safe cancellation semantics."""
     lock = manager.lock(serial_number)
@@ -815,6 +838,7 @@ async def _async_execute_rooms(
                     serial_number,
                     room,
                     cancel_event,
+                    refresh,
                 )
                 if finish_room_event.is_set():
                     break

--- a/custom_components/matic_robot/session_tracking.py
+++ b/custom_components/matic_robot/session_tracking.py
@@ -13,6 +13,8 @@ from typing import Protocol
 
 from .client.models import CleaningSession
 
+MIN_CLEANED_ROOM_SECONDS = 60
+
 
 class _HistoryState(Protocol):
     """The small part of a recorder State used for recovery."""
@@ -114,6 +116,16 @@ class CleaningSessionTracker:
         ):
             return native_session
         return tracked
+
+    def discard_current_room(self) -> None:
+        """Exclude an interrupted room from the finished session summary."""
+        room = self._current_room
+        if room is None:
+            return
+        self._room_durations.pop(room, None)
+        self._rooms = [item for item in self._rooms if item != room]
+        self._current_room = None
+        self._room_started_at = None
 
     def _restore_active(
         self,
@@ -220,15 +232,16 @@ def _build_session(
     rooms: list[str],
 ) -> CleaningSession:
     """Create one immutable public session from local tracking values."""
+    cleaned_rooms = [
+        room for room in rooms if durations.get(room, 0.0) >= MIN_CLEANED_ROOM_SECONDS
+    ]
     return CleaningSession(
         started_at=started_at.isoformat(),
         ended_at=ended_at.isoformat(),
         duration_seconds=max(0, round((ended_at - started_at).total_seconds())),
-        rooms=tuple(rooms),
+        rooms=tuple(cleaned_rooms),
         room_durations=tuple(
-            (room, max(0, round(durations[room])))
-            for room in rooms
-            if room in durations
+            (room, max(0, round(durations[room]))) for room in cleaned_rooms
         ),
         completed=True,
     )

--- a/custom_components/matic_robot/vacuum.py
+++ b/custom_components/matic_robot/vacuum.py
@@ -156,6 +156,7 @@ class MaticVacuum(MaticEntity, StateVacuumEntity):
         decision = self._plans.request_stop(self.coordinator.data.info.serial_number)
         if decision.behavior == "after_room":
             return
+        self.coordinator.async_discard_current_room()
         await self._async_command(UserCommand.STOP)
 
     async def async_return_to_base(self, **kwargs: object) -> None:
@@ -165,6 +166,7 @@ class MaticVacuum(MaticEntity, StateVacuumEntity):
             # The robot treats docking mid-task as recharge-and-resume and
             # heads back out afterwards; stop the task first so a
             # user-requested dock is final.
+            self.coordinator.async_discard_current_room()
             await self._async_command(UserCommand.STOP)
         await self._async_command(UserCommand.DOCK)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,8 @@ the integration so instructions and behavior stay aligned with each release.
   discovery, passkey, room-mapping, firmware, and Bluetooth constraints.
 - [Firmware compatibility](firmware-compatibility.md) — Track observed robot
   versions, validation status, regressions, and newly discovered capabilities.
+- [Release notes — 0.2.3](release-notes-0.2.3.md) — Room-to-room plans and
+  accurate interrupted-run history
 - [Release notes — 0.2.2](release-notes-0.2.2.md) — Connection, session-history,
   Activity, and map reliability
 - [Release notes — 0.2.1](release-notes-0.2.1.md) — Plan-editor reliability

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -95,6 +95,11 @@ saved room order breaks ties. Failed, cancelled, timed-out, or
 restart-interrupted rooms remain due because history advances only after
 verified completion.
 
+Each room is complete when the robot reports that it is returning from that
+room. The integration checks that transition every five seconds and sends the
+next room before the robot reaches the dock. Only the final room returns all
+the way to the dock, and learned room durations exclude that return trip.
+
 The finish-current-room policy estimates progress from elapsed time versus
 successful managed runs of the same room with the same cleaning settings. A
 stop below the configured threshold remains immediate; at or above it, the

--- a/docs/release-notes-0.2.3.md
+++ b/docs/release-notes-0.2.3.md
@@ -1,0 +1,47 @@
+# Release notes — 0.2.3
+
+Released: 2026-07-23
+
+## Summary
+
+0.2.3 keeps multi-room plans moving without an unwanted dock visit between
+rooms and makes interrupted-run history truthful. It also makes plan stopping
+idempotent and keeps the active-session indicator aligned with the robot's
+current operational state.
+
+## Reliable multi-room plans
+
+- A completed room is recognized as soon as the robot begins returning, even
+  on firmware that reports Cleaning and Returning simultaneously.
+- The next room is dispatched during that return phase, so the robot does not
+  reach the dock between rooms. It docks only after the last planned room.
+- A five-second operational refresh runs only while a managed room is active,
+  making the handoff responsive without increasing normal background polling.
+- Repeating a stop action after a plan has already ended is harmless.
+
+## Accurate stopping and room history
+
+- Immediate stop and return-to-base exclude the interrupted current room from
+  completed-room statistics.
+- Brief mapped-room transit under 60 seconds no longer credits that room as
+  cleaned.
+- Managed plan outcomes are the source of truth for room timestamps and
+  durations. A cancelled room is not credited, while older legitimate room
+  completions remain visible.
+- Small timing differences between plan dispatch and operational detection no
+  longer hide a legitimately completed first room.
+- Active cleaning session now follows Cleaning, Paused, and Returning state,
+  so it clears after docking even if stale native session telemetry remains.
+
+## Live verification
+
+A two-room plan was exercised on a real robot. The second room started during
+the first room's return without an intermediate dock visit. Stopping in the
+second room recorded it as cancelled, preserved earlier completed-room results,
+and left both Active cleaning session and Problem off at the dock.
+
+## Upgrading from 0.2.2
+
+Install 0.2.3 through HACS and restart Home Assistant. No re-pairing, entity-ID
+migration, or plan recreation is required. Existing plans and room history are
+preserved.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "matic-home-assistant"
-version = "0.2.2"
+version = "0.2.3"
 description = "Unofficial local-only Home Assistant integration for Matic robot vacuums"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -62,6 +62,17 @@ def _coordinator(hass, client) -> MaticCoordinator:
     return MaticCoordinator(hass, client, config_entry=_tracking_entry())
 
 
+def test_discard_current_room_delegates_to_session_tracker(hass) -> None:
+    coordinator = _coordinator(hass, _client())
+
+    with patch(
+        "custom_components.matic_robot.coordinator.CleaningSessionTracker.discard_current_room"
+    ) as discard:
+        coordinator.async_discard_current_room()
+
+    discard.assert_called_once_with()
+
+
 async def test_update_combines_required_and_optional_local_state(hass) -> None:
     client = _client()
     coordinator = _coordinator(hass, client)

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -109,7 +109,7 @@ def _state(
                 ),
             ),
             latest_session=CleaningSession(
-                "2026-01-01T08:00:00+00:00",
+                "2026-01-01T08:00:01+00:00",
                 "2026-01-01T08:10:00+00:00",
                 600,
                 ("Kitchen",),
@@ -147,6 +147,7 @@ def _entry(*, paused: bool = False, idle: bool = False, with_floor_plan: bool = 
         coverage_setting=CoverageSetting.STANDARD,
         async_request_refresh=AsyncMock(),
         async_request_full_refresh=AsyncMock(),
+        async_discard_current_room=MagicMock(),
         async_add_listener=MagicMock(return_value=MagicMock()),
         last_update_success=True,
     )
@@ -368,6 +369,101 @@ async def test_room_statistics_sensors_apply_and_restore_sessions() -> None:
     assert fresh.native_value == 600
 
 
+def test_managed_room_statistics_ignore_transit_and_cancelled_rooms() -> None:
+    entry = _entry()
+    coordinator = entry.runtime_data.coordinator
+    history = entry.runtime_data.cleaning_plans
+    history.snapshot.return_value["plan_history"] = {
+        "handoff": {
+            "rooms": {
+                "retired": {"room_id": "retired"},
+                "room-1": {
+                    "room_id": "room-1",
+                    "last_started": "2026-01-01T08:00:00+00:00",
+                    "last_completed": "2026-01-01T08:06:00+00:00",
+                    "last_duration_seconds": 360,
+                    "last_result": "completed",
+                },
+                "room-2": {
+                    "room_id": "room-2",
+                    "last_started": "2026-01-01T08:06:00+00:00",
+                    "last_result": "cancelled",
+                },
+            }
+        }
+    }
+    coordinator.data = replace(
+        coordinator.data,
+        telemetry=replace(
+            coordinator.data.telemetry,
+            latest_session=CleaningSession(
+                "2026-01-01T08:00:00+00:00",
+                "2026-01-01T08:10:00+00:00",
+                600,
+                ("Kitchen", "Study"),
+                (("Kitchen", 400), ("Study", 200)),
+                True,
+            ),
+        ),
+    )
+
+    kitchen = coordinator.data.floor_plan.rooms[0]
+    study = coordinator.data.floor_plan.rooms[1]
+    assert sensor.MaticRoomDurationSensor(entry, kitchen)._room_session_value() == (
+        "2026-01-01T08:06:00+00:00",
+        360,
+    )
+    study_duration = sensor.MaticRoomDurationSensor(entry, study)
+    study_last = sensor.MaticRoomLastCleanedSensor(entry, study)
+    study_duration._attr_native_value = 200
+    study_last._attr_native_value = sensor.dt_util.parse_datetime(
+        "2026-01-01T08:10:00+00:00"
+    )
+    study_duration._async_apply_session()
+    study_last._async_apply_session()
+    assert study_duration.native_value is None
+    assert study_last.native_value is None
+
+
+def test_managed_room_statistics_validate_session_and_unmatched_room() -> None:
+    snapshot = {
+        "plan_history": {
+            "handoff": {
+                "rooms": {
+                    "room-1": {
+                        "room_id": "room-1",
+                        "last_started": "2026-01-01T08:00:00+00:00",
+                        "last_completed": "2026-01-01T08:06:00+00:00",
+                        "last_duration_seconds": 360,
+                        "last_result": "completed",
+                    }
+                }
+            },
+            "older": {
+                "rooms": {
+                    "room-2": {
+                        "room_id": "room-2",
+                        "last_started": "2025-12-31T07:00:00+00:00",
+                        "last_completed": "2025-12-31T07:05:00+00:00",
+                        "last_duration_seconds": 300,
+                        "last_result": "completed",
+                    }
+                }
+            },
+        }
+    }
+
+    assert sensor._managed_room_session_value(
+        snapshot, "room-1", "invalid", "2026-01-01T08:10:00+00:00"
+    ) == (False, None)
+    assert sensor._managed_room_session_value(
+        snapshot,
+        "room-2",
+        "2026-01-01T07:59:00+00:00",
+        "2026-01-01T08:10:00+00:00",
+    ) == (True, ("2025-12-31T07:05:00+00:00", 300))
+
+
 def test_room_statistics_sensors_skip_unmatched_sessions() -> None:
     entry = _entry(with_floor_plan=False)
     room = _floor_plan().rooms[0]
@@ -479,7 +575,7 @@ def test_sensor_and_binary_sensor_values() -> None:
         False,
         False,
         False,
-        None,
+        True,
         None,
         None,
     ]

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -80,6 +80,7 @@ def test_decode_absent_or_non_finite_battery_as_unknown() -> None:
         ([106, 119], RobotActivity.CLEANING),
         ([109, 200, 119], RobotActivity.PAUSED),
         ([104, 105], RobotActivity.RETURNING),
+        ([104, 105, 106, 119], RobotActivity.RETURNING),
         ([106], RobotActivity.DOCKED),
         ([], RobotActivity.READY),
     ],

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -366,7 +366,7 @@ async def test_room_execution_uses_its_individual_settings() -> None:
 
     with patch(
         "custom_components.matic_robot.services._async_wait_for_vacuum_state",
-        AsyncMock(side_effect=["cleaning", "docked"]),
+        AsyncMock(side_effect=["cleaning", "returning"]),
     ) as wait:
         await _async_run_room(
             hass, _call(hass), manager, "vacuum.matic", "serial", room
@@ -383,6 +383,7 @@ async def test_room_execution_uses_its_individual_settings() -> None:
         },
     }
     assert wait.await_count == 2
+    assert wait.await_args_list[1].args[2] == {"returning", "docked", "idle"}
     manager.async_mark_completed.assert_awaited_once()
     assert bus.async_fire.call_args_list[-1].args[0] == "matic_robot_room_completed"
 

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -28,7 +28,7 @@ def test_release_versions_and_links_are_consistent() -> None:
     hacs = json.loads((ROOT / "hacs.json").read_text())
     project = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]
 
-    assert manifest["version"] == "0.2.2"
+    assert manifest["version"] == "0.2.3"
     assert project["version"] == manifest["version"]
     assert hacs["homeassistant"] == "2026.7.0"
     assert manifest["documentation"].startswith("https://github.com/")

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -157,7 +157,12 @@ async def test_intelligent_exact_preview_stop_and_reset_actions(hass) -> None:
         },
     )
     services = await _registered_services(hass, manager)
-    context = ("vacuum.test", SimpleNamespace(), "serial", {"room-study": "Study"})
+    coordinator = SimpleNamespace(
+        async_request_refresh=AsyncMock(),
+        async_discard_current_room=MagicMock(),
+    )
+    entry = SimpleNamespace(runtime_data=SimpleNamespace(coordinator=coordinator))
+    context = ("vacuum.test", entry, "serial", {"room-study": "Study"})
     call = ServiceCall(
         hass,
         DOMAIN,
@@ -180,6 +185,9 @@ async def test_intelligent_exact_preview_stop_and_reset_actions(hass) -> None:
 
     assert execute.await_count == 3
     assert execute.await_args_list[0].kwargs["intelligent"] is True
+    assert execute.await_args_list[0].kwargs["refresh"] is (
+        coordinator.async_request_refresh
+    )
     assert execute.await_args_list[1].kwargs["intelligent"] is False
     assert execute.await_args_list[2].kwargs["intelligent"] is False
     assert preview["plan_name"] == "Upstairs"
@@ -198,6 +206,7 @@ async def test_intelligent_exact_preview_stop_and_reset_actions(hass) -> None:
     ):
         await _registered_handler(services, "stop_intelligent_cleaning")(stop)
     assert manager.cancellation_event("serial").is_set()
+    coordinator.async_discard_current_room.assert_called_once_with()
     lock.release()
     services.async_call.assert_awaited_with(
         "vacuum",
@@ -244,7 +253,7 @@ async def test_intelligent_exact_preview_stop_and_reset_actions(hass) -> None:
         await _registered_handler(services, "reset_plan_history")(reset)
 
 
-async def test_managed_actions_report_missing_plan_and_inactive_run(hass) -> None:
+async def test_managed_actions_ignore_inactive_stop(hass) -> None:
     manager = CleaningPlanManager(hass)
     manager._store = SimpleNamespace(async_save=AsyncMock())
     await manager.async_save_plan(
@@ -287,8 +296,8 @@ async def test_managed_actions_report_missing_plan_and_inactive_run(hass) -> Non
             await _registered_handler(services, "reset_plan_history")(reset_missing)
         with pytest.raises(ServiceValidationError, match="disabled"):
             await _registered_handler(services, "preview_plan")(disabled)
-        with pytest.raises(ServiceValidationError, match="No managed"):
-            await _registered_handler(services, "stop_intelligent_cleaning")(stop)
+        await _registered_handler(services, "stop_intelligent_cleaning")(stop)
+    services.async_call.assert_not_awaited()
 
 
 async def test_room_native_plan_crud_is_complete(hass) -> None:
@@ -1057,6 +1066,44 @@ async def test_room_cancellation_records_history_and_reraises() -> None:
     manager.async_mark_cancelled.assert_awaited_once()
     manager.async_mark_completed.assert_not_awaited()
     assert bus.async_fire.call_args_list[-1].args[0] == "matic_robot_room_cancelled"
+
+
+async def test_room_completes_on_returning_without_waiting_for_dock(hass) -> None:
+    """Dispatch the next room as soon as a completed task starts returning."""
+
+    async def send_command(*_args, **_kwargs) -> None:
+        hass.states.async_set("vacuum.test", "cleaning")
+
+        async def finish_room() -> None:
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            hass.states.async_set("vacuum.test", "returning")
+
+        hass.async_create_task(finish_room(), eager_start=True)
+
+    hass.services.async_register("vacuum", "send_command", send_command)
+    manager = SimpleNamespace(
+        async_mark_started=AsyncMock(),
+        async_mark_completed=AsyncMock(),
+        async_mark_failed=AsyncMock(),
+    )
+    refresh = AsyncMock()
+
+    with patch("custom_components.matic_robot.services.ROOM_STATUS_REFRESH_SECONDS", 0):
+        await _async_run_room(
+            hass,
+            _execution_call(hass),
+            manager,
+            "vacuum.test",
+            "serial",
+            CleaningRoom("room-study", "Study", "vacuum", "quick"),
+            refresh=refresh,
+        )
+
+    assert hass.states.get("vacuum.test").state == "returning"
+    refresh.assert_awaited()
+    manager.async_mark_completed.assert_awaited_once()
+    manager.async_mark_failed.assert_not_awaited()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_session_tracking.py
+++ b/tests/test_session_tracking.py
@@ -104,6 +104,35 @@ def test_live_tracking_handles_room_changes_and_idle_updates() -> None:
     )
 
 
+def test_transit_rooms_and_interrupted_room_are_not_completed() -> None:
+    start = datetime(2026, 7, 21, 2, tzinfo=UTC)
+    tracker = CleaningSessionTracker()
+    tracker.update(
+        cleaning=True,
+        current_area="Hallway",
+        room_names=("Hallway", "Kitchen"),
+        now=start,
+    )
+    tracker.update(
+        cleaning=True,
+        current_area="Kitchen",
+        room_names=("Hallway", "Kitchen"),
+        now=start + timedelta(seconds=30),
+    )
+    tracker.discard_current_room()
+    result = tracker.update(
+        cleaning=False,
+        current_area="Kitchen",
+        room_names=("Hallway", "Kitchen"),
+        now=start + timedelta(minutes=3),
+    )
+
+    assert result is not None
+    assert result.rooms == ()
+    assert result.room_durations == ()
+    tracker.discard_current_room()
+
+
 def test_recovers_active_run_across_restart_without_double_counting() -> None:
     start = datetime(2026, 7, 21, 3, tzinfo=UTC)
     tracker = CleaningSessionTracker()
@@ -181,4 +210,4 @@ def test_helpers_reject_non_rooms_and_handle_timestamp_edges() -> None:
         ["Office", "Missing"],
     )
     assert reversed_session.duration_seconds == 0
-    assert reversed_session.room_durations == (("Office", 0),)
+    assert reversed_session.room_durations == ()


### PR DESCRIPTION
## What changed

- hand off managed multi-room plans when a completed room begins returning, avoiding an intermediate dock visit
- make stop-and-dock idempotent and exclude an interrupted current room from completion history
- reject brief room transit from room-cleaning history and prefer managed plan outcomes for room timestamps and durations
- keep Activity and active-session state aligned with simultaneous cleaning/returning firmware state
- bump the integration to 0.2.3 and add release notes

## Why

Live runs showed that the robot can report Cleaning and Returning simultaneously. Waiting only for dock/idle made room handoffs late, while native session summaries could credit transit or interrupted rooms.

## Validation

- 461 tests passed with 100% coverage
- Ruff check and format check
- strict MyPy
- public-tree privacy check
- wheel and source archive verification
- fresh-install import verification
- Home Assistant Yellow configuration check and restart
- live device state verified: 0.2.3 loaded, normal labeled map retained, Activity Docked, Active cleaning session Not running, Problem OK, completed-room durations retained, interrupted room uncredited

The experimental photo/3D map and custom-area editor are intentionally excluded and remain scoped for 0.3.0.