### PR TITLE
Finalize Matic 0.3.0 release documentation

### DIFF
--- a/docs/firmware-compatibility.md
+++ b/docs/firmware-compatibility.md
@@ -21,7 +21,7 @@ separates an observed update from verified compatibility.
 
 | Firmware | First observed | Integration | Status | Evidence | Changes or capabilities |
 | --- | --- | --- | --- | --- | --- |
-| [v169.9](firmware-versions/v169.md) | 2026-07-27 | 0.3.0 candidate | Control verified | Live on HA 2026.7.4; protocol 25; snapshot 28 populated / 12 empty / 0 failed; no endpoint availability changes | Full local map, pose, rooms, telemetry, and update state remained available; quick and standard coverage, all three cleaning modes, complete saved-plan handoff, both intelligent-stop branches, and persisted custom-area cleaning passed live without false credit |
+| [v169.9](firmware-versions/v169.md) | 2026-07-27 | 0.3.0 | Control verified | Live on HA 2026.7.4; protocol 25; snapshot 28 populated / 12 empty / 0 failed; no endpoint availability changes | Full local map, pose, rooms, telemetry, and update state remained available; quick and standard coverage, all three cleaning modes, complete saved-plan handoff, both intelligent-stop branches, and persisted custom-area cleaning passed live without false credit |
 | [v168.11](firmware-versions/v168.md) | 2026-07-20 | 0.2.0–0.2.3 | Core read verified | Live on HA 2026.7.2; protocol 25; automatic baseline snapshot 28 populated / 12 empty / 0 failed; selected stop/dock/room-plan paths later exercised | Uploader-state decoder fix released and live-confirmed; robot-side stream resets handled as transport noise; complete control matrix remains pending |
 
 An empty or pending entry is not a compatibility claim. Synthetic tests show

--- a/docs/firmware-versions/v169.md
+++ b/docs/firmware-versions/v169.md
@@ -5,7 +5,7 @@
 
 status: read and cleaning workflow matrix verified  
 first_observed_pacific: 2026-07-27  
-integration_version: 0.3.0 candidate  
+integration_version: 0.3.0<br>
 home_assistant_version: 2026.7.4  
 protocol_version: 25
 

--- a/docs/release-notes-0.3.0.md
+++ b/docs/release-notes-0.3.0.md
@@ -1,6 +1,6 @@
 # Release notes — 0.3.0
 
-Status: local release candidate — not published
+Released: 2026-07-29
 
 ## Summary
 
@@ -144,4 +144,12 @@ Status: local release candidate — not published
 
 ## Verification posture
 
-The unpublished candidate passes 866 Python tests / 8,015 statements at 100% coverage, 38 browser tests, strict typing, lint/format, privacy, exact-tree HACS and Hassfest, artifact parity, and clean-wheel import. Live Safari covered the map lifecycle. Real-robot runs covered both coverage levels, all three cleaning modes, a two-room no-dock handoff, both intelligent-stop branches, and persisted custom-area cleaning with fail-closed credit. HAOS reauthentication was exercised by forcing an authentication failure, removing the stale Bluetooth bond, recovering from expired and rejected passkeys, issuing and verifying a fresh credential, and restarting Core cleanly. Reconfigure exposes address updates and explicit Home Assistant re-pairing as distinct operations. Re-pairing replaces Home Assistant's saved credential; it does not claim robot-side revocation, because the tested Matic app exposes no individual credential removal control. Post-passkey progress follows the terminal pairing task directly, and BlueZ agent cleanup is bounded so successful setup cannot remain behind an indefinite progress dialog. Live Container Bluetooth proof and publishing remain open.
+The release passes 866 Python tests / 8,015 statements at 100% coverage, 38 browser tests, strict typing, lint/format, privacy, exact-tree HACS and Hassfest, artifact parity, and clean-wheel import. Live Safari covered the map lifecycle. Real-robot runs covered both coverage levels, all three cleaning modes, a two-room no-dock handoff, both intelligent-stop branches, and persisted custom-area cleaning with fail-closed credit. HAOS reauthentication was exercised by forcing an authentication failure, removing the stale Bluetooth bond, recovering from expired and rejected passkeys, issuing and verifying a fresh credential, and restarting Core cleanly. Reconfigure exposes address updates and explicit Home Assistant re-pairing as distinct operations. Re-pairing replaces Home Assistant's saved credential; it does not claim robot-side revocation, because the tested Matic app exposes no individual credential removal control. Post-passkey progress follows the terminal pairing task directly, and BlueZ agent cleanup is bounded so successful setup cannot remain behind an indefinite progress dialog. Home Assistant Container pairing has synthetic coverage and documented host D-Bus/Bluetooth requirements, but was not separately exercised with a physical adapter for this release.
+
+## Upgrading from 0.2.3
+
+Install 0.3.0 through HACS and restart Home Assistant. Existing config entries,
+plans, custom areas, and room history are preserved; re-pairing is not required.
+The administrator-only **Matic Map** panel appears after restart. The private
+photographic camera remains disabled by default and can be enabled from the
+robot's device page when needed.


### PR DESCRIPTION
## Summary

- mark 0.3.0 as released and align the verified firmware records
- document the supported upgrade path from 0.2.3
- state the Home Assistant Container Bluetooth validation boundary explicitly

## Validation

- 54 release, packaging, artifact, and public-tree tests
- Ruff lint and formatting
- strict MyPy
- public-tree privacy check
- wheel and source archive parity
- clean-wheel import
