### PR TITLE
Add Heavy Duty coverage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ and the integration is covered by automated tests.
 The integration adds Home Assistant-native planning and automation:
 
 - **Saved cleaning plans.** Named, reusable plans with a per-room cleaning
-  mode and coverage level, include toggles, and drag-orderable room lists,
+  mode and Quick, Optimal, or Heavy Duty coverage, include toggles, and
+  drag-orderable room lists,
   managed alongside custom areas in the Matic Map **Cleaning** workspace. Each plan can stop
   immediately or finish a sufficiently progressed current room without
   starting the next one. During an uninterrupted plan, the next room starts

--- a/custom_components/matic_robot/__init__.py
+++ b/custom_components/matic_robot/__init__.py
@@ -99,7 +99,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: MaticConfigEntry) -> boo
                 entry.options.get(CONF_CLEANING_MODE, CleaningMode.BOTH)
             ),
             coverage_setting=CoverageSetting(
-                entry.options.get(CONF_COVERAGE_SETTING, CoverageSetting.STANDARD)
+                entry.options.get(CONF_COVERAGE_SETTING, CoverageSetting.OPTIMAL)
             ),
             firmware_tracker=firmware_tracker,
         )

--- a/custom_components/matic_robot/client/commands.py
+++ b/custom_components/matic_robot/client/commands.py
@@ -30,7 +30,16 @@ class CoverageSetting(StrEnum):
     """Supported coverage passes displayed by the Matic app."""
 
     QUICK = "quick"
-    STANDARD = "standard"
+    OPTIMAL = "standard"
+    HEAVY_DUTY = "heavy_duty"
+    STANDARD = OPTIMAL  # Backward-compatible Python alias.
+
+
+_COVERAGE_SETTING_VALUES = {
+    CoverageSetting.HEAVY_DUTY: 0,
+    CoverageSetting.OPTIMAL: 1,
+    CoverageSetting.QUICK: 2,
+}
 
 
 class HermesConnectionKind(StrEnum):
@@ -88,7 +97,7 @@ def encode_coverage_command(
     partition_id: str,
     region_ids: Sequence[str],
     cleaning_mode: CleaningMode = CleaningMode.BOTH,
-    coverage_setting: CoverageSetting = CoverageSetting.STANDARD,
+    coverage_setting: CoverageSetting = CoverageSetting.OPTIMAL,
     ordered: bool = False,
     command_id_factory: Callable[[], UUID] = uuid4,
 ) -> bytes:
@@ -104,10 +113,7 @@ def encode_coverage_command(
 
     partition_id = str(UUID(partition_id))
     normalized_regions = tuple(str(UUID(value)) for value in region_ids)
-    setting_value = {
-        CoverageSetting.STANDARD: 1,
-        CoverageSetting.QUICK: 2,
-    }[coverage_setting]
+    setting_value = _COVERAGE_SETTING_VALUES[coverage_setting]
     specs = _coverage_specs(cleaning_mode, setting_value)
     goal_field = 1 if ordered else 2
     goals = b"".join(
@@ -138,7 +144,7 @@ def encode_custom_coverage_command(
     mission_id: int,
     circles: Sequence[tuple[float, float, float]],
     cleaning_mode: CleaningMode = CleaningMode.BOTH,
-    coverage_setting: CoverageSetting = CoverageSetting.STANDARD,
+    coverage_setting: CoverageSetting = CoverageSetting.OPTIMAL,
     command_id_factory: Callable[[], UUID] = uuid4,
 ) -> bytes:
     """Encode an official-app-compatible drawn-circle coverage command.
@@ -165,10 +171,7 @@ def encode_custom_coverage_command(
             raise ValueError("circle radius must be between 0.05 and 2.5 meters")
         normalized.append((x, y, radius))
 
-    setting_value = {
-        CoverageSetting.STANDARD: 1,
-        CoverageSetting.QUICK: 2,
-    }[coverage_setting]
+    setting_value = _COVERAGE_SETTING_VALUES[coverage_setting]
     custom_partition_id = str(command_id_factory())
     circles_message = b"".join(
         _field(

--- a/custom_components/matic_robot/config_flow.py
+++ b/custom_components/matic_robot/config_flow.py
@@ -1109,7 +1109,7 @@ class MaticRobotOptionsFlow(config_entries.OptionsFlow):
                 vol.Required(
                     "coverage_setting",
                     default=defaults.get(
-                        "coverage_setting", CoverageSetting.STANDARD.value
+                        "coverage_setting", CoverageSetting.OPTIMAL.value
                     ),
                 ): self._select(
                     [value.value for value in CoverageSetting],
@@ -1143,7 +1143,7 @@ class MaticRobotOptionsFlow(config_entries.OptionsFlow):
             ),
             "cleaning_mode": values.get("cleaning_mode", CleaningMode.VACUUM.value),
             "coverage_setting": values.get(
-                "coverage_setting", CoverageSetting.STANDARD.value
+                "coverage_setting", CoverageSetting.OPTIMAL.value
             ),
         }
 

--- a/custom_components/matic_robot/coordinator.py
+++ b/custom_components/matic_robot/coordinator.py
@@ -67,7 +67,7 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
         config_entry: ConfigEntry,
         *,
         cleaning_mode: CleaningMode = CleaningMode.BOTH,
-        coverage_setting: CoverageSetting = CoverageSetting.STANDARD,
+        coverage_setting: CoverageSetting = CoverageSetting.OPTIMAL,
         firmware_tracker: FirmwareTracker | None = None,
     ) -> None:
         super().__init__(

--- a/custom_components/matic_robot/manifest.json
+++ b/custom_components/matic_robot/manifest.json
@@ -24,7 +24,7 @@
     "numpy==2.3.2",
     "protobuf>=6"
   ],
-  "version": "0.3.0",
+  "version": "0.3.1",
   "zeroconf": [
     "_matic_hermes._tcp.local."
   ]

--- a/custom_components/matic_robot/matic_map_studio.js
+++ b/custom_components/matic_robot/matic_map_studio.js
@@ -3896,7 +3896,7 @@ class MaticMapStudio extends HTMLElement {
                 <label class="area-name-label">${text("area_name", "Area name")}<input class="area-name" maxlength="128" autocomplete="off"></label>
                 <div class="area-settings">
                   <label>${text("cleaning_mode", "Cleaning mode")}<select class="area-mode"><option value="vacuum">${text("vacuum", "Vacuum")}</option><option value="mop">${text("mop", "Mop")}</option><option value="vacuum_and_mop">${text("vacuum_and_mop", "Vacuum + mop")}</option></select></label>
-                  <label>${text("coverage", "Coverage")}<select class="area-coverage"><option value="quick">${text("quick", "Quick")}</option><option value="standard">${text("standard", "Standard")}</option></select></label>
+                  <label>${text("coverage", "Coverage")}<select class="area-coverage"><option value="quick">${text("quick", "Quick")}</option><option value="standard">${text("standard", "Optimal")}</option><option value="heavy_duty">${text("heavy_duty", "Heavy Duty")}</option></select></label>
                 </div>
                 <div class="area-actions"><span class="area-feedback" role="status" aria-live="polite" aria-atomic="true"></span><button class="area-delete" hidden>${text("area_delete", "Delete")}</button><button class="area-run" hidden>${text("area_run", "Clean now")}</button><button class="area-save">${text("area_save", "Save area")}</button></div>
               </div>

--- a/custom_components/matic_robot/room_plan_editor.js
+++ b/custom_components/matic_robot/room_plan_editor.js
@@ -295,7 +295,8 @@ class MaticRoomPlanEditor extends HTMLElement {
             row.coverage_setting,
             [
               { value: "quick", label: this._localize("quick", "Quick") },
-              { value: "standard", label: this._localize("standard", "Standard") },
+              { value: "standard", label: this._localize("standard", "Optimal") },
+              { value: "heavy_duty", label: this._localize("heavy_duty", "Heavy Duty") },
             ],
             (coverage_setting) => this._update(row.room_id, { coverage_setting }),
           ),

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -142,9 +142,9 @@ SAVED_ROOM_SCHEMA = vol.Schema(
         vol.Optional("cleaning_mode", default=CleaningMode.BOTH.value): vol.In(
             [value.value for value in CleaningMode]
         ),
-        vol.Optional(
-            "coverage_setting", default=CoverageSetting.STANDARD.value
-        ): vol.In([value.value for value in CoverageSetting]),
+        vol.Optional("coverage_setting", default=CoverageSetting.OPTIMAL.value): vol.In(
+            [value.value for value in CoverageSetting]
+        ),
     }
 )
 

--- a/custom_components/matic_robot/services.yaml
+++ b/custom_components/matic_robot/services.yaml
@@ -18,7 +18,7 @@ clean:
       selector:
         select:
           translation_key: coverage_setting
-          options: [quick, standard]
+          options: [quick, standard, heavy_duty]
     ordered:
       default: false
       selector:
@@ -41,7 +41,7 @@ clean_area:
       selector:
         select:
           translation_key: coverage_setting
-          options: [quick, standard]
+          options: [quick, standard, heavy_duty]
 
 intelligent_clean:
   target: *vacuum_target

--- a/custom_components/matic_robot/slam_scene.py
+++ b/custom_components/matic_robot/slam_scene.py
@@ -624,7 +624,7 @@ class MaticAreasView(HomeAssistantView):
                         "cleaning_mode", CleaningMode.VACUUM.value
                     ),
                     "coverage_setting": area.get(
-                        "coverage_setting", CoverageSetting.STANDARD.value
+                        "coverage_setting", CoverageSetting.OPTIMAL.value
                     ),
                     "status": status.value,
                 }
@@ -764,7 +764,7 @@ class MaticPlansView(HomeAssistantView):
                         room.get("cleaning_mode", CleaningMode.VACUUM.value)
                     ),
                     "coverage_setting": str(
-                        room.get("coverage_setting", CoverageSetting.STANDARD.value)
+                        room.get("coverage_setting", CoverageSetting.OPTIMAL.value)
                     ),
                 }
                 for room in raw_rooms

--- a/custom_components/matic_robot/strings.json
+++ b/custom_components/matic_robot/strings.json
@@ -99,10 +99,11 @@
     "plan_workspace_selected": "Default plan updated",
     "plan_workspace_started": "Plan started",
     "plan_workspace_unavailable": "Plans are unavailable",
+    "heavy_duty": "Heavy Duty",
     "quick": "Quick",
     "redo": "Redo",
     "room_editor_intro": "Turn on rooms to include them. Drag or use the arrows to set the cleaning order.",
-    "standard": "Standard",
+    "standard": "Optimal",
     "undo": "Undo",
     "vacuum": "Vacuum",
     "vacuum_and_mop": "Vacuum + mop",
@@ -394,7 +395,7 @@
       },
       "add_plan": {
         "title": "Create a cleaning plan",
-        "description": "Name the plan, pick how it runs, then turn on any of the robot's {room_count} rooms — all settings save together on this screen. Every room starts off; included rooms default to Vacuum and Standard.",
+        "description": "Name the plan, pick how it runs, then turn on any of the robot's {room_count} rooms — all settings save together on this screen. Every room starts off; included rooms default to Vacuum and Optimal.",
         "data": {
           "name": "Plan name",
           "run_behavior": "Cleaning order",
@@ -465,8 +466,9 @@
     },
     "coverage_setting": {
       "options": {
+        "heavy_duty": "Heavy Duty",
         "quick": "Quick",
-        "standard": "Standard"
+        "standard": "Optimal"
       }
     },
     "run_behavior": {
@@ -581,8 +583,9 @@
       "coverage_setting": {
         "name": "Default coverage",
         "state": {
+          "heavy_duty": "Heavy Duty",
           "quick": "Quick",
-          "standard": "Standard"
+          "standard": "Optimal"
         }
       },
       "saved_cleaning_plan": {

--- a/custom_components/matic_robot/translations/en.json
+++ b/custom_components/matic_robot/translations/en.json
@@ -99,10 +99,11 @@
     "plan_workspace_selected": "Default plan updated",
     "plan_workspace_started": "Plan started",
     "plan_workspace_unavailable": "Plans are unavailable",
+    "heavy_duty": "Heavy Duty",
     "quick": "Quick",
     "redo": "Redo",
     "room_editor_intro": "Turn on rooms to include them. Drag or use the arrows to set the cleaning order.",
-    "standard": "Standard",
+    "standard": "Optimal",
     "undo": "Undo",
     "vacuum": "Vacuum",
     "vacuum_and_mop": "Vacuum + mop",
@@ -394,7 +395,7 @@
       },
       "add_plan": {
         "title": "Create a cleaning plan",
-        "description": "Name the plan, pick how it runs, then turn on any of the robot's {room_count} rooms — all settings save together on this screen. Every room starts off; included rooms default to Vacuum and Standard.",
+        "description": "Name the plan, pick how it runs, then turn on any of the robot's {room_count} rooms — all settings save together on this screen. Every room starts off; included rooms default to Vacuum and Optimal.",
         "data": {
           "name": "Plan name",
           "run_behavior": "Cleaning order",
@@ -465,8 +466,9 @@
     },
     "coverage_setting": {
       "options": {
+        "heavy_duty": "Heavy Duty",
         "quick": "Quick",
-        "standard": "Standard"
+        "standard": "Optimal"
       }
     },
     "run_behavior": {
@@ -581,8 +583,9 @@
       "coverage_setting": {
         "name": "Default coverage",
         "state": {
+          "heavy_duty": "Heavy Duty",
           "quick": "Quick",
-          "standard": "Standard"
+          "standard": "Optimal"
         }
       },
       "saved_cleaning_plan": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,8 @@ the integration so instructions and behavior stay aligned with each release.
   discovery, passkey, room-mapping, firmware, and Bluetooth constraints.
 - [Firmware compatibility](firmware-compatibility.md) — Track observed robot
   versions, validation status, regressions, and newly discovered capabilities.
+- [Release notes — 0.3.1](release-notes-0.3.1.md) — Quick, Optimal, and Heavy
+  Duty coverage for plans, custom areas, entities, and actions
 - [Release notes — 0.3.0](release-notes-0.3.0.md) — Private 3D/2D map workspace
   Map Studio with an integrated photo-backed cleaning-area workspace
 - [Release notes — 0.2.3](release-notes-0.2.3.md) — Room-to-room plans and

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -55,8 +55,10 @@ would invert the meaning and display a fully charged robot as `Low`.
 ## Complete cleaning action
 
 `matic_robot.clean` supports any room subset or sequence,
-`vacuum`/`mop`/`vacuum_and_mop`, quick/standard coverage, and
-ordered/unordered execution. Omitted rooms clean the whole floor; room names
+`vacuum`/`mop`/`vacuum_and_mop`, Quick/Optimal/Heavy Duty coverage, and
+ordered/unordered execution. The YAML values are `quick`, `standard`, and
+`heavy_duty`; `standard` remains stable for compatibility while the UI uses
+Matic's current Optimal label. Omitted rooms clean the whole floor; room names
 and stable room IDs are both accepted.
 
 ```yaml
@@ -79,7 +81,7 @@ rooms are selected until the user chooses them:
 1. Name the plan and choose its default cleaning order.
 2. Review the vertical list of mapped rooms directly underneath.
 3. Leave unwanted rooms off; turn on rooms to reveal mode and coverage
-   dropdowns, defaulting to Vacuum and Standard.
+   dropdowns, defaulting to Vacuum and Optimal.
 4. Drag rooms or use arrow buttons to save the exact top-to-bottom order.
 5. Optionally enable **Finish the current room when stopping** and choose its
    estimated progress threshold.

--- a/docs/firmware-endpoint-map.md
+++ b/docs/firmware-endpoint-map.md
@@ -81,7 +81,7 @@ credentials, arbitrary names, and raw payload output are deliberately excluded.
 | --- | --- | --- |
 | `user_data` | Local client identity, timezone and connection kind | Internal session setup |
 | `user_command` | Stop, pause, resume, dock | Vacuum actions and `send_command` |
-| `user_command` | Full-floor/room coverage and official drawn-circle custom coverage; vacuum, mop or both; quick/standard; ordered/unordered | Vacuum start/Area/segment cleaning; `matic_robot.clean`; `matic_robot.clean_area`; saved plans and areas |
+| `user_command` | Full-floor/room coverage and official drawn-circle custom coverage; vacuum, mop or both; Quick/Optimal/Heavy Duty; ordered/unordered | Vacuum start/Area/segment cleaning; `matic_robot.clean`; `matic_robot.clean_area`; saved plans and areas |
 | `child_lock_enabled_command` | Boolean | Child-lock switch |
 | `petwaste_enabled_command` | Boolean | Pet-waste-avoidance switch |
 | `voice_enabled_command` | Boolean | Voice-assistant switch |

--- a/docs/release-notes-0.3.1.md
+++ b/docs/release-notes-0.3.1.md
@@ -1,0 +1,41 @@
+# Release notes — 0.3.1
+
+Released: 2026-07-29
+
+## Summary
+
+0.3.1 adds Matic's complete vacuum coverage choices to Home Assistant. Saved
+plans, custom cleaning areas, the default coverage entity, and cleaning actions
+now offer **Quick**, **Optimal**, and **Heavy Duty** using the same names as the
+official app.
+
+## Coverage compatibility
+
+- Existing `standard` values remain valid and now display as **Optimal**. Saved
+  plans, custom areas, automations, duration history, and entity state migrate
+  without changes.
+- New Heavy Duty selections use `heavy_duty` in action data and stored plan or
+  area settings.
+- Room cleaning and photo-map custom areas share the same verified encoding, so
+  coverage behavior remains consistent across both workflows.
+
+## Protocol and live verification
+
+Matic's native app encoder identified Heavy Duty as the legacy
+`DeprecatedDeep` protocol setting with wire value `0`. The implementation is
+guarded by a byte-for-byte synthetic fixture containing no robot or household
+data.
+
+A bounded Heavy Duty vacuum run was exercised on a real robot. It left the
+dock, navigated into the selected Hallway, accepted stop and dock commands, and
+returned to the charger without a robot error.
+
+The release passes 868 Python tests / 8,018 statements at 100% coverage, 38
+browser tests, strict typing, lint and format checks, the public-tree privacy
+gate, artifact parity, and clean-wheel import.
+
+## Upgrading from 0.3.0
+
+Install 0.3.1 through HACS and restart Home Assistant. Existing entries, plans,
+custom areas, automations, and cleaning history are preserved. Re-pairing is
+not required.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "matic-home-assistant"
-version = "0.3.0"
+version = "0.3.1"
 description = "Unofficial local-only Home Assistant integration for Matic robot vacuums"
 readme = "README.md"
 license = "MIT"

--- a/tests/browser/ui.spec.mjs
+++ b/tests/browser/ui.spec.mjs
@@ -499,6 +499,7 @@ test.describe("map studio", () => {
       editor.value = editor.value.map((room, index) => ({
         ...room,
         included: index === 0,
+        coverage_setting: index === 0 ? "heavy_duty" : room.coverage_setting,
       }));
       editor.dispatchEvent(new CustomEvent("value-changed", {
         detail: { value: editor.value },
@@ -521,7 +522,7 @@ test.describe("map studio", () => {
         rooms: [{
           room: "synthetic-kitchen",
           cleaning_mode: "vacuum",
-          coverage_setting: "standard",
+          coverage_setting: "heavy_duty",
         }],
       }),
       { entity_id: "vacuum.synthetic" },
@@ -543,7 +544,7 @@ test.describe("map studio", () => {
     await expect(studio.locator(".area-settings")).toBeVisible();
     await expect(studio.locator(".area-settings label")).toHaveText([
       "Cleaning modeVacuumMopVacuum + mop",
-      "CoverageQuickStandard",
+      "CoverageQuickOptimalHeavy Duty",
     ]);
     expect(await studio.locator(".area-detail").evaluate((detail) => {
       const map = detail.querySelector("ha-selector-matic-area")
@@ -553,6 +554,7 @@ test.describe("map studio", () => {
     })).toBeGreaterThan(0.95);
     await studio.locator(".area-new").click();
     await studio.locator(".area-name").fill("New area");
+    await studio.locator(".area-coverage").selectOption("heavy_duty");
     await studio.locator("ha-selector-matic-area").evaluate((editor) => {
       editor.value = [{ x: 0.5, y: 0.5, radius: 0.35 }];
       editor.dispatchEvent(new CustomEvent("value-changed", {
@@ -572,7 +574,7 @@ test.describe("map studio", () => {
       name: "New area",
       circles: [{ x: 0.5, y: 0.5, radius: 0.35 }],
       cleaning_mode: "vacuum",
-      coverage_setting: "standard",
+      coverage_setting: "heavy_duty",
     });
 
     await studio.locator(".area-run").click();

--- a/tests/test_api_paths.py
+++ b/tests/test_api_paths.py
@@ -1167,7 +1167,7 @@ async def test_command_wrappers_encode_and_route(monkeypatch) -> None:
         ),
         [(0.0, 0.0, 0.35)],
         cleaning_mode=CleaningMode.VACUUM,
-        coverage_setting=CoverageSetting.QUICK,
+        coverage_setting=CoverageSetting.HEAVY_DUTY,
     )
     assert client._async_send_channel_payload.await_count == 3
     assert all(

--- a/tests/test_coverage_commands.py
+++ b/tests/test_coverage_commands.py
@@ -36,6 +36,13 @@ OFFICIAL_CUSTOM_VACUUM = b64decode(
     "euYICuMIGuAIEgQSAgoAGgUVKgAAACqgCBKBATIiChYSFBISCd1Oxzk1tK0UEYXsFsjReLyMGggIARAAIAAoADpbChYKFBISCapKqqqqqqqqEaqqqqqqqqqKEj0aOxI5ChEKCg0AAADAFQAAgL8VzczMPgoRCgoNAAAAwBWamZm/Fc3MzD4KEQoKDQAAAMAVMzOzvxXNzMw+GgISABKBATIiChYSFBISCTVGSLFb+nrWEd6scAyWIIunGggIARAAIAAoATpbChYKFBISCapKqqqqqqqqEaqqqqqqqqqKEj0aOxI5ChEKCg0AAADAFQAAgL8VzczMPgoRCgoNAAAAwBWamZm/Fc3MzD4KEQoKDQAAAMAVMzOzvxXNzMw+GgISABKBATIiChYSFBISCQZAPtW9kpVVEXueU1JRS2mFGggIARAAIAAoAjpbChYKFBISCapKqqqqqqqqEaqqqqqqqqqKEj0aOxI5ChEKCg0AAADAFQAAgL8VzczMPgoRCgoNAAAAwBWamZm/Fc3MzD4KEQoKDQAAAMAVMzOzvxXNzMw+GgISABKBATIiChYSFBISCWRIP9EONzD/EQ/5lKQf1jOTGggIARAAIAAoAzpbChYKFBISCapKqqqqqqqqEaqqqqqqqqqKEj0aOxI5ChEKCg0AAADAFQAAgL8VzczMPgoRCgoNAAAAwBWamZm/Fc3MzD4KEQoKDQAAAMAVMzOzvxXNzMw+GgISABKBATIiChYSFBISCXFL+5F1tCqBEdZjRE6sJymaGggIARABIAAoADpbChYKFBISCapKqqqqqqqqEaqqqqqqqqqKEj0aOxI5ChEKCg0AAADAFQAAgL8VzczMPgoRCgoNAAAAwBWamZm/Fc3MzD4KEQoKDQAAAMAVMzOzvxXNzMw+GgISABKBATIiChYSFBISCXFIFnKXyxerEdMmhjyf/KybGggIARABIAAoATpbChYKFBISCapKqqqqqqqqEaqqqqqqqqqKEj0aOxI5ChEKCg0AAADAFQAAgL8VzczMPgoRCgoNAAAAwBWamZm/Fc3MzD4KEQoKDQAAAMAVMzOzvxXNzMw+GgISABKBATIiChYSFBISCX5KFUloV6/fERLWXzJDcAKrGggIARABIAAoAjpbChYKFBISCapKqqqqqqqqEaqqqqqqqqqKEj0aOxI5ChEKCg0AAADAFQAAgL8VzczMPgoRCgoNAAAAwBWamZm/Fc3MzD4KEQoKDQAAAMAVMzOzvxXNzMw+GgISABKBATIiChYSFBISCf9L3S/p7FkwEfJgsD6Lt+6RGggIARABIAAoAzpbChYKFBISCapKqqqqqqqqEaqqqqqqqqqKEj0aOxI5ChEKCg0AAADAFQAAgL8VzczMPgoRCgoNAAAAwBWamZm/Fc3MzD4KEQoKDQAAAMAVMzOzvxXNzMw+GgISADIWEhQSEgk3Rd79CxMrFhFPEAAeY5kzqjoWChQSEgngQq4yRROC3RG3kczH3BUyiA=="
 )
 
+# Produced by Matic 1.167.0's native encoder from the same synthetic custom
+# area input as OFFICIAL_CUSTOM_VACUUM, with its DeprecatedDeep setting. The
+# current app presents this wire-compatible setting as Heavy Duty.
+OFFICIAL_CUSTOM_HEAVY_DUTY_VACUUM = b64decode(
+    "euYICuMIGuAIEgQSAgoAGgUVKgAAACqgCBKBATIiChYSFBISCb1EDEaIL1VmETswGOawfOWtGggIABAAIAAoADpbChYKFBISCapKqqqqqqqqEaqqqqqqqqqKEj0aOxI5ChEKCg0AAADAFQAAgL8VzczMPgoRCgoNAAAAwBWamZm/Fc3MzD4KEQoKDQAAAMAVMzOzvxXNzMw+GgISABKBATIiChYSFBISCSxEQjj5VndnEQNW352r2C2JGggIABAAIAAoATpbChYKFBISCapKqqqqqqqqEaqqqqqqqqqKEj0aOxI5ChEKCg0AAADAFQAAgL8VzczMPgoRCgoNAAAAwBWamZm/Fc3MzD4KEQoKDQAAAMAVMzOzvxXNzMw+GgISABKBATIiChYSFBISCWlAJYb/Pv7lEbkD9gpsYeitGggIABAAIAAoAjpbChYKFBISCapKqqqqqqqqEaqqqqqqqqqKEj0aOxI5ChEKCg0AAADAFQAAgL8VzczMPgoRCgoNAAAAwBWamZm/Fc3MzD4KEQoKDQAAAMAVMzOzvxXNzMw+GgISABKBATIiChYSFBISCSpNLh2juupNEaebZMHnwMywGggIABAAIAAoAzpbChYKFBISCapKqqqqqqqqEaqqqqqqqqqKEj0aOxI5ChEKCg0AAADAFQAAgL8VzczMPgoRCgoNAAAAwBWamZm/Fc3MzD4KEQoKDQAAAMAVMzOzvxXNzMw+GgISABKBATIiChYSFBISCb9HsSXRd94IEVp3o/UCGHmuGggIABABIAAoADpbChYKFBISCapKqqqqqqqqEaqqqqqqqqqKEj0aOxI5ChEKCg0AAADAFQAAgL8VzczMPgoRCgoNAAAAwBWamZm/Fc3MzD4KEQoKDQAAAMAVMzOzvxXNzMw+GgISABKBATIiChYSFBISCeZIzRhm0r7hEaPtZE2naCyoGggIABABIAAoATpbChYKFBISCapKqqqqqqqqEaqqqqqqqqqKEj0aOxI5ChEKCg0AAADAFQAAgL8VzczMPgoRCgoNAAAAwBWamZm/Fc3MzD4KEQoKDQAAAMAVMzOzvxXNzMw+GgISABKBATIiChYSFBISCUNPP2k2tFBnEXlYrX7BhGuXGggIABABIAAoAjpbChYKFBISCapKqqqqqqqqEaqqqqqqqqqKEj0aOxI5ChEKCg0AAADAFQAAgL8VzczMPgoRCgoNAAAAwBWamZm/Fc3MzD4KEQoKDQAAAMAVMzOzvxXNzMw+GgISABKBATIiChYSFBISCSVFiR+E71MlEab1SomDWk6dGggIABABIAAoAzpbChYKFBISCapKqqqqqqqqEaqqqqqqqqqKEj0aOxI5ChEKCg0AAADAFQAAgL8VzczMPgoRCgoNAAAAwBWamZm/Fc3MzD4KEQoKDQAAAMAVMzOzvxXNzMw+GgISADIWEhQSEgnESLEDH+YWTRGkpyQgdxbFmjoWChQSEglqTyOtqc2BrhFmJ12WbM7QgQ=="
+)
+
 
 def _coverage(payload: bytes) -> bytes:
     return first_bytes(first_bytes(first_bytes(payload, 15), 1), 3)
@@ -50,7 +57,23 @@ def _official_ids(payload: bytes) -> Iterator[UUID]:
     yield UUID(uuid_string(first_bytes(coverage, 7)))
 
 
-def test_standard_vacuum_matches_official_encoder_byte_for_byte() -> None:
+def _official_custom_ids(payload: bytes) -> Iterator[UUID]:
+    coverage = _coverage(payload)
+    goals = bytes_fields(first_bytes(coverage, 5), 2)
+    target = first_bytes(goals[0], 7)
+    yield UUID(uuid_string(first_bytes(first_bytes(target, 1), 1)))
+    for goal in goals:
+        yield UUID(uuid_string(first_bytes(first_bytes(goal, 6), 1)))
+    for field in (6, 7):
+        yield UUID(uuid_string(first_bytes(coverage, field)))
+
+
+def test_optimal_keeps_the_existing_standard_storage_value() -> None:
+    assert CoverageSetting.OPTIMAL.value == "standard"
+    assert CoverageSetting.STANDARD is CoverageSetting.OPTIMAL
+
+
+def test_optimal_vacuum_matches_official_encoder_byte_for_byte() -> None:
     ids = _official_ids(OFFICIAL_STANDARD_VACUUM)
 
     assert (
@@ -59,7 +82,7 @@ def test_standard_vacuum_matches_official_encoder_byte_for_byte() -> None:
             partition_id=PARTITION_ID,
             region_ids=[REGION_ID],
             cleaning_mode=CleaningMode.VACUUM,
-            coverage_setting=CoverageSetting.STANDARD,
+            coverage_setting=CoverageSetting.OPTIMAL,
             command_id_factory=lambda: next(ids),
         )
         == OFFICIAL_STANDARD_VACUUM
@@ -67,15 +90,7 @@ def test_standard_vacuum_matches_official_encoder_byte_for_byte() -> None:
 
 
 def test_custom_vacuum_matches_official_encoder_byte_for_byte() -> None:
-    coverage = _coverage(OFFICIAL_CUSTOM_VACUUM)
-    goals = bytes_fields(first_bytes(coverage, 5), 2)
-    target = first_bytes(goals[0], 7)
-    partition_id = UUID(uuid_string(first_bytes(first_bytes(target, 1), 1)))
-    ids = iter(
-        [partition_id]
-        + [UUID(uuid_string(first_bytes(first_bytes(goal, 6), 1))) for goal in goals]
-        + [UUID(uuid_string(first_bytes(coverage, field))) for field in (6, 7)]
-    )
+    ids = _official_custom_ids(OFFICIAL_CUSTOM_VACUUM)
 
     assert (
         encode_custom_coverage_command(
@@ -86,6 +101,21 @@ def test_custom_vacuum_matches_official_encoder_byte_for_byte() -> None:
             command_id_factory=lambda: next(ids),
         )
         == OFFICIAL_CUSTOM_VACUUM
+    )
+
+
+def test_heavy_duty_custom_vacuum_matches_official_encoder_byte_for_byte() -> None:
+    ids = _official_custom_ids(OFFICIAL_CUSTOM_HEAVY_DUTY_VACUUM)
+
+    assert (
+        encode_custom_coverage_command(
+            mission_id=42,
+            circles=((-2.0, -1.0, 0.4), (-2.0, -1.2, 0.4), (-2.0, -1.4, 0.4)),
+            cleaning_mode=CleaningMode.VACUUM,
+            coverage_setting=CoverageSetting.HEAVY_DUTY,
+            command_id_factory=lambda: next(ids),
+        )
+        == OFFICIAL_CUSTOM_HEAVY_DUTY_VACUUM
     )
 
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1120,13 +1120,13 @@ async def test_selects_update_next_clean_preferences(hass) -> None:
     )
 
     await mode.async_select_option(CleaningMode.VACUUM.value)
-    await coverage.async_select_option(CoverageSetting.QUICK.value)
+    await coverage.async_select_option(CoverageSetting.HEAVY_DUTY.value)
 
     assert mode.current_option == CleaningMode.VACUUM.value
-    assert coverage.current_option == CoverageSetting.QUICK.value
+    assert coverage.current_option == CoverageSetting.HEAVY_DUTY.value
     assert entry.options == {
         "cleaning_mode": CleaningMode.VACUUM.value,
-        "coverage_setting": CoverageSetting.QUICK.value,
+        "coverage_setting": CoverageSetting.HEAVY_DUTY.value,
     }
     mode.async_write_ha_state.assert_called_once()
     coverage.async_write_ha_state.assert_called_once()

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -85,7 +85,7 @@ def test_rooms_resolve_live_names_ids_and_individual_settings() -> None:
             {
                 "room": "Kitchen",
                 "cleaning_mode": "vacuum_and_mop",
-                "coverage_setting": "standard",
+                "coverage_setting": "heavy_duty",
             },
             {
                 "room_id": "room-study",
@@ -101,7 +101,7 @@ def test_rooms_resolve_live_names_ids_and_individual_settings() -> None:
     )
 
     assert rooms == [
-        CleaningRoom("room-kitchen", "Kitchen", "vacuum_and_mop", "standard"),
+        CleaningRoom("room-kitchen", "Kitchen", "vacuum_and_mop", "heavy_duty"),
         CleaningRoom("room-study", "Study", "vacuum", "quick"),
     ]
 

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -289,7 +289,7 @@ def test_plan_editor_is_a_single_room_matrix() -> None:
         assert "rooms" not in steps["add_plan"]["data"]
         assert "all settings save together" in steps["add_plan"]["description"]
         assert "Every room starts off" in steps["add_plan"]["description"]
-        assert "default to Vacuum and Standard" in steps["add_plan"]["description"]
+        assert "default to Vacuum and Optimal" in steps["add_plan"]["description"]
         assert "run_behavior" in steps["add_plan"]["data"]
         assert "room_editor" in steps["add_plan"]["data"]
         behavior = steps["add_plan"]["data_description"]["run_behavior"]
@@ -361,6 +361,16 @@ def test_user_copy_matches_pairing_and_plan_behavior() -> None:
         assert selects["coverage_setting"]["name"] == "Default coverage"
         assert selects["saved_cleaning_plan"]["name"] == "Default cleaning plan"
         assert selects["custom_cleaning_area"]["name"] == "Custom cleaning area"
+        assert translations["selector"]["coverage_setting"]["options"] == {
+            "heavy_duty": "Heavy Duty",
+            "quick": "Quick",
+            "standard": "Optimal",
+        }
+        assert selects["coverage_setting"]["state"] == {
+            "heavy_duty": "Heavy Duty",
+            "quick": "Quick",
+            "standard": "Optimal",
+        }
         assert (
             translations["entity"]["button"]["clean_selected_area"]["name"]
             == "Clean selected area"

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -28,7 +28,7 @@ def test_release_versions_and_links_are_consistent() -> None:
     hacs = json.loads((ROOT / "hacs.json").read_text())
     project = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]
 
-    assert manifest["version"] == "0.3.0"
+    assert manifest["version"] == "0.3.1"
     assert project["version"] == manifest["version"]
     assert hacs["homeassistant"] == "2026.7.0"
     assert manifest["documentation"].startswith("https://github.com/")

--- a/tests/test_room_plan_selector.py
+++ b/tests/test_room_plan_selector.py
@@ -23,7 +23,7 @@ def test_room_plan_selector_preserves_order_and_preferences() -> None:
             "room_id": "study",
             "included": True,
             "cleaning_mode": "mop",
-            "coverage_setting": "quick",
+            "coverage_setting": "heavy_duty",
         },
         {
             "room_id": "kitchen",

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -157,7 +157,7 @@ async def test_clean_action_routes_every_verified_preference() -> None:
             "entity_id": ["vacuum.test"],
             "rooms": ["Study", "Kitchen"],
             "cleaning_mode": "mop",
-            "coverage_setting": "quick",
+            "coverage_setting": "heavy_duty",
             "ordered": True,
         },
     )
@@ -176,7 +176,7 @@ async def test_clean_action_routes_every_verified_preference() -> None:
             "params": {
                 "rooms": ["Study", "Kitchen"],
                 "cleaning_mode": "mop",
-                "coverage": "quick",
+                "coverage": "heavy_duty",
                 "ordered": True,
             },
         },
@@ -234,7 +234,7 @@ async def test_clean_area_uses_only_private_saved_geometry(hass) -> None:
             {
                 "entity_id": ["vacuum.test"],
                 "area": "Litter box",
-                "coverage_setting": "quick",
+                "coverage_setting": "heavy_duty",
             }
         ),
     )
@@ -252,7 +252,7 @@ async def test_clean_area_uses_only_private_saved_geometry(hass) -> None:
         floor_plan,
         [(1.0, 2.0, 0.35)],
         cleaning_mode=CleaningMode.VACUUM,
-        coverage_setting=CoverageSetting.QUICK,
+        coverage_setting=CoverageSetting.HEAVY_DUTY,
     )
     coordinator.async_request_refresh.assert_awaited_once()
 


### PR DESCRIPTION
## Summary

- add Heavy Duty coverage to saved plans, custom areas, native entities, and cleaning actions
- align coverage labels with Matic's Quick, Optimal, and Heavy Duty names while preserving `standard` as Optimal's stored value
- bump the integration to 0.3.1 and add release and automation documentation

## Protocol evidence

Matic's native encoder identifies Heavy Duty as the legacy DeprecatedDeep setting with wire value `0`. A byte-for-byte synthetic fixture guards the encoding without containing robot or household data.

A bounded live Hallway vacuum run accepted Heavy Duty, entered the selected room, stopped, returned, and reached the charger without a robot error.

## Validation

- 868 Python tests; 8,018 statements at 100% coverage
- 38 Playwright browser tests
- Ruff lint and format
- strict MyPy
- public-tree privacy check
- 0.3.1 artifact parity
- clean-wheel import
