### PR TITLE
Sync the auto-merge gate with the hardened canonical copy

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -59,11 +59,24 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
+  # The verdict and the override's audit trail are read through issue endpoints
+  # (issue comments, and the timeline that names who applied the label).
+  issues: read
+  # The gate stamps its verdict onto the head commit as a status, which is what
+  # makes the decision outlive this run. Unlike the Administration (read) the
+  # branch-protection lookup needs, `statuses` IS a grantable workflow permission.
+  statuses: write
 
 jobs:
   enable-auto-merge:
     name: enable-auto-merge
-    runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","ci"]') }}
+    # The self-hosted fallback asks for `mbp`, the one label the whole runner fleet
+    # carries. It previously asked for `ci`, which only this repo's runner happens to
+    # have: in any other repo the expression resolved to a label set matching no
+    # runner, and the job queued until it timed out. A canonical file has to name a
+    # label that is true fleet-wide, because per-repo variation belongs in the repo
+    # vars below, not in forked copies of the file.
+    runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
     # `issue_comment` carries `issue.pull_request` but NO top-level
     # `pull_request`, so `github.event.pull_request.draft == false` is false and
     # the job is skipped outright — the verdict path would never even start.
@@ -86,6 +99,11 @@ jobs:
           # Administration (read), which GITHUB_TOKEN cannot hold. Such a run now
           # FAILS loudly there rather than quietly never arming anything.
           GH_TOKEN: ${{ secrets.AUTO_MERGE_PAT || github.token }}
+          # The status stamp authenticates with THIS token instead — see the stamping
+          # block. `permissions:` grants scopes to github.token and to nothing else,
+          # so the statuses:write declared above says nothing about what the operator's
+          # PAT is allowed to do.
+          STATUS_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           EVENT_NAME: ${{ github.event_name }}
           EVENT_PR_URL: ${{ github.event.pull_request.html_url }}
@@ -93,6 +111,10 @@ jobs:
           EVENT_IS_PR: ${{ github.event.issue.pull_request != null }}
           REVIEW_BOT: chatgpt-codex-connector[bot]
           OVERRIDE_LABEL: auto-merge-now
+          # The status context stamped on each reviewed head. Adding this name to a
+          # branch's REQUIRED status checks is what turns the gate from advisory into
+          # enforcement — see the stamping block for the ordering that requires.
+          REVIEW_GATE_CONTEXT: review-gate
           INPUT_PR: ${{ inputs.pull_request }}
         run: |
           set -euo pipefail
@@ -199,8 +221,17 @@ jobs:
           # can fail in; it is invisible until someone wonders why nothing merges.
           # Capture the read as a distinct success/failure: a genuine zero still
           # refuses to arm (below), while an unreadable answer stops the run loudly.
+          #
+          # $REVIEW_GATE_CONTEXT is EXCLUDED from the count, because this gate's own
+          # status must not satisfy the CI precondition the gate sits behind. Once that
+          # context is added to a branch's required checks — the rollout step this
+          # workflow asks for — it would otherwise be the one entry counted here on a
+          # branch with no build or test gates, turning "at least one required check
+          # exists" from a real precondition into a statement about this workflow
+          # itself, and arming reviewed PRs with nothing verifying that they build.
           if ! required_count="$(gh api "repos/$REPO/branches/$base_ref/protection" \
-            --jq '(.required_status_checks.contexts // []) | length')"; then
+            --jq '(.required_status_checks.contexts // [])
+                  | map(select(. != env.REVIEW_GATE_CONTEXT)) | length')"; then
             echo "Could not read branch protection for $base_ref (the API error is above)."
             echo "That endpoint requires repository Administration (read) access, which"
             echo "GITHUB_TOKEN does not have and cannot be granted. Configure the"
@@ -214,7 +245,8 @@ jobs:
             exit 1
           fi
           if [[ "$required_count" == "0" ]]; then
-            echo "Base branch $base_ref has no required status checks; refusing to enable auto-merge before CI gates."
+            echo "Base branch $base_ref has no required CI checks apart from '$REVIEW_GATE_CONTEXT',"
+            echo "which does not count as one; refusing to enable auto-merge before CI gates."
             exit 0
           fi
 
@@ -228,8 +260,8 @@ jobs:
           # Arm only once the reviewer has covered THIS head: its verdict carries
           # "Reviewed commit: <sha>". A stale review of an older head does not count.
           # Escape hatch: the OVERRIDE_LABEL arms regardless (reviewer down, quota
-          # exhausted, or a deliberate hotfix) — applying a label needs write access
-          # and leaves an audit trail, which a silent race did not.
+          # exhausted, or a deliberate hotfix) — a label leaves an audit trail, which
+          # a silent race did not, and the account that applied it is checked below.
           head_sha="$(gh pr view "$pr_ref" --json headRefOid --jq '.headRefOid')"
           pr_number="$(gh pr view "$pr_ref" --json number --jq '.number')"
           # The sha is interpolated into the verdict-matching pattern below. An
@@ -242,13 +274,105 @@ jobs:
           fi
           auto_merge_enabled="$(gh pr view "$pr_ref" --json autoMergeRequest --jq '.autoMergeRequest != null')"
 
+          # STAMP THE VERDICT ONTO THE HEAD, so enforcement outlives this run.
+          #
+          # Everything below arms and withdraws, and all of it is bounded by how fast
+          # this workflow can react. Push B onto a PR armed for reviewed head A and the
+          # arm survives the push; the `synchronize` run that would withdraw it is only
+          # QUEUED, behind whatever else is in this workflow's concurrency group and
+          # behind everything else on the runner. Gate runs have queued minutes behind
+          # iOS jobs on the shared runner, and B's required checks can finish first — at
+          # which point GitHub merges B on the strength of a review of A. No amount of
+          # re-checking inside a run closes that, because the danger lives between runs.
+          #
+          # A commit status does. It is attached to a SHA, so a new commit simply does
+          # not have one, and once `$REVIEW_GATE_CONTEXT` is a required check the merge
+          # is blocked by GitHub itself rather than by this workflow winning a race.
+          #
+          # ORDERING, and it matters: adding this context to a branch's required checks
+          # before the stamping workflow is live on that branch's default branch wedges
+          # every PR — nothing would ever post the context. Ship the workflow first,
+          # then require the check.
+          #
+          # Only two states are ever stamped. `success` says this exact head cleared the
+          # gate. `pending` says it has not, which is also what an unstamped head looks
+          # like to a required check — so pending adds legibility (a description saying
+          # what is being waited on) without changing the outcome. `failure` is never
+          # stamped: an interim push has not failed anything, and painting it red would
+          # train everyone to ignore the signal that matters.
+          #
+          # Revocation boundary, stated honestly: statuses are per-sha, so a new push
+          # cannot inherit an old verdict. Evidence deleted AFTER a success stamp on the
+          # SAME sha is the residual case, and it is largely covered — deleting a reply
+          # or a review fires the `deleted` events this workflow listens for, and that
+          # run re-evaluates and re-stamps `pending`. What is not covered is a deletion
+          # whose run never happens or fails; the withdraw path still removes the arm on
+          # the next event, but a stale `success` could sit on that sha until then.
+          # TOKEN SPLIT, and it is deliberate. Every other call here runs as GH_TOKEN,
+          # the PAT, because they need things only it has: Administration (read) for
+          # the branch-protection lookup, and a real user's attribution on the merge so
+          # downstream workflows fire. This one call runs as github.token instead.
+          # `permissions:` grants scopes to github.token and to NOTHING else, so the
+          # statuses:write declared at the top of this file says nothing about what an
+          # operator-provided PAT may do — a fine-grained PAT without "Commit statuses:
+          # write" would 403 here while the workflow appeared to hold the permission.
+          # Authenticating the stamp with the token the permission actually governs
+          # makes the declaration load-bearing instead of decorative, and keeps the
+          # enforcement backstop working regardless of how the PAT was scoped.
+          # (Statuses posted by github.token do not trigger workflow runs, which costs
+          # nothing here: no workflow listens on `status`, and branch protection
+          # evaluates the context regardless of who posted it.)
+          stamp_review_gate() {
+            GH_TOKEN="$STATUS_TOKEN" gh api "repos/$REPO/statuses/$head_sha" --silent \
+              -f state="$1" \
+              -f context="$REVIEW_GATE_CONTEXT" \
+              -f description="$2" \
+              -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
+          }
+
           # Evidence is REVOCABLE — a disposition reply can be deleted and the
           # override label removed — so this is a function, evaluated immediately
           # before arming and again immediately after. `--match-head-commit` guards
           # only the sha; it says nothing about replies or labels.
           evaluate_evidence() {
+            # The override is an AUTHORIZATION, so the authority behind it is verified
+            # rather than inferred from the platform. On a personal-account repository
+            # the only people who can label are collaborators with write, which made
+            # "the label implies write access" accidentally true; an organization
+            # grants the triage role labelling rights WITHOUT write, so converting
+            # this account would quietly widen who can bypass a review — a weakening
+            # nothing would announce. Read who applied the label and check them.
+            # Anything unverifiable simply is not an override: the run falls back to
+            # requiring a review pass, which is the safe direction and is stated in
+            # the log rather than assumed.
+            override_authorized=false
             if gh pr view "$pr_ref" --json labels --jq '.labels[].name' | grep -Fxq "$OVERRIDE_LABEL"; then
-              echo "Override label '$OVERRIDE_LABEL' present; skipping the review gate for $head_sha."
+              # Stream the logins and take the last line rather than filtering with
+              # `| last`: --paginate applies --jq to EACH page, so a per-page `last`
+              # would emit one login per page instead of the most recent one. The
+              # most recent labelling is the live one — the label can be removed and
+              # re-applied by a different account.
+              if ! label_actor="$(gh api "repos/$REPO/issues/$pr_number/timeline?per_page=100" --paginate \
+                --jq '.[] | select(.event == "labeled" and .label.name == env.OVERRIDE_LABEL)
+                          | .actor.login' | tail -n 1)"; then
+                echo "Could not read who applied '$OVERRIDE_LABEL'; not honoring the override."
+              elif [[ -z "$label_actor" ]]; then
+                echo "No 'labeled' event names who applied '$OVERRIDE_LABEL'; not honoring the override."
+              # `.permission` is the legacy triple: maintain reports as write, and
+              # triage reports as read. Matching on it is what excludes triage;
+              # `.role_name` would need every writing role enumerated instead.
+              elif ! actor_permission="$(gh api "repos/$REPO/collaborators/$label_actor/permission" \
+                --jq '.permission')"; then
+                echo "Could not verify $label_actor's access; not honoring the override."
+              elif [[ "$actor_permission" != "admin" && "$actor_permission" != "write" ]]; then
+                echo "'$OVERRIDE_LABEL' was applied by $label_actor ($actor_permission), who cannot authorize a merge; not honoring the override."
+              else
+                override_authorized=true
+              fi
+            fi
+
+            if [[ "$override_authorized" == "true" ]]; then
+              echo "Override label '$OVERRIDE_LABEL' applied by $label_actor ($actor_permission); skipping the review gate for $head_sha."
               reviewed=true
             else
               # (a) A verdict must name THIS head. The verdict abbreviates the sha,
@@ -293,16 +417,50 @@ jobs:
                 # A disposition must come from someone who can actually accept the
                 # risk. Any participant can reply in a thread, so counting every
                 # non-bot reply would let an unaffiliated account clear the gate by
-                # answering each finding. Trust is by repository association.
-                elif ! answered="$(gh api "repos/$REPO/pulls/$pr_number/comments?per_page=100" --paginate \
-                  --jq '.[] | select(.user.login != env.REVIEW_BOT)
-                            | select(.author_association == "OWNER"
-                                  or .author_association == "MEMBER"
-                                  or .author_association == "COLLABORATOR")
-                            | .in_reply_to_id // empty')"; then
+                # answering each finding. This resolves each author's ACCESS, the
+                # same standard the override label is held to: `author_association`
+                # is not it, because MEMBER and COLLABORATOR describe attachment to
+                # the repository rather than write permission — on an organization,
+                # or wherever a read/triage collaborator exists, both are reachable
+                # without any ability to merge. Today these are personal-account
+                # repositories where every collaborator has write, so this is the
+                # same future-proofing as the label path, kept consistent with it
+                # rather than left as the one authorization still taken on trust.
+                elif ! reply_rows="$(gh api "repos/$REPO/pulls/$pr_number/comments?per_page=100" --paginate \
+                  --jq '.[] | select(.user.login != env.REVIEW_BOT) | select(.in_reply_to_id != null)
+                            | "\(.user.login) \(.in_reply_to_id)"')"; then
                   echo "Could not read finding replies for $head_sha; failing closed."
                   reviewed=false
                 else
+                  # One permission lookup per distinct author, not per reply. The
+                  # cache is per evaluation rather than per run, so the late
+                  # re-evaluations re-resolve access for the same reason they
+                  # re-read the replies themselves: both can be revoked.
+                  answered=""
+                  checked_authors=""
+                  authorized_authors=""
+                  while read -r reply_author reply_target; do
+                    [[ -z "$reply_author" || -z "$reply_target" ]] && continue
+                    if ! printf '%s\n' "$checked_authors" | grep -qxF "$reply_author"; then
+                      checked_authors+="$reply_author"$'\n'
+                      if ! reply_author_access="$(gh api "repos/$REPO/collaborators/$reply_author/permission" \
+                        --jq '.permission')"; then
+                        # Unreadable access is not permission. Only this author's
+                        # replies stop counting; the rest of the evidence stands.
+                        echo "Could not verify $reply_author's access; their replies do not disposition findings."
+                        reply_author_access="unreadable"
+                      fi
+                      if [[ "$reply_author_access" == "admin" || "$reply_author_access" == "write" ]]; then
+                        authorized_authors+="$reply_author"$'\n'
+                      else
+                        echo "Replies from $reply_author ($reply_author_access) do not disposition findings; that needs write access."
+                      fi
+                    fi
+                    if printf '%s\n' "$authorized_authors" | grep -qxF "$reply_author"; then
+                      answered+="$reply_target"$'\n'
+                    fi
+                  done <<< "$reply_rows"
+
                   findings=""
                   while read -r finding_id review_id; do
                     [[ -z "$finding_id" ]] && continue
@@ -336,9 +494,31 @@ jobs:
               echo "Head $head_sha is not cleared; withdrawing the existing auto-merge."
               gh pr merge "$pr_ref" --disable-auto
             fi
+            # A failed stamp here is reported, not fatal: the arm is already withdrawn,
+            # which is the protection that matters, and failing the run would paint
+            # every waiting-for-review PR red — the state most PRs are in most of the
+            # time. The next event re-runs this and tries again.
+            if ! stamp_review_gate pending "Waiting for a review pass on ${head_sha:0:10}"; then
+              echo "Could not update the '$REVIEW_GATE_CONTEXT' status for $head_sha."
+            fi
             echo "Leaving auto-merge disabled. This workflow re-runs when a review or comment lands;"
             echo "apply the '$OVERRIDE_LABEL' label to arm without a review pass."
             exit 0
+          fi
+
+          # Cleared: stamp BEFORE the already-armed exit below, so every path that
+          # accepts this head also records that acceptance on the head itself. A PR
+          # armed by an earlier run must still end up with the context, or the required
+          # check would block a merge this gate has already approved.
+          if ! stamp_review_gate success "Review gate cleared for ${head_sha:0:10}"; then
+            # Loud, unlike the pending case: without the context a required check has
+            # nothing to satisfy it, so the PR silently stops merging. Not withdrawing
+            # the arm — the evidence held, so the arm is legitimate; only the backstop
+            # is missing, and a queued run will re-stamp it.
+            echo "Could not post the '$REVIEW_GATE_CONTEXT' status for $head_sha."
+            echo "The verdict is not recorded on the head, so a required '$REVIEW_GATE_CONTEXT'"
+            echo "check has nothing to satisfy it. Failing so this is visible."
+            exit 1
           fi
 
           if [[ "$auto_merge_enabled" == "true" ]]; then
@@ -352,6 +532,10 @@ jobs:
           evaluate_evidence
           if [[ "$reviewed" != "true" ]]; then
             echo "Evidence changed while evaluating; not arming."
+            # Take the stamp back with it — this sha was marked cleared moments ago.
+            if ! stamp_review_gate pending "Review evidence for ${head_sha:0:10} was withdrawn"; then
+              echo "Could not withdraw the '$REVIEW_GATE_CONTEXT' status for $head_sha."
+            fi
             exit 0
           fi
 
@@ -392,6 +576,9 @@ jobs:
           if [[ "$reviewed" != "true" ]]; then
             echo "Evidence was withdrawn during arming; disabling auto-merge again."
             gh pr merge "$pr_ref" --disable-auto
+            if ! stamp_review_gate pending "Review evidence for ${head_sha:0:10} was withdrawn"; then
+              echo "Could not withdraw the '$REVIEW_GATE_CONTEXT' status for $head_sha."
+            fi
             exit 1
           fi
           echo "Evidence still holds after arming $head_sha."


### PR DESCRIPTION
Brings this repository to the hardened copy that now runs on
ProspectOre/BiteVote main, where the review gate has been proven end to end:

- an unreadable branch-protection response fails the run loudly instead of
  degrading to "no required checks", which had made the gate a silent,
  permanent never-arm wherever AUTO_MERGE_PAT was unset
- the workflow_dispatch input is required, so manual dispatch is usable
- the self-hosted fallback asks for `mbp`, the one label the whole runner
  fleet carries, rather than a label only one repository has
- the override label and finding dispositions are both authorized by RESOLVED
  repository permission (admin or write), not by author_association
- the verdict is stamped on the head it covers as the `review-gate` commit
  status, so enforcement outlives the run and a later push cannot inherit it
- `review-gate` is excluded from the count of required CI checks, so the gate
  cannot satisfy the CI precondition it sits behind
- the status write authenticates with github.token, the token the workflow
  permissions actually govern, rather than the operator-provided PAT

## Sequencing — read before touching branch protection

This file stamps a per-head commit status, context `review-gate`, and that context is the enforcement backstop: a commit that has not been reviewed simply has no status, so GitHub blocks the merge itself rather than this workflow racing to withdraw an arm.

**`review-gate` must NOT be added to this repository's required status checks until all three hold:**

1. this PR is merged, so something exists to post the context (requiring it first wedges every PR — nothing would ever satisfy it);
2. `AUTO_MERGE_PAT` is provisioned, since the branch-protection read needs repository Administration (read), which `GITHUB_TOKEN` cannot be granted at all — without it the run exits before stamping;
3. runner routing is verified for this repository — either working GitHub-hosted Linux, or `USE_HOSTED_RUNNERS`/`USE_HOSTED_LINUX` set to `false` with a self-hosted runner carrying the `mbp` label.

A fourth condition is worth checking while you are there: the gate refuses to arm unless the base branch already requires at least one REAL CI check, and `review-gate` deliberately does not count toward that. A repository whose only required check is `review-gate` will never auto-merge anything.

No branch-protection changes are made by this PR.