### PR TITLE
Release 0.3.2 with native mobile map interactions

### DIFF
--- a/.github/workflows/browser.yml
+++ b/.github/workflows/browser.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  chromium:
+  browser:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -24,5 +24,5 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
-      - run: npx playwright install --with-deps chromium
+      - run: npx playwright install --with-deps chromium webkit
       - run: npm run test:browser

--- a/custom_components/matic_robot/frontend.py
+++ b/custom_components/matic_robot/frontend.py
@@ -7,7 +7,9 @@ from hashlib import sha256
 from pathlib import Path
 
 from homeassistant.components import frontend
-from homeassistant.components.http import StaticPathConfig
+from homeassistant.components.http import (  # type: ignore[attr-defined,unused-ignore]
+    StaticPathConfig,
+)
 from homeassistant.core import HomeAssistant
 
 from .slam_scene import (

--- a/custom_components/matic_robot/manifest.json
+++ b/custom_components/matic_robot/manifest.json
@@ -24,7 +24,7 @@
     "numpy==2.3.2",
     "protobuf>=6"
   ],
-  "version": "0.3.1",
+  "version": "0.3.2",
   "zeroconf": [
     "_matic_hermes._tcp.local."
   ]

--- a/custom_components/matic_robot/matic_map_studio.js
+++ b/custom_components/matic_robot/matic_map_studio.js
@@ -267,6 +267,9 @@ class MaticMapStudio extends HTMLElement {
     this._drag = undefined;
     this._pinch = undefined;
     this._gesture = undefined;
+    this._lastTouchTap = undefined;
+    this._doubleTapZoom = undefined;
+    this._handledTouchDoubleTapAt = undefined;
     this._labelsVisible = true;
     this._preferencesIdentity = undefined;
     this._preferencesSaveTimer = undefined;
@@ -2246,7 +2249,7 @@ class MaticMapStudio extends HTMLElement {
     this._applyCamera(this._preset(view), animate);
   }
 
-  _applyCamera(target, animate = true) {
+  _applyCamera(target, animate = true, duration = 520) {
     this._cancelMotion();
     if (!animate || this._reducedMotion) {
       this._camera = { ...target };
@@ -2257,7 +2260,7 @@ class MaticMapStudio extends HTMLElement {
     const started = performance.now();
     this._camera.orthographic = target.orthographic;
     const step = (now) => {
-      const progress = maticClamp((now - started) / 520, 0, 1);
+      const progress = maticClamp((now - started) / duration, 0, 1);
       const eased = 1 - (1 - progress) ** 3;
       const yawDelta = maticAngleDelta(target.yaw - start.yaw);
       this._camera = {
@@ -2324,6 +2327,28 @@ class MaticMapStudio extends HTMLElement {
     };
   }
 
+  _elasticClamp(value, minimum, maximum, maximumOvershoot) {
+    if (value < minimum) {
+      return minimum - Math.min(maximumOvershoot, (minimum - value) * 0.24);
+    }
+    if (value > maximum) {
+      return maximum + Math.min(maximumOvershoot, (value - maximum) * 0.24);
+    }
+    return value;
+  }
+
+  _constrainCameraDistance(value, { elastic = false } = {}) {
+    const bounds = this._cameraDistanceBounds();
+    return elastic
+      ? this._elasticClamp(
+        value,
+        bounds.minimum,
+        bounds.maximum,
+        (bounds.maximum - bounds.minimum) * 0.08,
+      )
+      : maticClamp(value, bounds.minimum, bounds.maximum);
+  }
+
   _zoomPercentageBounds(home) {
     const distance = this._cameraDistanceBounds();
     return {
@@ -2353,11 +2378,28 @@ class MaticMapStudio extends HTMLElement {
     };
   }
 
-  _constrainCameraTarget(camera) {
+  _constrainCameraTarget(camera, { elastic = false } = {}) {
     const bounds = this._cameraTargetBounds();
-    camera.targetX = maticClamp(camera.targetX, -bounds.x, bounds.x);
-    camera.targetZ = maticClamp(camera.targetZ, -bounds.z, bounds.z);
+    camera.targetX = elastic
+      ? this._elasticClamp(camera.targetX, -bounds.x, bounds.x, bounds.x * 0.1)
+      : maticClamp(camera.targetX, -bounds.x, bounds.x);
+    camera.targetZ = elastic
+      ? this._elasticClamp(camera.targetZ, -bounds.z, bounds.z, bounds.z * 0.1)
+      : maticClamp(camera.targetZ, -bounds.z, bounds.z);
     return camera;
+  }
+
+  _settleCamera() {
+    const target = this._constrainCameraTarget({
+      ...this._camera,
+      distance: this._constrainCameraDistance(this._camera.distance),
+    });
+    const displacement = Math.max(
+      Math.abs(target.distance - this._camera.distance),
+      Math.abs(target.targetX - this._camera.targetX),
+      Math.abs(target.targetZ - this._camera.targetZ),
+    );
+    if (displacement > 0.0001) this._applyCamera(target, true, 220);
   }
 
   _isMouseWheel(event, deltaX, deltaY) {
@@ -2369,7 +2411,7 @@ class MaticMapStudio extends HTMLElement {
     return this._view === "three" ? 1.38 : Math.PI / 2 - 0.018;
   }
 
-  _panValues(camera, deltaX, deltaY) {
+  _panValues(camera, deltaX, deltaY, options = {}) {
     const viewport = this.shadowRoot.querySelector(".viewport");
     const worldPerPixel = camera.distance / Math.max(200, viewport.clientHeight) * 1.75;
     const rightX = Math.cos(camera.yaw);
@@ -2383,11 +2425,11 @@ class MaticMapStudio extends HTMLElement {
       targetZ: camera.targetZ
         - deltaX * worldPerPixel * rightZ
         + deltaY * worldPerPixel * forwardZ,
-    });
+    }, options);
   }
 
-  _panBy(deltaX, deltaY) {
-    const target = this._panValues(this._camera, deltaX, deltaY);
+  _panBy(deltaX, deltaY, options = {}) {
+    const target = this._panValues(this._camera, deltaX, deltaY, options);
     this._camera.targetX = target.targetX;
     this._camera.targetZ = target.targetZ;
     this._requestRender();
@@ -2413,7 +2455,7 @@ class MaticMapStudio extends HTMLElement {
           this._maximumPitch(),
         );
       } else {
-        this._panBy(velocityX * elapsed, velocityY * elapsed);
+        this._panBy(velocityX * elapsed, velocityY * elapsed, { elastic: true });
       }
       const decay = 0.9 ** (elapsed / 16);
       velocityX *= decay;
@@ -2423,6 +2465,7 @@ class MaticMapStudio extends HTMLElement {
         this._inertiaFrame = window.requestAnimationFrame(step);
       } else {
         this._inertiaFrame = undefined;
+        this._settleCamera();
       }
     };
     this._inertiaFrame = window.requestAnimationFrame(step);
@@ -2741,11 +2784,43 @@ class MaticMapStudio extends HTMLElement {
       } catch (_error) {
         return;
       }
+      const now = performance.now();
+      const lastTap = this._lastTouchTap;
+      const isDoubleTap = event.pointerType === "touch"
+        && this._pointers.size === 0
+        && lastTap
+        && now - lastTap.time <= 320
+        && Math.hypot(event.clientX - lastTap.x, event.clientY - lastTap.y) <= 28;
       this._pointers.set(event.pointerId, {
         x: event.clientX,
         y: event.clientY,
         pointerType: event.pointerType,
       });
+      if (isDoubleTap) {
+        const bounds = viewport.getBoundingClientRect();
+        const focused = this._panValues(
+          this._camera,
+          (bounds.left + bounds.width / 2 - event.clientX) * 0.55,
+          (bounds.top + bounds.height / 2 - event.clientY) * 0.55,
+        );
+        this._doubleTapZoom = {
+          pointerId: event.pointerId,
+          startX: event.clientX,
+          startY: event.clientY,
+          moved: false,
+          camera: {
+            ...this._camera,
+            targetX: focused.targetX,
+            targetZ: focused.targetZ,
+          },
+        };
+        this._handledTouchDoubleTapAt = now;
+        this._lastTouchTap = undefined;
+        this._drag = undefined;
+        viewport.classList.add("moving");
+        return;
+      }
+      if (lastTap && now - lastTap.time > 320) this._lastTouchTap = undefined;
       if (this._pointers.size === 1) {
         this._drag = {
           pointerId: event.pointerId,
@@ -2756,6 +2831,8 @@ class MaticMapStudio extends HTMLElement {
           lastTime: performance.now(),
           velocityX: 0,
           velocityY: 0,
+          startTime: now,
+          moved: 0,
           pointerType: event.pointerType,
           camera: { ...this._camera },
           mode: this._view === "top" || event.shiftKey || [1, 2].includes(event.button)
@@ -2764,6 +2841,8 @@ class MaticMapStudio extends HTMLElement {
         };
       } else if (this._pointers.size === 2) {
         const [first, second] = [...this._pointers.values()];
+        this._lastTouchTap = undefined;
+        this._doubleTapZoom = undefined;
         this._drag = undefined;
         this._pinch = {
           distance: Math.hypot(second.x - first.x, second.y - first.y),
@@ -2783,11 +2862,31 @@ class MaticMapStudio extends HTMLElement {
       this._pointers.set(
         event.pointerId,
         {
+          ...this._pointers.get(event.pointerId),
           x: sample.clientX,
           y: sample.clientY,
           pointerType: event.pointerType,
         },
       );
+      if (this._doubleTapZoom?.pointerId === event.pointerId) {
+        const gesture = this._doubleTapZoom;
+        const deltaY = sample.clientY - gesture.startY;
+        gesture.moved ||= Math.hypot(
+          sample.clientX - gesture.startX,
+          deltaY,
+        ) > 5;
+        this._camera = {
+          ...gesture.camera,
+          distance: this._constrainCameraDistance(
+            gesture.camera.distance * Math.exp(
+              maticClamp(deltaY * 0.009, -2.2, 2.2),
+            ),
+            { elastic: true },
+          ),
+        };
+        this._requestRender();
+        return;
+      }
       if (this._pinch && this._pointers.size >= 2) {
         const [first, second] = [...this._pointers.values()];
         const distance = Math.max(1, Math.hypot(second.x - first.x, second.y - first.y));
@@ -2795,10 +2894,9 @@ class MaticMapStudio extends HTMLElement {
         const centerX = (first.x + second.x) / 2;
         const centerY = (first.y + second.y) / 2;
         const start = this._pinch.camera;
-        this._camera.distance = maticClamp(
+        this._camera.distance = this._constrainCameraDistance(
           start.distance * this._pinch.distance / distance,
-          Math.max(0.3, this._radius * 0.08),
-          this._radius * 8,
+          { elastic: true },
         );
         this._camera.yaw = maticAngleDelta(
           start.yaw + maticAngleDelta(angle - this._pinch.angle),
@@ -2814,6 +2912,7 @@ class MaticMapStudio extends HTMLElement {
           start,
           centerX - this._pinch.centerX,
           0,
+          { elastic: true },
         );
         this._camera.targetX = panned.targetX;
         this._camera.targetZ = panned.targetZ;
@@ -2830,6 +2929,7 @@ class MaticMapStudio extends HTMLElement {
         drag.lastX = sample.clientX;
         drag.lastY = sample.clientY;
         drag.lastTime = now;
+        drag.moved = Math.max(drag.moved, Math.hypot(deltaX, deltaY));
         if (drag.mode === "orbit") {
           this._camera.yaw = maticAngleDelta(
             drag.camera.yaw + deltaX * 0.0045,
@@ -2840,7 +2940,12 @@ class MaticMapStudio extends HTMLElement {
             this._maximumPitch(),
           );
         } else {
-          const target = this._panValues(drag.camera, deltaX, deltaY);
+          const target = this._panValues(
+            drag.camera,
+            deltaX,
+            deltaY,
+            { elastic: true },
+          );
           this._camera.targetX = target.targetX;
           this._camera.targetZ = target.targetZ;
         }
@@ -2851,6 +2956,24 @@ class MaticMapStudio extends HTMLElement {
       if (!this._pointers.has(event.pointerId)) return;
       const drag = this._drag;
       const wasPinching = Boolean(this._pinch);
+      const wasDoubleTapZoom = this._doubleTapZoom?.pointerId === event.pointerId;
+      if (wasDoubleTapZoom) {
+        const gesture = this._doubleTapZoom;
+        this._doubleTapZoom = undefined;
+        if (!cancelled && !gesture.moved) {
+          const distance = this._cameraDistanceBounds();
+          this._applyCamera({
+            ...gesture.camera,
+            distance: maticClamp(
+              gesture.camera.distance / 1.6,
+              distance.minimum,
+              distance.maximum,
+            ),
+          });
+        } else if (!cancelled) {
+          this._settleCamera();
+        }
+      }
       this._pointers.delete(event.pointerId);
       this._pinch = undefined;
       const remaining = [...this._pointers.entries()][0];
@@ -2863,19 +2986,41 @@ class MaticMapStudio extends HTMLElement {
         lastTime: performance.now(),
         velocityX: 0,
         velocityY: 0,
+        startTime: performance.now(),
+        moved: 0,
+        fromPinch: wasPinching,
         pointerType: remaining[1].pointerType,
         camera: { ...this._camera },
         mode: this._view === "top" ? "pan" : "orbit",
       } : undefined;
       if (!remaining) {
         viewport.classList.remove("moving");
+        const isTap = !cancelled
+          && !wasPinching
+          && !wasDoubleTapZoom
+          && drag?.pointerType === "touch"
+          && !drag.fromPinch
+          && drag.moved <= 8
+          && performance.now() - drag.startTime <= 350;
+        this._lastTouchTap = isTap
+          ? {
+            time: performance.now(),
+            x: event.clientX,
+            y: event.clientY,
+          }
+          : undefined;
         if (
           !cancelled
           && !wasPinching
+          && !wasDoubleTapZoom
           && drag
           && drag.pointerType !== "mouse"
         ) {
           this._startInertia(drag.velocityX, drag.velocityY, drag.mode);
+        } else if (!cancelled && !wasDoubleTapZoom) {
+          this._settleCamera();
+        } else if (cancelled) {
+          this._settleCamera();
         }
       }
       if (viewport.hasPointerCapture(event.pointerId)) {
@@ -2926,6 +3071,10 @@ class MaticMapStudio extends HTMLElement {
     viewport.addEventListener("dblclick", (event) => {
       if (this._view === "rooms") return;
       event.preventDefault();
+      if (
+        this._handledTouchDoubleTapAt !== undefined
+        && performance.now() - this._handledTouchDoubleTapAt < 500
+      ) return;
       this._zoom(event.shiftKey ? 1 / 1.6 : 1.6);
     });
   }
@@ -2999,6 +3148,32 @@ class MaticMapStudio extends HTMLElement {
     if (!status) return;
     status.textContent = message;
     status.dataset.tone = tone;
+    const sheet = this.shadowRoot.querySelector(".area-fields");
+    if (sheet) sheet.dataset.tone = message ? tone : "normal";
+    this._syncAreaSheet();
+  }
+
+  _syncAreaSheet() {
+    const title = this.shadowRoot.querySelector(".area-sheet-title");
+    const summary = this.shadowRoot.querySelector(".area-sheet-summary");
+    if (!title || !summary) return;
+    const name = this.shadowRoot.querySelector(".area-name")?.value.trim();
+    const mode = this.shadowRoot.querySelector(".area-mode")?.selectedOptions?.[0]?.text;
+    const coverage = this.shadowRoot.querySelector(".area-coverage")
+      ?.selectedOptions?.[0]?.text;
+    const feedback = this.shadowRoot.querySelector(".area-feedback")?.textContent.trim();
+    title.textContent = name || this._localize("area_details", "Area details");
+    summary.textContent = feedback || [mode, coverage].filter(Boolean).join(" · ")
+      || this._localize("area_details_hint", "Name and cleaning settings");
+  }
+
+  _toggleAreaSheet(force = undefined) {
+    const sheet = this.shadowRoot.querySelector(".area-fields");
+    const toggle = this.shadowRoot.querySelector(".area-sheet-toggle");
+    if (!sheet || !toggle) return;
+    const expanded = force ?? sheet.dataset.expanded !== "true";
+    sheet.dataset.expanded = String(expanded);
+    toggle.setAttribute("aria-expanded", String(expanded));
   }
 
   _resetAreaSavePresentation() {
@@ -3456,6 +3631,7 @@ class MaticMapStudio extends HTMLElement {
     host.append(editor);
     this._areaBaseline = JSON.stringify(this._areaDraft());
     this._syncAreaActions();
+    this._syncAreaSheet();
   }
 
   async _saveArea() {
@@ -3603,7 +3779,7 @@ class MaticMapStudio extends HTMLElement {
         .zoom-value { min-width: 42px; text-align: center; }
         .angle-value { min-width: 72px; text-align: center; font-size: 11px; }
         .resolution-value { padding: 7px 10px; border-radius: 999px; background: color-mix(in srgb, var(--card-background-color) 82%, transparent); text-align: center; font-size: 11px; }
-        .viewport { position: relative; min-height: 0; overflow: hidden; touch-action: none; overscroll-behavior: contain; cursor: grab; outline: none; contain: strict; user-select: none; -webkit-user-select: none; -webkit-touch-callout: none; background: radial-gradient(circle at 50% 30%, #223149, #080d13 68%); transition: background .32s ease; }
+        .viewport { position: relative; min-height: 0; overflow: hidden; touch-action: none; overscroll-behavior: contain; cursor: grab; outline: none; contain: strict; user-select: none; -webkit-user-select: none; -webkit-touch-callout: none; -webkit-tap-highlight-color: transparent; background: radial-gradient(circle at 50% 30%, #223149, #080d13 68%); transition: background .32s ease; }
         .viewport.top-down { background-color: color-mix(in srgb, var(--primary-background-color, #080d13) 91%, var(--primary-color) 9%); background-image: radial-gradient(color-mix(in srgb, var(--primary-text-color) 14%, transparent) .7px, transparent .8px); background-size: 14px 14px; }
         .viewport:focus-visible { box-shadow: inset 0 0 0 2px var(--primary-color); }
         .viewport.moving { cursor: grabbing; }
@@ -3737,7 +3913,9 @@ class MaticMapStudio extends HTMLElement {
         .plan-run { border-color: #35c759; color: #fff; background: #16883a; }
         .plan-delete { color: var(--error-color); }
         .area-detail { position: relative; min-width: 0; min-height: 0; overflow: hidden; }
-        .area-fields { position: absolute; right: 16px; bottom: 16px; width: min(410px, calc(100% - 32px)); display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 10px; padding: 12px; border: 1px solid color-mix(in srgb, var(--primary-text-color) 14%, transparent); border-radius: 16px; background: color-mix(in srgb, var(--card-background-color) 90%, transparent); box-shadow: 0 18px 48px rgba(0,0,0,.34); backdrop-filter: blur(22px) saturate(1.18); z-index: 7; }
+        .area-fields { position: absolute; right: 16px; bottom: 16px; width: min(410px, calc(100% - 32px)); padding: 12px; border: 1px solid color-mix(in srgb, var(--primary-text-color) 14%, transparent); border-radius: 16px; background: color-mix(in srgb, var(--card-background-color) 90%, transparent); box-shadow: 0 18px 48px rgba(0,0,0,.34); backdrop-filter: blur(22px) saturate(1.18); -webkit-backdrop-filter: blur(22px) saturate(1.18); z-index: 7; }
+        .area-sheet-toggle { display: none; }
+        .area-sheet-content { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 10px; }
         .area-fields label { min-width: 0; display: grid; gap: 4px; color: var(--secondary-text-color); font-size: 11px; }
         .area-fields input, .area-fields select { min-height: 44px; padding: 0 11px; border: 1px solid var(--divider-color); border-radius: 11px; color: var(--primary-text-color); background: var(--card-background-color); font: inherit; }
         .area-name-label { grid-column: 1 / -1; }
@@ -3756,7 +3934,66 @@ class MaticMapStudio extends HTMLElement {
         }
         @media (max-width: 1050px) { .privacy, .status, .resolution-value { display: none; } .heading { min-width: 0; } header { gap: 8px; padding-inline: 10px; } }
         @media (max-width: 760px) { .areas-shell { grid-template-rows: auto minmax(0, 1fr); } .areas-header { flex-wrap: wrap; gap: 7px; padding: 7px 9px; } .areas-heading { flex: 1 1 auto; } .areas-heading .areas-status { display: none; } .cleaning-tabs { order: 3; width: 100%; } .cleaning-tabs button { flex: 1 1 50%; } .plans-toolbar, .areas-toolbar { margin-left: auto; } .plans-list, .areas-list { width: min(210px, 42vw); } .plan-form { width: min(100% - 24px, 960px); padding: 22px 0 70px; } .plan-primary-fields, .plan-options { grid-template-columns: 1fr; } .plan-actions { flex-wrap: wrap; } .plan-feedback { flex: 1 1 100%; padding: 0 4px 2px; } }
-        @media (max-width: 650px) { .shell { grid-template-rows: 56px minmax(0, 1fr); } h1 { font-size: 16px; } .privacy { display: none; } .heading { flex: 1 1 auto; min-width: 0; } .segmented button { min-height: 36px; padding: 0 10px; } .scene-summary { flex: 0 0 auto; } .status, .resolution-value { display: none; } .health-value { max-width: 72px; overflow: hidden; text-overflow: ellipsis; } .camera-options { display: none; } .spatial-controls { top: 10px; left: 10px; } .map-command-bar { top: 58px; right: 10px; gap: 7px; } .zoom-control .zoom-slider { width: 76px; } .zoom-control .zoom-value { display: none; } .map-actions .layers { width: 38px; padding-inline: 0; } .room-overlay-label { display: none; } .cleaning-actions button { padding-inline: 9px; } .timeline { bottom: 10px; } .timeline-panel { width: min(430px, calc(100vw - 36px)); grid-template-columns: auto minmax(100px, 1fr) auto; gap: 5px; } .timeline-live { grid-column: 1 / -1; min-height: 34px !important; } .gesture-help { right: 10px; bottom: 70px; max-width: none; font-size: 11px; } .areas-heading h2 { font-size: 15px; } .plans-list, .areas-list { flex: 1 1 auto; width: auto; min-width: 0; } .plan-new, .area-new { padding-inline: 10px; } .area-fields { right: 8px; bottom: 8px; width: calc(100% - 16px); padding: 10px; } }
+        @media (max-width: 650px) {
+          .shell { grid-template-rows: 56px minmax(0, 1fr); }
+          header { padding-right: max(10px, env(safe-area-inset-right)); padding-left: max(10px, env(safe-area-inset-left)); }
+          h1 { font-size: 16px; }
+          .privacy { display: none; }
+          .heading { flex: 1 1 auto; min-width: 0; }
+          .segmented button { min-height: 36px; padding: 0 10px; }
+          .scene-summary { flex: 0 0 auto; }
+          .status, .resolution-value { display: none; }
+          .health-value { max-width: 72px; overflow: hidden; text-overflow: ellipsis; }
+          .camera-options, .spatial-controls .zoom-control { display: none; }
+          .spatial-controls { top: max(10px, env(safe-area-inset-top)); left: max(10px, env(safe-area-inset-left)); padding: 3px; border-radius: 13px; }
+          .spatial-controls > button { width: 44px; min-width: 44px; min-height: 44px; }
+          .map-command-bar { position: static; display: contents; }
+          .map-command-bar .floating-controls { position: absolute; }
+          .map-actions { top: max(10px, env(safe-area-inset-top)); right: max(10px, env(safe-area-inset-right)); padding: 3px; border-radius: 13px; }
+          .map-actions > button, .map-more > summary { width: 44px; min-width: 44px; min-height: 44px; }
+          .map-actions .layers { width: 44px; padding-inline: 0; }
+          .room-overlay-label { display: none; }
+          .cleaning-actions { left: 50%; bottom: calc(64px + max(10px, env(safe-area-inset-bottom))); gap: 2px; padding: 3px; border-radius: 15px; transform: translateX(-50%); }
+          .cleaning-actions button { min-height: 46px; gap: 6px; padding-inline: 12px; white-space: nowrap; }
+          .cleaning-actions ha-icon { width: 19px; height: 19px; --mdc-icon-size: 19px; }
+          .timeline { bottom: max(10px, env(safe-area-inset-bottom)); }
+          .timeline > summary { min-width: 142px; min-height: 44px; }
+          .timeline-panel { width: min(430px, calc(100vw - 24px)); grid-template-columns: auto minmax(100px, 1fr) auto; gap: 5px; }
+          .timeline-live { grid-column: 1 / -1; min-height: 38px !important; }
+          .gesture-help { right: 10px; bottom: calc(126px + env(safe-area-inset-bottom)); max-width: none; font-size: 11px; }
+          .areas-shell { grid-template-rows: auto minmax(0, 1fr); }
+          .areas-header { display: grid; grid-template-columns: 44px minmax(0, 1fr) auto; gap: 6px; padding: max(6px, env(safe-area-inset-top)) max(8px, env(safe-area-inset-right)) 6px max(8px, env(safe-area-inset-left)); }
+          .areas-back { width: 44px; min-width: 44px; min-height: 44px; padding: 0; }
+          .areas-heading { display: none; }
+          .areas-header > .spacer { display: none; }
+          .cleaning-tabs { grid-column: 1 / -1; grid-row: 2; order: initial; width: auto; padding: 2px; }
+          .cleaning-tabs button { min-height: 38px; flex: 1 1 50%; padding-inline: 8px; }
+          .plans-toolbar, .areas-toolbar { grid-column: 2 / 4; grid-row: 1; min-width: 0; margin: 0; }
+          .plans-list, .areas-list { flex: 1 1 auto; width: auto; min-width: 0; min-height: 44px; }
+          .plan-new, .area-new { width: 44px; min-width: 44px; min-height: 44px; overflow: hidden; padding: 0; font-size: 0; }
+          .plan-new::before, .area-new::before { content: "+"; font-size: 24px; font-weight: 350; line-height: 1; }
+          .plan-form { width: min(100% - 20px, 960px); padding: 18px 0 calc(72px + env(safe-area-inset-bottom)); }
+          .area-fields { right: max(8px, env(safe-area-inset-right)); bottom: max(8px, env(safe-area-inset-bottom)); left: max(8px, env(safe-area-inset-left)); width: auto; max-height: min(62dvh, 520px); box-sizing: border-box; overflow: hidden auto; padding: 5px 10px calc(10px + env(safe-area-inset-bottom)); border-radius: 20px; overscroll-behavior: contain; transition: max-height .2s ease, background .2s ease; }
+          .area-sheet-toggle { position: relative; width: 100%; min-height: 54px; display: grid; grid-template-columns: minmax(0, 1fr) 28px; align-items: center; gap: 8px; padding: 6px 0 0; border: 0; background: transparent; text-align: left; transform: none !important; }
+          .area-sheet-grabber { position: absolute; top: 1px; left: 50%; width: 30px; height: 4px; border-radius: 999px; background: color-mix(in srgb, var(--primary-text-color) 30%, transparent); transform: translateX(-50%); }
+          .area-sheet-copy { min-width: 0; display: grid; gap: 1px; }
+          .area-sheet-title { overflow: hidden; color: var(--primary-text-color); font-size: 14px; font-weight: 620; text-overflow: ellipsis; white-space: nowrap; }
+          .area-sheet-summary { overflow: hidden; color: var(--secondary-text-color); font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
+          .area-sheet-toggle ha-icon { width: 22px; height: 22px; color: var(--secondary-text-color); transition: transform .2s ease; }
+          .area-fields[data-expanded="true"] .area-sheet-toggle ha-icon { transform: rotate(180deg); }
+          .area-sheet-content { display: none; grid-template-columns: minmax(0, 1fr); gap: 10px; padding: 5px 2px 2px; }
+          .area-fields[data-expanded="true"] .area-sheet-content { display: grid; }
+          .area-name-label, .area-settings, .area-actions { grid-column: 1; }
+          .area-settings { grid-template-columns: 1fr 1fr; }
+          .area-actions { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: 8px; }
+          .area-feedback { grid-column: 1 / -1; min-height: 0; margin: 0; text-align: center; }
+          .area-feedback:empty { display: none; }
+          .area-fields[data-tone="success"] .area-sheet-summary { color: #35c759; }
+          .area-fields[data-tone="error"] .area-sheet-summary { color: var(--error-color); }
+          .area-delete { grid-column: 1 / -1; grid-row: 3; border: 0; background: transparent; }
+          .area-run, .area-save { width: 100%; min-height: 48px; }
+          .area-run[hidden] + .area-save { grid-column: 1 / -1; }
+        }
       </style>
       <div class="shell">
         <header>
@@ -3892,13 +4129,20 @@ class MaticMapStudio extends HTMLElement {
             </section>
             <section class="area-detail" hidden>
               <div class="area-editor-host"></div>
-              <div class="area-fields">
-                <label class="area-name-label">${text("area_name", "Area name")}<input class="area-name" maxlength="128" autocomplete="off"></label>
-                <div class="area-settings">
-                  <label>${text("cleaning_mode", "Cleaning mode")}<select class="area-mode"><option value="vacuum">${text("vacuum", "Vacuum")}</option><option value="mop">${text("mop", "Mop")}</option><option value="vacuum_and_mop">${text("vacuum_and_mop", "Vacuum + mop")}</option></select></label>
-                  <label>${text("coverage", "Coverage")}<select class="area-coverage"><option value="quick">${text("quick", "Quick")}</option><option value="standard">${text("standard", "Optimal")}</option><option value="heavy_duty">${text("heavy_duty", "Heavy Duty")}</option></select></label>
+              <div class="area-fields" data-expanded="false">
+                <button class="area-sheet-toggle" type="button" aria-expanded="false" aria-controls="area-sheet-content">
+                  <span class="area-sheet-grabber" aria-hidden="true"></span>
+                  <span class="area-sheet-copy"><strong class="area-sheet-title">${text("area_details", "Area details")}</strong><span class="area-sheet-summary">${text("area_details_hint", "Name and cleaning settings")}</span></span>
+                  <ha-icon icon="mdi:chevron-up" aria-hidden="true"></ha-icon>
+                </button>
+                <div class="area-sheet-content" id="area-sheet-content">
+                  <label class="area-name-label">${text("area_name", "Area name")}<input class="area-name" maxlength="128" autocomplete="off"></label>
+                  <div class="area-settings">
+                    <label>${text("cleaning_mode", "Cleaning mode")}<select class="area-mode"><option value="vacuum">${text("vacuum", "Vacuum")}</option><option value="mop">${text("mop", "Mop")}</option><option value="vacuum_and_mop">${text("vacuum_and_mop", "Vacuum + mop")}</option></select></label>
+                    <label>${text("coverage", "Coverage")}<select class="area-coverage"><option value="quick">${text("quick", "Quick")}</option><option value="standard">${text("standard", "Optimal")}</option><option value="heavy_duty">${text("heavy_duty", "Heavy Duty")}</option></select></label>
+                  </div>
+                  <div class="area-actions"><span class="area-feedback" role="status" aria-live="polite" aria-atomic="true"></span><button class="area-delete" hidden>${text("area_delete", "Delete")}</button><button class="area-run" hidden>${text("area_run", "Clean now")}</button><button class="area-save">${text("area_save", "Save area")}</button></div>
                 </div>
-                <div class="area-actions"><span class="area-feedback" role="status" aria-live="polite" aria-atomic="true"></span><button class="area-delete" hidden>${text("area_delete", "Delete")}</button><button class="area-run" hidden>${text("area_run", "Clean now")}</button><button class="area-save">${text("area_save", "Save area")}</button></div>
               </div>
             </section>
           </div>
@@ -4012,6 +4256,8 @@ class MaticMapStudio extends HTMLElement {
     }
     this._guardButton(this.shadowRoot.querySelector(".area-new"), () =>
       this._selectArea(undefined));
+    this._guardButton(this.shadowRoot.querySelector(".area-sheet-toggle"), () =>
+      this._toggleAreaSheet());
     this.shadowRoot.querySelector(".areas-list").addEventListener(
       "change",
       (event) => this._selectArea(event.target.value || undefined),
@@ -4031,6 +4277,7 @@ class MaticMapStudio extends HTMLElement {
           this._setAreaActionStatus("");
           this._resetAreaSavePresentation();
           this._syncAreaActions();
+          this._syncAreaSheet();
         },
       );
     }

--- a/custom_components/matic_robot/room_plan_editor.js
+++ b/custom_components/matic_robot/room_plan_editor.js
@@ -331,6 +331,10 @@ class MaticAreaEditor extends HTMLElement {
     this._activePointerId = undefined;
     this._pointers = new Map();
     this._pinch = undefined;
+    this._doubleTapZoom = undefined;
+    this._lastTap = undefined;
+    this._navigationFrame = undefined;
+    this._pinchReleaseVelocity = undefined;
     this._expanded = true;
     this._undoStack = [];
     this._redoStack = [];
@@ -422,6 +426,7 @@ class MaticAreaEditor extends HTMLElement {
       window.cancelAnimationFrame(this._labelFrame);
       this._labelFrame = undefined;
     }
+    this._cancelNavigationMotion();
     this._releasePhotoObjectUrl();
     this._restorePageScroll();
   }
@@ -874,24 +879,56 @@ class MaticAreaEditor extends HTMLElement {
     });
   }
 
-  _setViewBox(svg, viewBox) {
+  _constrainedViewBox(viewBox, { elastic = false } = {}) {
     const base = this._baseViewBox;
-    const width = Math.max(base.width * 0.1, Math.min(base.width, viewBox.width));
-    const height = Math.max(base.height * 0.1, Math.min(base.height, viewBox.height));
+    const resist = (value, minimum, maximum, maximumOvershoot) => {
+      if (!elastic) return Math.max(minimum, Math.min(maximum, value));
+      if (value < minimum) {
+        return minimum - Math.min(maximumOvershoot, (minimum - value) * 0.24);
+      }
+      if (value > maximum) {
+        return maximum + Math.min(maximumOvershoot, (value - maximum) * 0.24);
+      }
+      return value;
+    };
+    const width = resist(
+      viewBox.width,
+      base.width * 0.1,
+      base.width,
+      base.width * 0.08,
+    );
+    const height = resist(
+      viewBox.height,
+      base.height * 0.1,
+      base.height,
+      base.height * 0.08,
+    );
     const overflowX = base.width * 0.15;
     const overflowY = base.height * 0.15;
-    this._viewBox = {
-      x: Math.max(
-        base.x - overflowX,
-        Math.min(base.x + base.width + overflowX - width, viewBox.x),
+    const minimumX = base.x - overflowX;
+    const maximumX = base.x + base.width + overflowX - width;
+    const minimumY = base.y - overflowY;
+    const maximumY = base.y + base.height + overflowY - height;
+    return {
+      x: resist(
+        viewBox.x,
+        Math.min(minimumX, maximumX),
+        Math.max(minimumX, maximumX),
+        base.width * 0.1,
       ),
-      y: Math.max(
-        base.y - overflowY,
-        Math.min(base.y + base.height + overflowY - height, viewBox.y),
+      y: resist(
+        viewBox.y,
+        Math.min(minimumY, maximumY),
+        Math.max(minimumY, maximumY),
+        base.height * 0.1,
       ),
       width,
       height,
     };
+  }
+
+  _setViewBox(svg, viewBox, options = {}) {
+    this._viewBox = this._constrainedViewBox(viewBox, options);
     svg.setAttribute(
       "viewBox",
       `${this._viewBox.x} ${this._viewBox.y} ${this._viewBox.width} ${this._viewBox.height}`,
@@ -900,7 +937,86 @@ class MaticAreaEditor extends HTMLElement {
     this._scheduleRoomLabelLayout();
   }
 
+  _cancelNavigationMotion() {
+    if (this._navigationFrame !== undefined) {
+      window.cancelAnimationFrame(this._navigationFrame);
+      this._navigationFrame = undefined;
+    }
+  }
+
+  _animateViewBox(svg, target, duration = 240) {
+    this._cancelNavigationMotion();
+    const start = { ...this._viewBox };
+    const constrained = this._constrainedViewBox(target);
+    if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) {
+      this._setViewBox(svg, constrained);
+      return;
+    }
+    const started = performance.now();
+    const step = (now) => {
+      const progress = Math.min(1, (now - started) / duration);
+      const eased = 1 - (1 - progress) ** 3;
+      this._setViewBox(svg, Object.fromEntries(
+        ["x", "y", "width", "height"].map((key) => [
+          key,
+          start[key] + (constrained[key] - start[key]) * eased,
+        ]),
+      ));
+      if (progress < 1) this._navigationFrame = window.requestAnimationFrame(step);
+      else this._navigationFrame = undefined;
+    };
+    this._navigationFrame = window.requestAnimationFrame(step);
+  }
+
+  _settleViewBox(svg) {
+    const constrained = this._constrainedViewBox(this._viewBox);
+    const displacement = Math.max(
+      ...["x", "y", "width", "height"].map(
+        (key) => Math.abs(constrained[key] - this._viewBox[key]),
+      ),
+    );
+    if (displacement > this._baseViewBox.width * 0.0001) {
+      this._animateViewBox(svg, constrained, 220);
+    }
+  }
+
+  _startPanInertia(svg, velocityX, velocityY) {
+    this._cancelNavigationMotion();
+    velocityX = Math.max(-1.4, Math.min(1.4, velocityX));
+    velocityY = Math.max(-1.4, Math.min(1.4, velocityY));
+    if (
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches
+      || Math.hypot(velocityX, velocityY) < 0.025
+    ) {
+      this._settleViewBox(svg);
+      return;
+    }
+    let previous = performance.now();
+    const step = (now) => {
+      const elapsed = Math.min(32, now - previous);
+      previous = now;
+      this._panByPixels(
+        svg,
+        velocityX * elapsed,
+        velocityY * elapsed,
+        this._viewBox,
+        { elastic: true },
+      );
+      const decay = 0.91 ** (elapsed / 16);
+      velocityX *= decay;
+      velocityY *= decay;
+      if (Math.hypot(velocityX, velocityY) >= 0.012) {
+        this._navigationFrame = window.requestAnimationFrame(step);
+      } else {
+        this._navigationFrame = undefined;
+        this._settleViewBox(svg);
+      }
+    };
+    this._navigationFrame = window.requestAnimationFrame(step);
+  }
+
   _zoom(svg, factor, center) {
+    this._cancelNavigationMotion();
     const current = this._viewBox;
     const focus = center || {
       x: current.x + current.width / 2,
@@ -923,16 +1039,23 @@ class MaticAreaEditor extends HTMLElement {
       || (Math.abs(deltaX) < 0.5 && Math.abs(deltaY) >= 50);
   }
 
-  _panByPixels(svg, deltaX, deltaY, viewBox = this._viewBox) {
+  _panByPixels(
+    svg,
+    deltaX,
+    deltaY,
+    viewBox = this._viewBox,
+    options = {},
+  ) {
     const bounds = svg.getBoundingClientRect();
     this._setViewBox(svg, {
       ...viewBox,
       x: viewBox.x - deltaX * viewBox.width / Math.max(1, bounds.width),
       y: viewBox.y - deltaY * viewBox.height / Math.max(1, bounds.height),
-    });
+    }, options);
   }
 
   _fitMap(svg) {
+    this._cancelNavigationMotion();
     this._setViewBox(svg, { ...this._baseViewBox });
   }
 
@@ -1005,6 +1128,10 @@ class MaticAreaEditor extends HTMLElement {
 
   _setTool(tool) {
     if (!["draw", "erase", "pan"].includes(tool)) return;
+    this._cancelNavigationMotion();
+    this._lastTap = undefined;
+    this._doubleTapZoom = undefined;
+    this._pinchReleaseVelocity = undefined;
     this._tool = tool;
     this._panStart = undefined;
     const svg = this.shadowRoot.querySelector(".map");
@@ -1152,7 +1279,7 @@ class MaticAreaEditor extends HTMLElement {
 
   _commitDraft() {
     const base = this._draftBaseValue;
-    if (!base) return;
+    if (!base) return false;
     const next = this._tool === "erase"
       ? this._draftEraseValue
       : [...base, ...(this._draftStroke || [])];
@@ -1165,10 +1292,11 @@ class MaticAreaEditor extends HTMLElement {
     if (!changed) {
       this._syncMarks();
       this._announce(this._localize("area_outside_map", "Paint inside a mapped room."));
-      return;
+      return false;
     }
     this._setValue(next);
     this._announce(this._localize("area_added", "Cleaning area updated."));
+    return true;
   }
 
   _syncMarks(circles = this._value) {
@@ -1282,7 +1410,7 @@ class MaticAreaEditor extends HTMLElement {
         .intro { color: var(--secondary-text-color); font-size: 12px; }
         .map-stage { position: absolute; inset: 0; min-height: 0; overflow: hidden; }
         .map-shell { position: relative; height: 100%; min-height: 0; }
-        .map { display: block; width: 100%; height: 100%; min-height: 0; border: 0; border-radius: 0; background: radial-gradient(circle at 50% 40%, #182538, #0c131d 72%); touch-action: none; user-select: none; outline: none; }
+        .map { display: block; width: 100%; height: 100%; min-height: 0; border: 0; border-radius: 0; background: radial-gradient(circle at 50% 40%, #182538, #0c131d 72%); touch-action: none; user-select: none; -webkit-tap-highlight-color: transparent; outline: none; }
         .map:focus-visible { border-color: var(--primary-color); box-shadow: inset 0 0 0 2px var(--primary-color); }
         .map[data-tool="draw"], .map[data-tool="erase"] { cursor: none; }
         .map[data-tool="pan"] { cursor: grab; }
@@ -1330,17 +1458,23 @@ class MaticAreaEditor extends HTMLElement {
         .announcement { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
         .visually-hidden { position: absolute !important; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
         @media (max-width: 820px) {
-          .topbar { top: 8px; right: 8px; left: 8px; gap: 6px; }
+          .topbar { top: max(8px, env(safe-area-inset-top)); right: max(8px, env(safe-area-inset-right)); left: max(8px, env(safe-area-inset-left)); gap: 6px; }
           .title-group { width: 100%; }
           .photo-status { display: none; }
           .room-focus { flex: 1 1 140px; max-width: none; }
-          button { min-height: 42px; padding: 0 10px; }
+          button { min-height: 44px; min-width: 44px; padding: 0 10px; }
           .map { min-height: 260px; }
           .map-help { display: none; }
-          .footer { right: 8px; bottom: 8px; left: 8px; max-width: none; overflow-x: auto; }
+          .map-controls { justify-content: center; }
+          .navigation-controls, .tool-picker { flex: 0 0 auto; padding: 3px; border-radius: 13px; }
+          .navigation-controls button, .tool-picker button, .map-options > summary { min-width: 44px; min-height: 44px; padding: 0; }
+          .zoom-control { display: none; }
+          .map-options-panel { right: 0; left: auto; width: min(250px, calc(100vw - 32px)); }
+          .footer { right: auto; bottom: max(8px, env(safe-area-inset-bottom)); left: max(8px, env(safe-area-inset-left)); max-width: calc(100% - 16px); overflow-x: auto; padding: 3px; scrollbar-width: none; }
+          .workspace.embedded .footer { bottom: calc(72px + env(safe-area-inset-bottom)); }
+          .footer::-webkit-scrollbar { display: none; }
+          .footer button { min-height: 44px; }
           .radius input[type=range] { width: 110px; }
-          .area-zoom-slider { width: 76px; }
-          .area-zoom-value { display: none; }
           .tool-picker .tool-label { display: none; }
           .count { display: none; }
         }
@@ -1451,17 +1585,62 @@ class MaticAreaEditor extends HTMLElement {
       event.preventDefault();
       event.stopImmediatePropagation();
       svg.focus({ preventScroll: true });
+      this._cancelNavigationMotion();
       try {
         svg.setPointerCapture(event.pointerId);
       } catch (_error) {
         return;
       }
+      const now = performance.now();
+      const lastTap = this._lastTap;
+      const isDoubleTap = event.pointerType === "touch"
+        && this._pointers.size === 0
+        && lastTap
+        && now - lastTap.time <= 320
+        && Math.hypot(event.clientX - lastTap.x, event.clientY - lastTap.y) <= 28;
       this._pointers.set(event.pointerId, {
         x: event.clientX,
         y: event.clientY,
+        startX: event.clientX,
+        startY: event.clientY,
+        lastX: event.clientX,
+        lastY: event.clientY,
+        lastTime: now,
+        velocityX: 0,
+        velocityY: 0,
+        moved: 0,
+        started: now,
+        pointerType: event.pointerType,
+        navigationOnly: false,
       });
+      if (isDoubleTap) {
+        this._undoStack = this._undoStack.slice(0, lastTap.undoDepth);
+        this._redoStack = lastTap.redoStack;
+        this._setValue(lastTap.base, { record: false });
+        const point = svg.createSVGPoint();
+        point.x = event.clientX;
+        point.y = event.clientY;
+        this._doubleTapZoom = {
+          pointerId: event.pointerId,
+          startX: event.clientX,
+          startY: event.clientY,
+          focus: point.matrixTransform(svg.getScreenCTM().inverse()),
+          viewBox: { ...this._viewBox },
+          moved: false,
+        };
+        this._lastTap = undefined;
+        this._activePointerId = event.pointerId;
+        this._panStart = undefined;
+        this._pointers.get(event.pointerId).navigationOnly = true;
+        svg.classList.add("moving");
+        return;
+      }
+      if (lastTap && now - lastTap.time > 320) this._lastTap = undefined;
       if (this._pointers.size === 2) {
         cancelDraft();
+        this._lastTap = undefined;
+        this._doubleTapZoom = undefined;
+        this._pinchReleaseVelocity = undefined;
         this._activePointerId = undefined;
         this._panStart = undefined;
         const [first, second] = [...this._pointers.values()];
@@ -1476,7 +1655,14 @@ class MaticAreaEditor extends HTMLElement {
           centerY,
           focus: point.matrixTransform(svg.getScreenCTM().inverse()),
           viewBox: { ...this._viewBox },
+          lastCenterX: centerX,
+          lastCenterY: centerY,
+          lastTime: now,
+          velocityX: 0,
+          velocityY: 0,
         };
+        first.navigationOnly = true;
+        second.navigationOnly = true;
         svg.classList.add("moving");
         return;
       }
@@ -1492,7 +1678,12 @@ class MaticAreaEditor extends HTMLElement {
       } else {
         if (this._tool === "draw" && this._value.length >= 512) {
           this._activePointerId = undefined;
-          svg.releasePointerCapture(event.pointerId);
+          this._pointers.delete(event.pointerId);
+          try {
+            svg.releasePointerCapture(event.pointerId);
+          } catch (_error) {
+            // Safari may release capture while the pointerdown handler is running.
+          }
           return;
         }
         this._draftBaseValue = this._cloneValue();
@@ -1504,7 +1695,25 @@ class MaticAreaEditor extends HTMLElement {
     });
     svg.addEventListener("pointermove", (event) => {
       if (this._pointers.has(event.pointerId)) {
-        this._pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+        const pointerState = this._pointers.get(event.pointerId);
+        const now = performance.now();
+        const elapsed = Math.max(1, now - pointerState.lastTime);
+        const instantaneousX = (event.clientX - pointerState.lastX) / elapsed;
+        const instantaneousY = (event.clientY - pointerState.lastY) / elapsed;
+        pointerState.velocityX = pointerState.velocityX * 0.55 + instantaneousX * 0.45;
+        pointerState.velocityY = pointerState.velocityY * 0.55 + instantaneousY * 0.45;
+        pointerState.x = event.clientX;
+        pointerState.y = event.clientY;
+        pointerState.lastX = event.clientX;
+        pointerState.lastY = event.clientY;
+        pointerState.lastTime = now;
+        pointerState.moved = Math.max(
+          pointerState.moved,
+          Math.hypot(
+            event.clientX - pointerState.startX,
+            event.clientY - pointerState.startY,
+          ),
+        );
       }
       const brushCursor = this.shadowRoot.querySelector(".brush-cursor");
       if (
@@ -1517,6 +1726,30 @@ class MaticAreaEditor extends HTMLElement {
         brushCursor.setAttribute("cy", -point.y);
         brushCursor.setAttribute("r", this._radius);
         brushCursor.setAttribute("visibility", "visible");
+      }
+      if (
+        this._doubleTapZoom?.pointerId === event.pointerId
+        && this._pointers.has(event.pointerId)
+      ) {
+        event.preventDefault();
+        const gesture = this._doubleTapZoom;
+        const deltaY = event.clientY - gesture.startY;
+        gesture.moved ||= Math.hypot(
+          event.clientX - gesture.startX,
+          deltaY,
+        ) > 5;
+        const factor = Math.exp(Math.max(-2.2, Math.min(2.2, deltaY * 0.009)));
+        const width = gesture.viewBox.width * factor;
+        const height = gesture.viewBox.height * factor;
+        const ratioX = (gesture.focus.x - gesture.viewBox.x) / gesture.viewBox.width;
+        const ratioY = (gesture.focus.y - gesture.viewBox.y) / gesture.viewBox.height;
+        this._setViewBox(svg, {
+          x: gesture.focus.x - width * ratioX,
+          y: gesture.focus.y - height * ratioY,
+          width,
+          height,
+        }, { elastic: true });
+        return;
       }
       if (this._pinch && this._pointers.size >= 2) {
         event.preventDefault();
@@ -1531,6 +1764,15 @@ class MaticAreaEditor extends HTMLElement {
         const ratioX = (start.focus.x - start.viewBox.x) / start.viewBox.width;
         const ratioY = (start.focus.y - start.viewBox.y) / start.viewBox.height;
         const bounds = svg.getBoundingClientRect();
+        const now = performance.now();
+        const elapsed = Math.max(1, now - start.lastTime);
+        const instantaneousX = (centerX - start.lastCenterX) / elapsed;
+        const instantaneousY = (centerY - start.lastCenterY) / elapsed;
+        start.velocityX = start.velocityX * 0.55 + instantaneousX * 0.45;
+        start.velocityY = start.velocityY * 0.55 + instantaneousY * 0.45;
+        start.lastCenterX = centerX;
+        start.lastCenterY = centerY;
+        start.lastTime = now;
         this._setViewBox(svg, {
           x: start.focus.x - width * ratioX
             - (centerX - start.centerX) * width / Math.max(1, bounds.width),
@@ -1538,7 +1780,7 @@ class MaticAreaEditor extends HTMLElement {
             - (centerY - start.centerY) * height / Math.max(1, bounds.height),
           width,
           height,
-        });
+        }, { elastic: true });
         return;
       }
       if (event.pointerId !== this._activePointerId) return;
@@ -1552,6 +1794,7 @@ class MaticAreaEditor extends HTMLElement {
           event.clientX - this._panStart.x,
           event.clientY - this._panStart.y,
           this._panStart.viewBox,
+          { elastic: true },
         );
       }
     });
@@ -1562,29 +1805,133 @@ class MaticAreaEditor extends HTMLElement {
       }
     });
     const finishPointer = (event) => {
-      if (event.pointerId === this._activePointerId) this._commitDraft();
+      if (!this._pointers.has(event.pointerId)) return;
+      const pointerState = this._pointers.get(event.pointerId);
+      const wasPinching = Boolean(this._pinch);
+      const pinchVelocity = wasPinching
+        ? { x: this._pinch.velocityX, y: this._pinch.velocityY }
+        : undefined;
+      const wasDoubleTapZoom = this._doubleTapZoom?.pointerId === event.pointerId;
+      let changed = false;
+      let tapBase;
+      let tapUndoDepth;
+      let tapRedoStack;
+      if (wasDoubleTapZoom) {
+        const gesture = this._doubleTapZoom;
+        this._doubleTapZoom = undefined;
+        if (gesture.moved) {
+          this._settleViewBox(svg);
+        } else {
+          const width = gesture.viewBox.width * 0.5;
+          const height = gesture.viewBox.height * 0.5;
+          const ratioX = (gesture.focus.x - gesture.viewBox.x)
+            / gesture.viewBox.width;
+          const ratioY = (gesture.focus.y - gesture.viewBox.y)
+            / gesture.viewBox.height;
+          this._animateViewBox(svg, {
+            x: gesture.focus.x - width * ratioX,
+            y: gesture.focus.y - height * ratioY,
+            width,
+            height,
+          });
+        }
+      } else if (event.pointerId === this._activePointerId && this._draftBaseValue) {
+        tapBase = this._cloneValue(this._draftBaseValue);
+        tapUndoDepth = this._undoStack.length;
+        tapRedoStack = this._redoStack.map((value) => this._cloneValue(value));
+        changed = this._commitDraft();
+      }
       this._pointers.delete(event.pointerId);
-      if (this._pointers.size < 2) this._pinch = undefined;
+      if (wasPinching && this._pointers.size === 1) {
+        const [remainingId, remaining] = [...this._pointers.entries()][0];
+        this._pinch = undefined;
+        this._pinchReleaseVelocity = pinchVelocity;
+        this._activePointerId = remainingId;
+        remaining.navigationOnly = true;
+        remaining.startX = remaining.x;
+        remaining.startY = remaining.y;
+        remaining.lastX = remaining.x;
+        remaining.lastY = remaining.y;
+        remaining.lastTime = performance.now();
+        remaining.velocityX = pinchVelocity.x;
+        remaining.velocityY = pinchVelocity.y;
+        remaining.moved = 0;
+        this._panStart = {
+          x: remaining.x,
+          y: remaining.y,
+          viewBox: { ...this._viewBox },
+        };
+      } else if (this._pointers.size < 2) {
+        this._pinch = undefined;
+      }
       if (this._pointers.size === 0) {
+        const isTap = pointerState.pointerType === "touch"
+          && pointerState.moved <= 8
+          && performance.now() - pointerState.started <= 350;
+        if (!wasDoubleTapZoom && !wasPinching && isTap) {
+          this._lastTap = {
+            time: performance.now(),
+            x: event.clientX,
+            y: event.clientY,
+            base: tapBase || this._cloneValue(),
+            undoDepth: tapUndoDepth ?? this._undoStack.length,
+            redoStack: tapRedoStack || this._redoStack.map(
+              (value) => this._cloneValue(value),
+            ),
+            changed,
+          };
+        } else if (!wasDoubleTapZoom) {
+          this._lastTap = undefined;
+        }
+        const velocity = pointerState.navigationOnly || this._panStart
+          ? {
+            x: pointerState.velocityX || this._pinchReleaseVelocity?.x || 0,
+            y: pointerState.velocityY || this._pinchReleaseVelocity?.y || 0,
+          }
+          : undefined;
         this._panStart = undefined;
         this._activePointerId = undefined;
+        this._pinchReleaseVelocity = undefined;
         svg.classList.remove("moving");
+        if (velocity && !wasDoubleTapZoom) {
+          this._startPanInertia(svg, velocity.x, velocity.y);
+        } else if (!wasDoubleTapZoom) {
+          this._settleViewBox(svg);
+        }
       }
-      if (svg.hasPointerCapture(event.pointerId)) svg.releasePointerCapture(event.pointerId);
+      if (svg.hasPointerCapture(event.pointerId)) {
+        try {
+          svg.releasePointerCapture(event.pointerId);
+        } catch (_error) {
+          // Safari can release capture before dispatching the terminal event.
+        }
+      }
     };
     const cancelPointer = (event) => {
+      if (!this._pointers.has(event.pointerId)) return;
       cancelDraft();
+      this._lastTap = undefined;
+      this._doubleTapZoom = undefined;
+      this._pinchReleaseVelocity = undefined;
       this._pointers.delete(event.pointerId);
       if (this._pointers.size < 2) this._pinch = undefined;
       if (this._pointers.size === 0) {
         this._panStart = undefined;
         this._activePointerId = undefined;
         svg.classList.remove("moving");
+        this._settleViewBox(svg);
       }
-      if (svg.hasPointerCapture(event.pointerId)) svg.releasePointerCapture(event.pointerId);
+      if (svg.hasPointerCapture(event.pointerId)) {
+        try {
+          svg.releasePointerCapture(event.pointerId);
+        } catch (_error) {
+          // Safari can release capture before dispatching pointercancel.
+        }
+      }
     };
     svg.addEventListener("pointerup", finishPointer);
     svg.addEventListener("pointercancel", cancelPointer);
+    svg.addEventListener("lostpointercapture", cancelPointer);
     svg.addEventListener("wheel", (event) => {
       event.preventDefault();
       event.stopPropagation();

--- a/custom_components/matic_robot/strings.json
+++ b/custom_components/matic_robot/strings.json
@@ -15,6 +15,8 @@
     "area_map_layer": "Map appearance",
     "area_marks": "brush points",
     "area_name": "Area name",
+    "area_details": "Area details",
+    "area_details_hint": "Name and cleaning settings",
     "area_new": "New area",
     "area_not_selected": "Paint an area to continue",
     "area_outside_map": "Paint inside a mapped room.",

--- a/custom_components/matic_robot/translations/en.json
+++ b/custom_components/matic_robot/translations/en.json
@@ -15,6 +15,8 @@
     "area_map_layer": "Map appearance",
     "area_marks": "brush points",
     "area_name": "Area name",
+    "area_details": "Area details",
+    "area_details_hint": "Name and cleaning settings",
     "area_new": "New area",
     "area_not_selected": "Paint an area to continue",
     "area_outside_map": "Paint inside a mapped room.",

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,8 @@ the integration so instructions and behavior stay aligned with each release.
   discovery, passkey, room-mapping, firmware, and Bluetooth constraints.
 - [Firmware compatibility](firmware-compatibility.md) — Track observed robot
   versions, validation status, regressions, and newly discovered capabilities.
+- [Release notes — 0.3.2](release-notes-0.3.2.md) — Native mobile gestures and
+  a touch-first Map Studio and custom-area workspace
 - [Release notes — 0.3.1](release-notes-0.3.1.md) — Quick, Optimal, and Heavy
   Duty coverage for plans, custom areas, entities, and actions
 - [Release notes — 0.3.0](release-notes-0.3.0.md) — Private 3D/2D map workspace

--- a/docs/release-notes-0.3.2.md
+++ b/docs/release-notes-0.3.2.md
@@ -1,0 +1,48 @@
+# Release notes — 0.3.2
+
+Released: 2026-07-31
+
+## Summary
+
+0.3.2 makes Map Studio and custom cleaning areas substantially more natural on
+phones and tablets. Controls respect device safe areas, the map remains the
+primary surface, and editing details move into a compact contextual sheet.
+
+## Touch navigation
+
+- Pinch zoom, two-finger pan and twist rotation cooperate without abrupt mode
+  changes or accidental drawing.
+- Double-tap zoom and double-tap-drag zoom follow the target under the user's
+  finger.
+- A lifted finger transitions cleanly from a two-finger gesture into one-finger
+  navigation.
+- Momentum, elastic limits and spring-back keep exploration responsive while
+  preventing the map from getting lost off-screen.
+- Gesture cancellation, reduced-motion preferences and touch-target sizing are
+  handled consistently across Map Studio and the custom-area editor.
+
+## Mobile cleaning workspace
+
+- Plans and custom areas remain first-class actions without obscuring the map.
+- Custom-area drawing tools stay separate from navigation controls, reducing
+  unintended brush marks during map exploration.
+- Area name, cleaning settings and actions use a contextual bottom sheet that
+  preserves useful map space and keeps feedback beside the action.
+- Browser CI now exercises the touch-critical paths in mobile WebKit as well as
+  the complete Chromium suite.
+
+This release changes no robot protocol commands and sends no map data outside
+Home Assistant.
+
+## Verification
+
+The release candidate passes 868 Python tests / 8,018 statements at 100%
+coverage, 41 Chromium browser tests, three iPhone WebKit interaction tests,
+strict typing, lint and format checks, the public-tree privacy gate, artifact
+parity, and clean-wheel import.
+
+## Upgrading from 0.3.1
+
+Install 0.3.2 through HACS and restart Home Assistant. Existing entries, plans,
+custom areas, automations, map history, and cleaning history are preserved.
+Re-pairing is not required.

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -16,6 +16,11 @@ export default defineConfig({
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
     },
+    {
+      name: "mobile-webkit",
+      grep: /mobile maps touch-first|does not paint when a touch|matches native mobile/,
+      use: { ...devices["iPhone 15"] },
+    },
   ],
   webServer: {
     command: "node tests/browser/server.mjs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "matic-home-assistant"
-version = "0.3.1"
+version = "0.3.2"
 description = "Unofficial local-only Home Assistant integration for Matic robot vacuums"
 readme = "README.md"
 license = "MIT"

--- a/tests/browser/server.mjs
+++ b/tests/browser/server.mjs
@@ -23,7 +23,9 @@ const server = createServer((request, response) => {
       "Content-Type": path === "/" ? "text/html; charset=utf-8" : "text/plain",
       "Cache-Control": "no-store",
     });
-    response.end(path === "/" ? "<!doctype html><title>Matic UI test</title>" : "ok");
+    response.end(path === "/"
+      ? "<!doctype html><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"><title>Matic UI test</title>"
+      : "ok");
     return;
   }
   const file = scripts.get(path);

--- a/tests/browser/ui.spec.mjs
+++ b/tests/browser/ui.spec.mjs
@@ -386,6 +386,172 @@ test.describe("custom-area editor", () => {
     expect(afterWheel[2]).not.toBeCloseTo(afterTrackpad[2], 5);
   });
 
+  test("does not paint when a touch becomes a two-finger map gesture", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    const editor = await loadAreaEditor(page);
+    await page.evaluate(() => {
+      const map = window.__areaEditor.shadowRoot.querySelector(".map");
+      const bounds = map.getBoundingClientRect();
+      const syntheticPointer = (type, pointerId, x, y) => ({
+        type,
+        init: {
+          bubbles: true,
+          cancelable: true,
+          pointerId,
+          pointerType: "touch",
+          button: 0,
+          clientX: bounds.left + bounds.width * x,
+          clientY: bounds.top + bounds.height * y,
+        },
+      });
+      const events = [
+        syntheticPointer("pointerdown", 41, 0.40, 0.48),
+        syntheticPointer("pointermove", 41, 0.45, 0.48),
+        syntheticPointer("pointerdown", 42, 0.62, 0.48),
+        syntheticPointer("pointermove", 41, 0.34, 0.44),
+        syntheticPointer("pointermove", 42, 0.68, 0.52),
+        syntheticPointer("pointerup", 41, 0.34, 0.44),
+        syntheticPointer("pointerup", 42, 0.68, 0.52),
+      ];
+      for (const event of events) {
+        map.dispatchEvent(new PointerEvent(event.type, event.init));
+      }
+    });
+    expect(await page.evaluate(() => window.__areaEditor.value)).toEqual([]);
+    await editor.locator(".fit").click();
+
+    await page.evaluate(() => {
+      const map = window.__areaEditor.shadowRoot.querySelector(".map");
+      const bounds = map.getBoundingClientRect();
+      const syntheticPointer = (type, x) => new PointerEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        pointerId: 43,
+        pointerType: "touch",
+        button: 0,
+        clientX: bounds.left + bounds.width * x,
+        clientY: bounds.top + bounds.height * 0.52,
+      });
+      const events = [
+        syntheticPointer("pointerdown", 0.42),
+        syntheticPointer("pointermove", 0.50),
+        syntheticPointer("pointerup", 0.50),
+      ];
+      for (const event of events) {
+        map.dispatchEvent(event);
+      }
+    });
+    const committed = await page.evaluate(() => window.__areaEditor.value.length);
+    expect(committed).toBeGreaterThan(0);
+
+    await page.evaluate((events) => {
+      const map = window.__areaEditor.shadowRoot.querySelector(".map");
+      for (const event of events) {
+        map.dispatchEvent(new PointerEvent(event.type, event.init));
+      }
+    }, [
+      pointer("pointerdown", 44, 220, 330),
+      pointer("pointermove", 44, 260, 330),
+      pointer("pointercancel", 44, 260, 330),
+    ]);
+    expect(await page.evaluate(() => window.__areaEditor.value.length)).toBe(committed);
+  });
+
+  test("matches native mobile double-tap zoom, drag zoom, and pan momentum", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    const editor = await loadAreaEditor(page);
+    const map = editor.locator(".map");
+    const initialWidth = Number((await map.getAttribute("viewBox")).split(" ")[2]);
+
+    const firstTapCount = await page.evaluate(() => {
+      const mapElement = window.__areaEditor.shadowRoot.querySelector(".map");
+      const bounds = mapElement.getBoundingClientRect();
+      const x = bounds.left + bounds.width * 0.42;
+      const y = bounds.top + bounds.height * 0.52;
+      const dispatch = (type, pointerId, clientY = y) => mapElement.dispatchEvent(
+        new PointerEvent(type, {
+          bubbles: true,
+          cancelable: true,
+          pointerId,
+          pointerType: "touch",
+          isPrimary: true,
+          button: 0,
+          clientX: x,
+          clientY,
+        }),
+      );
+      dispatch("pointerdown", 51);
+      dispatch("pointerup", 51);
+      const count = window.__areaEditor.value.length;
+      dispatch("pointerdown", 52);
+      dispatch("pointerup", 52);
+      return count;
+    });
+    expect(firstTapCount).toBeGreaterThan(0);
+    await expect.poll(() => page.evaluate(() => window.__areaEditor.value.length)).toBe(0);
+    await expect.poll(async () => Number(
+      (await map.getAttribute("viewBox")).split(" ")[2],
+    )).toBeLessThan(initialWidth * 0.7);
+
+    await editor.locator(".fit").click();
+    await page.evaluate(() => {
+      const mapElement = window.__areaEditor.shadowRoot.querySelector(".map");
+      const bounds = mapElement.getBoundingClientRect();
+      const x = bounds.left + bounds.width * 0.42;
+      const y = bounds.top + bounds.height * 0.52;
+      const dispatch = (type, pointerId, clientY = y) => mapElement.dispatchEvent(
+        new PointerEvent(type, {
+          bubbles: true,
+          cancelable: true,
+          pointerId,
+          pointerType: "touch",
+          isPrimary: true,
+          button: 0,
+          clientX: x,
+          clientY,
+        }),
+      );
+      dispatch("pointerdown", 53);
+      dispatch("pointerup", 53);
+      dispatch("pointerdown", 54);
+      dispatch("pointermove", 54, y - 100);
+      dispatch("pointerup", 54, y - 100);
+    });
+    expect(await page.evaluate(() => window.__areaEditor.value)).toEqual([]);
+    const dragZoomWidth = Number((await map.getAttribute("viewBox")).split(" ")[2]);
+    expect(dragZoomWidth).toBeLessThan(initialWidth * 0.6);
+
+    await editor.locator("[data-tool=pan]").click();
+    const releaseX = await page.evaluate(async () => {
+      const mapElement = window.__areaEditor.shadowRoot.querySelector(".map");
+      const bounds = mapElement.getBoundingClientRect();
+      const y = bounds.top + bounds.height * 0.52;
+      const dispatch = (type, clientX) => mapElement.dispatchEvent(
+        new PointerEvent(type, {
+          bubbles: true,
+          cancelable: true,
+          pointerId: 55,
+          pointerType: "touch",
+          isPrimary: true,
+          button: 0,
+          clientX,
+          clientY: y,
+        }),
+      );
+      const startX = bounds.left + bounds.width * 0.42;
+      dispatch("pointerdown", startX);
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      dispatch("pointermove", startX + 55);
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      dispatch("pointermove", startX + 90);
+      dispatch("pointerup", startX + 90);
+      return Number(mapElement.getAttribute("viewBox").split(" ")[0]);
+    });
+    await expect.poll(async () => Number(
+      (await map.getAttribute("viewBox")).split(" ")[0],
+    )).not.toBeCloseTo(releaseX, 2);
+  });
+
   test("declutters overlapping room labels", async ({ page }) => {
     const editor = await loadAreaEditor(page);
     await page.evaluate(() => {
@@ -1288,6 +1454,205 @@ test.describe("map studio", () => {
       cameraStepsVisible: [...element.shadowRoot.querySelectorAll(".camera-step")]
         .some((button) => button.offsetParent !== null),
     }))).toEqual({ header: 56, menuOpen: false, cameraStepsVisible: false });
+  });
+
+  test("keeps mobile maps touch-first and moves area settings into a bottom sheet", async ({ page }) => {
+    const sceneUrl = "/api/matic_robot/slam_scene/mobile";
+    const areasUrl = "/api/matic_robot/areas/mobile";
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.route("/api/matic_robot/slam_entries", async (route) => route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ entries: [{
+        entry_id: "mobile",
+        scene_url: sceneUrl,
+        areas_url: areasUrl,
+        plans_url: "/api/matic_robot/plans/mobile",
+        area_editor_url: "/matic_robot/test/room-plan-editor.js",
+        map_revision: 1,
+        map_complete: true,
+        map_health: "ready",
+      }] }),
+    }));
+    await page.route(sceneUrl, async (route) => route.fulfill({
+      status: 200,
+      contentType: "application/vnd.matic.slam-scene",
+      body: syntheticScene("Mobile room", 12),
+    }));
+    await page.route(areasUrl, async (route) => route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ scene_url: sceneUrl, rooms: ROOMS, areas: [] }),
+    }));
+    await installBrowserDoubles(page, { webgl: true });
+    const studio = await loadStudio(page, {
+      "vacuum.mobile": { attributes: { matic_entry_id: "mobile" } },
+    });
+
+    const mapLayout = await studio.evaluate((element) => {
+      const root = element.shadowRoot;
+      const viewport = root.querySelector(".viewport").getBoundingClientRect();
+      const fit = root.querySelector(".spatial-controls").getBoundingClientRect();
+      const actions = root.querySelector(".map-actions").getBoundingClientRect();
+      const cleaning = root.querySelector(".cleaning-actions").getBoundingClientRect();
+      const overlap = (first, second) => !(
+        first.right <= second.left
+        || first.left >= second.right
+        || first.bottom <= second.top
+        || first.top >= second.bottom
+      );
+      return {
+        sliderVisible: root.querySelector(".spatial-controls .zoom-control")
+          .offsetParent !== null,
+        fitSize: [fit.width, fit.height],
+        actionsSize: [actions.width, actions.height],
+        cleaningInside: cleaning.left >= viewport.left
+          && cleaning.right <= viewport.right
+          && cleaning.bottom <= viewport.bottom,
+        cleaningInLowerHalf: cleaning.top > viewport.top + viewport.height / 2,
+        topControlsOverlap: overlap(fit, actions),
+        horizontalOverflow: document.documentElement.scrollWidth > innerWidth,
+      };
+    });
+    expect(mapLayout.sliderVisible).toBe(false);
+    expect(mapLayout.fitSize[1]).toBeGreaterThanOrEqual(50);
+    expect(mapLayout.actionsSize[1]).toBeGreaterThanOrEqual(50);
+    expect(mapLayout.cleaningInside).toBe(true);
+    expect(mapLayout.cleaningInLowerHalf).toBe(true);
+    expect(mapLayout.topControlsOverlap).toBe(false);
+    expect(mapLayout.horizontalOverflow).toBe(false);
+
+    const tapStartDistance = await page.evaluate(() => {
+      const viewport = window.__studio.shadowRoot.querySelector(".viewport");
+      const bounds = viewport.getBoundingClientRect();
+      const x = bounds.left + bounds.width * 0.58;
+      const y = bounds.top + bounds.height * 0.48;
+      const dispatch = (type, pointerId, clientY = y) => viewport.dispatchEvent(
+        new PointerEvent(type, {
+          bubbles: true,
+          cancelable: true,
+          pointerId,
+          pointerType: "touch",
+          isPrimary: true,
+          button: 0,
+          clientX: x,
+          clientY,
+        }),
+      );
+      const distance = window.__studio._camera.distance;
+      dispatch("pointerdown", 61);
+      dispatch("pointerup", 61);
+      dispatch("pointerdown", 62);
+      dispatch("pointerup", 62);
+      return distance;
+    });
+    await expect.poll(() => page.evaluate(() => window.__studio._camera.distance))
+      .toBeLessThan(tapStartDistance * 0.8);
+
+    const dragStartDistance = await page.evaluate(() => {
+      window.__studio._applyPreset("three", false);
+      const viewport = window.__studio.shadowRoot.querySelector(".viewport");
+      const bounds = viewport.getBoundingClientRect();
+      const x = bounds.left + bounds.width * 0.58;
+      const y = bounds.top + bounds.height * 0.48;
+      const dispatch = (type, pointerId, clientY = y) => viewport.dispatchEvent(
+        new PointerEvent(type, {
+          bubbles: true,
+          cancelable: true,
+          pointerId,
+          pointerType: "touch",
+          isPrimary: true,
+          button: 0,
+          clientX: x,
+          clientY,
+        }),
+      );
+      const distance = window.__studio._camera.distance;
+      dispatch("pointerdown", 63);
+      dispatch("pointerup", 63);
+      dispatch("pointerdown", 64);
+      dispatch("pointermove", 64, y - 90);
+      dispatch("pointerup", 64, y - 90);
+      return distance;
+    });
+    expect(await page.evaluate(() => window.__studio._camera.distance))
+      .toBeLessThan(dragStartDistance * 0.55);
+
+    const elasticZoom = await page.evaluate(() => {
+      window.__studio._applyPreset("three", false);
+      const viewport = window.__studio.shadowRoot.querySelector(".viewport");
+      const bounds = viewport.getBoundingClientRect();
+      const x = bounds.left + bounds.width * 0.58;
+      const y = bounds.top + bounds.height * 0.48;
+      const dispatch = (type, pointerId, clientY = y) => viewport.dispatchEvent(
+        new PointerEvent(type, {
+          bubbles: true,
+          cancelable: true,
+          pointerId,
+          pointerType: "touch",
+          isPrimary: true,
+          button: 0,
+          clientX: x,
+          clientY,
+        }),
+      );
+      dispatch("pointerdown", 65);
+      dispatch("pointerup", 65);
+      dispatch("pointerdown", 66);
+      dispatch("pointermove", 66, y + 300);
+      const during = window.__studio._camera.distance;
+      const maximum = window.__studio._cameraDistanceBounds().maximum;
+      dispatch("pointerup", 66, y + 300);
+      return { during, maximum };
+    });
+    expect(elasticZoom.during).toBeGreaterThan(elasticZoom.maximum);
+    await expect.poll(() => page.evaluate(() => window.__studio._camera.distance))
+      .toBeLessThanOrEqual(elasticZoom.maximum);
+
+    await studio.locator(".cleaning-areas").click();
+    await expect(studio.locator(".area-detail")).toBeVisible();
+    const collapsed = await studio.evaluate((element) => {
+      const root = element.shadowRoot;
+      const workspace = root.querySelector(".areas-workspace").getBoundingClientRect();
+      const header = root.querySelector(".areas-header").getBoundingClientRect();
+      const sheet = root.querySelector(".area-fields").getBoundingClientRect();
+      const editor = root.querySelector("ha-selector-matic-area").shadowRoot;
+      const nav = editor.querySelector(".navigation-controls").getBoundingClientRect();
+      const tools = editor.querySelector(".tool-picker").getBoundingClientRect();
+      return {
+        headerHeight: header.height,
+        sheetHeight: sheet.height,
+        sheetInside: sheet.left >= workspace.left
+          && sheet.right <= workspace.right
+          && sheet.bottom <= workspace.bottom,
+        zoomVisible: editor.querySelector(".zoom-control").offsetParent !== null,
+        toolTargets: [...editor.querySelectorAll(".tool-picker button")]
+          .map((button) => button.getBoundingClientRect().height),
+        toolbarsShareRow: Math.abs(nav.top - tools.top) < 2,
+      };
+    });
+    expect(collapsed.headerHeight).toBeLessThanOrEqual(110);
+    expect(collapsed.sheetHeight).toBeLessThanOrEqual(76);
+    expect(collapsed.sheetInside).toBe(true);
+    expect(collapsed.zoomVisible).toBe(false);
+    expect(collapsed.toolTargets.every((height) => height >= 44)).toBe(true);
+    expect(collapsed.toolbarsShareRow).toBe(true);
+
+    await studio.locator(".area-sheet-toggle").click();
+    await expect(studio.locator(".area-sheet-toggle")).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+    await expect(studio.locator(".area-name")).toBeVisible();
+    const expandedHeight = await studio.locator(".area-fields").evaluate(
+      (sheet) => sheet.getBoundingClientRect().height,
+    );
+    expect(expandedHeight).toBeGreaterThan(collapsed.sheetHeight + 100);
+    await studio.locator(".area-name").fill("Touch area");
+    await expect(studio.locator(".area-sheet-title")).toHaveText("Touch area");
+    await expect(studio.locator(".area-sheet-summary")).toHaveText(
+      "Vacuum · Optimal",
+    );
   });
 
   test("localizes accessible controls and persists per-user view preferences", async ({ page }) => {

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -28,7 +28,7 @@ def test_release_versions_and_links_are_consistent() -> None:
     hacs = json.loads((ROOT / "hacs.json").read_text())
     project = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]
 
-    assert manifest["version"] == "0.3.1"
+    assert manifest["version"] == "0.3.2"
     assert project["version"] == manifest["version"]
     assert hacs["homeassistant"] == "2026.7.0"
     assert manifest["documentation"].startswith("https://github.com/")


### PR DESCRIPTION
## What changed

- Refine Map Studio and custom-area editing for phone and tablet safe areas.
- Add native-style pinch, pan, twist, double-tap, double-tap-drag, momentum, elastic bounds, and gesture handoff.
- Separate custom-area drawing from two-finger navigation and move area details into a contextual bottom sheet.
- Add mobile WebKit interaction coverage to the browser workflow.
- Publish 0.3.2 metadata and release notes.

## Why

The desktop map surfaces were capable, but the mobile hierarchy and gesture arbitration did not yet match the interaction quality expected from a native map. The editor could also begin painting while a one-finger gesture became a two-finger navigation gesture.

## Impact

Existing entries, plans, custom areas, automations, map history, and cleaning history are preserved. Re-pairing is not required. No robot protocol command changes are included.

## Validation

- 868 Python tests / 8,018 statements at 100% coverage.
- 41 Chromium browser tests.
- 3 iPhone WebKit interaction tests.
- Ruff lint and formatting.
- Strict MyPy.
- Public-tree privacy gate.
- Source diff integrity.
- Release archive parity.
- Clean-wheel import.
- Live Home Assistant Map Studio source installed and SHA-256 matched after reload.

Full combined Home Assistant and physical iPhone smoke remains the final publication gate.