### PR TITLE
Release 0.3.3 with automatic area revalidation

### DIFF
--- a/custom_components/matic_robot/__init__.py
+++ b/custom_components/matic_robot/__init__.py
@@ -106,6 +106,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: MaticConfigEntry) -> boo
         await coordinator.async_config_entry_first_refresh()
         plans = hass.data[DOMAIN][DATA_PLAN_MANAGER]
         serial_number = str(entry.data[CONF_SERIAL_NUMBER])
+        await plans.async_upgrade_area_bindings(
+            serial_number, coordinator.data.floor_plan
+        )
         try:
             native_history = await client.async_get_cleaning_session_records()
         except MaticError as err:

--- a/custom_components/matic_robot/area_binding.py
+++ b/custom_components/matic_robot/area_binding.py
@@ -5,20 +5,26 @@ from __future__ import annotations
 import hashlib
 import math
 import struct
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from enum import StrEnum
 from typing import Any
 
+import voluptuous as vol
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import issue_registry as ir
 
+from .area_selector import MaticAreaSelector
 from .client.models import FloorPlan
 from .const import DOMAIN
 
 AREA_SCHEMA_VERSION = 1
 MAP_BINDING_VERSION = 1
+SCOPED_MAP_BINDING_VERSION = 2
 _FINGERPRINT_DOMAIN = b"matic-area-geometry\0"
+_SCOPED_FINGERPRINT_DOMAIN = b"matic-area-local-geometry\0"
 _MILLIMETERS_PER_METER = 1_000
+_LOCAL_UNITS_PER_METER = 100
+_LOCAL_GEOMETRY_MARGIN_METERS = 0.25
 _MIN_SIGNED_64 = -(1 << 63)
 _MAX_SIGNED_64 = (1 << 63) - 1
 _AREA_REPAIR_LEARN_MORE_URL = (
@@ -119,7 +125,26 @@ def floor_plan_geometry_fingerprint(floor_plan: FloorPlan) -> str:
 
 
 def binding_for_floor_plan(floor_plan: FloorPlan) -> MapBinding:
-    """Return the versioned identity and geometry binding for a floor plan."""
+    """Return the legacy whole-floor identity and geometry binding."""
+    return {
+        "version": MAP_BINDING_VERSION,
+        **_floor_plan_binding(floor_plan),
+    }
+
+
+def binding_for_area(
+    floor_plan: FloorPlan, circles: Sequence[Mapping[str, Any]]
+) -> MapBinding:
+    """Bind an area to its map identity and nearby room geometry."""
+    return {
+        "version": SCOPED_MAP_BINDING_VERSION,
+        **_floor_plan_binding(floor_plan),
+        "local_geometry_sha256": area_geometry_fingerprint(floor_plan, circles),
+    }
+
+
+def _floor_plan_binding(floor_plan: FloorPlan) -> MapBinding:
+    """Return validated floor identity fields shared by binding versions."""
     mission_id = floor_plan.mission_id
     if (
         isinstance(mission_id, bool)
@@ -131,11 +156,96 @@ def binding_for_floor_plan(floor_plan: FloorPlan) -> MapBinding:
     if not isinstance(partition_id, str) or not partition_id:
         raise ValueError("floor plan partition id is invalid")
     return {
-        "version": MAP_BINDING_VERSION,
         "mission_id": mission_id,
         "partition_id": partition_id,
         "geometry_sha256": floor_plan_geometry_fingerprint(floor_plan),
     }
+
+
+def area_geometry_fingerprint(
+    floor_plan: FloorPlan, circles: Sequence[Mapping[str, Any]]
+) -> str:
+    """Fingerprint map geometry only near one painted cleaning area.
+
+    The fingerprint includes the immutable saved circles, mapped-floor
+    occupancy probes, and room-boundary segments within a small safety margin.
+    Geometry elsewhere on the floor cannot invalidate the area. Local boundary
+    coordinates are quantized to centimeters so sub-centimeter decoder jitter
+    does not create a Repair.
+    """
+    normalized = _validate_area_circles(floor_plan, circles)
+    ordered = sorted(
+        (
+            float(circle["x"]),
+            float(circle["y"]),
+            float(circle["radius"]),
+        )
+        for circle in normalized
+    )
+    neighborhood = (
+        min(x - radius for x, _y, radius in ordered) - _LOCAL_GEOMETRY_MARGIN_METERS,
+        min(y - radius for _x, y, radius in ordered) - _LOCAL_GEOMETRY_MARGIN_METERS,
+        max(x + radius for x, _y, radius in ordered) + _LOCAL_GEOMETRY_MARGIN_METERS,
+        max(y + radius for _x, y, radius in ordered) + _LOCAL_GEOMETRY_MARGIN_METERS,
+    )
+    room_boundaries = tuple(
+        [list(point) for point in room.boundary] for room in floor_plan.rooms
+    )
+
+    segments: set[tuple[int, int, int, int]] = set()
+    for room in floor_plan.rooms:
+        boundary = room.boundary
+        for start, end in zip(boundary, (*boundary[1:], boundary[0]), strict=True):
+            clipped = _clip_segment(start, end, neighborhood)
+            if clipped is None:
+                continue
+            first = (
+                _quantize_local(clipped[0][0]),
+                _quantize_local(clipped[0][1]),
+            )
+            second = (
+                _quantize_local(clipped[1][0]),
+                _quantize_local(clipped[1][1]),
+            )
+            if second < first:
+                first, second = second, first
+            segments.add((*first, *second))
+
+    digest = hashlib.sha256()
+    digest.update(_SCOPED_FINGERPRINT_DOMAIN)
+    digest.update(struct.pack(">H", SCOPED_MAP_BINDING_VERSION))
+    digest.update(struct.pack(">I", len(ordered)))
+    for x, y, radius in ordered:
+        digest.update(
+            struct.pack(
+                ">qqq",
+                _quantize_coordinate(x),
+                _quantize_coordinate(y),
+                _quantize_coordinate(radius),
+            )
+        )
+        probe_radius = radius + _LOCAL_GEOMETRY_MARGIN_METERS
+        diagonal = probe_radius / math.sqrt(2)
+        probes = (
+            (x, y),
+            (x - probe_radius, y),
+            (x + probe_radius, y),
+            (x, y - probe_radius),
+            (x, y + probe_radius),
+            (x - diagonal, y - diagonal),
+            (x - diagonal, y + diagonal),
+            (x + diagonal, y - diagonal),
+            (x + diagonal, y + diagonal),
+        )
+        occupancy = sum(
+            int(_point_in_floor(probe_x, probe_y, room_boundaries)) << index
+            for index, (probe_x, probe_y) in enumerate(probes)
+        )
+        digest.update(struct.pack(">H", occupancy))
+    digest.update(struct.pack(">I", len(segments)))
+    for segment in sorted(segments):
+        digest.update(struct.pack(">qqqq", *segment))
+    return digest.hexdigest()
 
 
 def area_binding_status(
@@ -156,7 +266,7 @@ def area_binding_status(
     if not isinstance(saved, Mapping) or not _valid_saved_binding(saved):
         return AreaBindingStatus.INVALID
     try:
-        current = binding_for_floor_plan(floor_plan)
+        current = _floor_plan_binding(floor_plan)
     except OverflowError, TypeError, ValueError:
         return AreaBindingStatus.INVALID
 
@@ -165,28 +275,56 @@ def area_binding_status(
     if saved["partition_id"] != current["partition_id"]:
         return AreaBindingStatus.PARTITION_CHANGED
     saved_geometry = str(saved["geometry_sha256"]).casefold()
+    if saved["version"] == MAP_BINDING_VERSION:
+        if saved_geometry != current["geometry_sha256"]:
+            return AreaBindingStatus.GEOMETRY_CHANGED
+        return AreaBindingStatus.CURRENT
+
+    try:
+        local_geometry = area_geometry_fingerprint(floor_plan, area["circles"])
+    except KeyError, OverflowError, TypeError, ValueError:
+        return AreaBindingStatus.INVALID
+    if str(saved["local_geometry_sha256"]).casefold() == local_geometry:
+        return AreaBindingStatus.CURRENT
     if saved_geometry != current["geometry_sha256"]:
         return AreaBindingStatus.GEOMETRY_CHANGED
-    return AreaBindingStatus.CURRENT
+    return AreaBindingStatus.INVALID
+
+
+def area_binding_allows_review(area: Mapping[str, Any], floor_plan: FloorPlan) -> bool:
+    """Return whether stale coordinates can be shown for local confirmation."""
+    if area_binding_status(area, floor_plan) is not AreaBindingStatus.GEOMETRY_CHANGED:
+        return False
+    try:
+        _validate_area_circles(floor_plan, area["circles"])
+    except KeyError, TypeError, ValueError:
+        return False
+    return True
 
 
 def _valid_saved_binding(binding: Mapping[str, Any]) -> bool:
     """Return whether a persisted binding has the exact supported shape."""
-    if set(binding) != {
+    base_fields = {
         "version",
         "mission_id",
         "partition_id",
         "geometry_sha256",
-    }:
+    }
+    version = binding.get("version")
+    if isinstance(version, bool) or not isinstance(version, int):
         return False
-    version = binding["version"]
+    expected_fields = (
+        base_fields
+        if version == MAP_BINDING_VERSION
+        else {*base_fields, "local_geometry_sha256"}
+    )
+    if set(binding) != expected_fields:
+        return False
     mission_id = binding["mission_id"]
     partition_id = binding["partition_id"]
     geometry = binding["geometry_sha256"]
     return (
-        not isinstance(version, bool)
-        and isinstance(version, int)
-        and version == MAP_BINDING_VERSION
+        version in {MAP_BINDING_VERSION, SCOPED_MAP_BINDING_VERSION}
         and not isinstance(mission_id, bool)
         and isinstance(mission_id, int)
         and 0 <= mission_id <= 0xFFFFFFFF
@@ -195,6 +333,84 @@ def _valid_saved_binding(binding: Mapping[str, Any]) -> bool:
         and isinstance(geometry, str)
         and len(geometry) == 64
         and all(character in "0123456789abcdefABCDEF" for character in geometry)
+        and (
+            version == MAP_BINDING_VERSION
+            or _valid_digest(binding["local_geometry_sha256"])
+        )
+    )
+
+
+def _valid_digest(value: Any) -> bool:
+    """Return whether a stored SHA-256 digest is canonicalizable."""
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(character in "0123456789abcdefABCDEF" for character in value)
+    )
+
+
+def _validate_area_circles(
+    floor_plan: FloorPlan, circles: Sequence[Mapping[str, Any]]
+) -> list[dict[str, float]]:
+    """Validate saved circles against the mapped floor without exposing them."""
+    rooms = [
+        {
+            "room_id": room.id,
+            "name": room.name,
+            "boundary": [list(point) for point in room.boundary],
+        }
+        for room in floor_plan.rooms
+    ]
+    try:
+        return MaticAreaSelector({"rooms": rooms})(circles)
+    except vol.Invalid as err:
+        raise ValueError("area circles are invalid for the mapped floor") from err
+
+
+def _point_in_floor(
+    x: float, y: float, room_boundaries: Sequence[list[list[float]]]
+) -> bool:
+    """Return whether one probe lies in any mapped room."""
+    return any(
+        MaticAreaSelector._point_in_polygon(x, y, boundary)
+        for boundary in room_boundaries
+    )
+
+
+def _clip_segment(
+    start: tuple[float, float],
+    end: tuple[float, float],
+    bounds: tuple[float, float, float, float],
+) -> tuple[tuple[float, float], tuple[float, float]] | None:
+    """Clip a line segment to an axis-aligned local area neighborhood."""
+    start_x, start_y = start
+    delta_x = end[0] - start_x
+    delta_y = end[1] - start_y
+    minimum_x, minimum_y, maximum_x, maximum_y = bounds
+    lower = 0.0
+    upper = 1.0
+    for direction, offset in (
+        (-delta_x, start_x - minimum_x),
+        (delta_x, maximum_x - start_x),
+        (-delta_y, start_y - minimum_y),
+        (delta_y, maximum_y - start_y),
+    ):
+        if direction == 0:
+            if offset < 0:
+                return None
+            continue
+        ratio = offset / direction
+        if direction < 0:
+            if ratio > upper:
+                return None
+            lower = max(lower, ratio)
+        else:
+            if ratio < lower:
+                return None
+            upper = min(upper, ratio)
+    return (
+        (start_x + lower * delta_x, start_y + lower * delta_y),
+        (start_x + upper * delta_x, start_y + upper * delta_y),
     )
 
 
@@ -222,10 +438,20 @@ def _smallest_rotation(points: _CanonicalPolygon) -> _CanonicalPolygon:
 
 def _quantize_coordinate(value: float) -> int:
     """Convert finite meters to signed millimeters, normalizing negative zero."""
+    return _quantize(value, _MILLIMETERS_PER_METER)
+
+
+def _quantize_local(value: float) -> int:
+    """Convert a local boundary coordinate to signed centimeters."""
+    return _quantize(value, _LOCAL_UNITS_PER_METER)
+
+
+def _quantize(value: float, units_per_meter: int) -> int:
+    """Convert finite meters to a bounded signed integer unit."""
     numeric = float(value)
     if not math.isfinite(numeric):
         raise ValueError("room boundary coordinates must be finite")
-    scaled = numeric * _MILLIMETERS_PER_METER
+    scaled = numeric * units_per_meter
     if not math.isfinite(scaled):
         raise ValueError("room boundary coordinate is out of range")
     quantized = math.floor(scaled + 0.5) if scaled >= 0 else math.ceil(scaled - 0.5)

--- a/custom_components/matic_robot/config_flow.py
+++ b/custom_components/matic_robot/config_flow.py
@@ -27,7 +27,9 @@ from .area_binding import (
     AREA_SCHEMA_VERSION,
     AreaBindingStatus,
     MapBinding,
+    area_binding_allows_review,
     area_binding_status,
+    binding_for_area,
     binding_for_floor_plan,
 )
 from .area_selector import MaticAreaSelector
@@ -1461,7 +1463,7 @@ class MaticRobotOptionsFlow(config_entries.OptionsFlow):
             if not area_id or area_id in self._manager.areas(self._serial_number):
                 errors["name"] = "duplicate_area"
             else:
-                _floor_plan, binding = context
+                floor_plan, _binding = context
                 self._area_id = area_id
                 await self._manager.async_save_area(
                     self._serial_number,
@@ -1472,7 +1474,9 @@ class MaticRobotOptionsFlow(config_entries.OptionsFlow):
                         "circles": user_input["area_editor"],
                         "cleaning_mode": user_input["cleaning_mode"],
                         "coverage_setting": user_input["coverage_setting"],
-                        "map_binding": binding,
+                        "map_binding": binding_for_area(
+                            floor_plan, user_input["area_editor"]
+                        ),
                     },
                 )
                 return await self.async_step_area_menu()
@@ -1500,7 +1504,7 @@ class MaticRobotOptionsFlow(config_entries.OptionsFlow):
                     clear_circles=True,
                     status=AREA_STATUS_REDRAW_REQUIRED,
                 )
-            _floor_plan, binding = context
+            floor_plan, _binding = context
             await self._manager.async_save_area(
                 self._serial_number,
                 self._area_id,
@@ -1510,19 +1514,23 @@ class MaticRobotOptionsFlow(config_entries.OptionsFlow):
                     "circles": user_input["area_editor"],
                     "cleaning_mode": user_input["cleaning_mode"],
                     "coverage_setting": user_input["coverage_setting"],
-                    "map_binding": binding,
+                    "map_binding": binding_for_area(
+                        floor_plan, user_input["area_editor"]
+                    ),
                 },
             )
             return await self.async_step_area_menu()
         context = self._live_area_context()
-        is_current = (
-            context is not None
-            and area_binding_status(area, context[0]) is AreaBindingStatus.CURRENT
+        is_current = context is not None and (
+            area_binding_status(area, context[0]) is AreaBindingStatus.CURRENT
+        )
+        can_review = context is not None and area_binding_allows_review(
+            area, context[0]
         )
         return self._show_area_form(
             "edit_area",
             area,
-            clear_circles=not is_current,
+            clear_circles=not is_current and not can_review,
             status=(AREA_STATUS_CURRENT if is_current else AREA_STATUS_REDRAW_REQUIRED),
         )
 

--- a/custom_components/matic_robot/manifest.json
+++ b/custom_components/matic_robot/manifest.json
@@ -24,7 +24,7 @@
     "numpy==2.3.2",
     "protobuf>=6"
   ],
-  "version": "0.3.2",
+  "version": "0.3.3",
   "zeroconf": [
     "_matic_hermes._tcp.local."
   ]

--- a/custom_components/matic_robot/matic_map_studio.js
+++ b/custom_components/matic_robot/matic_map_studio.js
@@ -3179,7 +3179,12 @@ class MaticMapStudio extends HTMLElement {
   _resetAreaSavePresentation() {
     const save = this.shadowRoot.querySelector(".area-save");
     if (!save) return;
-    save.textContent = this._localize("area_save", "Save area");
+    const area = this._areas.find(
+      (candidate) => candidate.id === this._selectedAreaId,
+    );
+    save.textContent = area?.can_rebind
+      ? this._localize("area_confirm_current", "Confirm on current map")
+      : this._localize("area_save", "Save area");
     save.removeAttribute("aria-busy");
   }
 
@@ -3570,7 +3575,7 @@ class MaticMapStudio extends HTMLElement {
     for (const area of this._areas) {
       const option = document.createElement("option");
       option.value = String(area.id);
-      option.textContent = String(area.name || area.id);
+      option.textContent = `${area.status === "current" ? "" : "⚠ "}${String(area.name || area.id)}`;
       picker.append(option);
     }
     picker.value = this._selectedAreaId || "";
@@ -3593,9 +3598,12 @@ class MaticMapStudio extends HTMLElement {
     const draft = this._areaDraft();
     const valid = Boolean(draft.name && draft.circles.length);
     const dirty = JSON.stringify(draft) !== this._areaBaseline;
+    const area = this._areas.find(
+      (candidate) => candidate.id === this._selectedAreaId,
+    );
     const save = this.shadowRoot.querySelector(".area-save");
     const run = this.shadowRoot.querySelector(".area-run");
-    if (save) save.disabled = !valid || !dirty;
+    if (save) save.disabled = !valid || (!dirty && !area?.can_rebind);
     if (run && !run.hidden) run.disabled = dirty;
   }
 
@@ -3627,9 +3635,28 @@ class MaticMapStudio extends HTMLElement {
       embedded: true,
     };
     editor.value = area?.circles || [];
-    editor.addEventListener("value-changed", () => this._syncAreaActions());
+    editor.addEventListener("value-changed", () => {
+      this._setAreaActionStatus("");
+      this._syncAreaActions();
+    });
     host.append(editor);
     this._areaBaseline = JSON.stringify(this._areaDraft());
+    if (area?.can_rebind) {
+      this._setAreaActionStatus(
+        this._localize(
+          "area_review_required",
+          "Review the saved outline, then confirm it on the current map.",
+        ),
+      );
+    } else if (area && area.status !== "current") {
+      this._setAreaActionStatus(
+        this._localize(
+          "area_redraw_required",
+          "Redraw this area on the current map before saving.",
+        ),
+        "error",
+      );
+    }
     this._syncAreaActions();
     this._syncAreaSheet();
   }

--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -17,6 +17,12 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.storage import Store
 from homeassistant.util import dt as dt_util
 
+from .area_binding import (
+    MAP_BINDING_VERSION,
+    AreaBindingStatus,
+    area_binding_status,
+    binding_for_area,
+)
 from .client.models import CleaningSessionRecord, FloorPlan
 from .const import DOMAIN
 
@@ -359,6 +365,31 @@ class CleaningPlanManager:
     def areas(self, serial_number: str) -> dict[str, dict[str, Any]]:
         """Return a private copy of locally saved drawn areas."""
         return deepcopy(self._robot(serial_number)["areas"])
+
+    async def async_upgrade_area_bindings(
+        self, serial_number: str, floor_plan: FloorPlan | None
+    ) -> int:
+        """Upgrade exactly current whole-map area bindings to scoped bindings."""
+        if floor_plan is None:
+            return 0
+        upgraded = 0
+        for area in self._robot(serial_number)["areas"].values():
+            binding = area.get("map_binding")
+            if (
+                not isinstance(binding, Mapping)
+                or binding.get("version") != MAP_BINDING_VERSION
+                or area_binding_status(area, floor_plan)
+                is not AreaBindingStatus.CURRENT
+            ):
+                continue
+            try:
+                area["map_binding"] = binding_for_area(floor_plan, area["circles"])
+            except KeyError, TypeError, ValueError:
+                continue
+            upgraded += 1
+        if upgraded:
+            await self._async_save_and_notify(serial_number)
+        return upgraded
 
     def area(self, serial_number: str, reference: str | None = None) -> dict[str, Any]:
         """Return one locally saved area by stable ID or exact name."""

--- a/custom_components/matic_robot/slam_scene.py
+++ b/custom_components/matic_robot/slam_scene.py
@@ -23,8 +23,9 @@ from homeassistant.util import slugify
 from .area_binding import (
     AREA_SCHEMA_VERSION,
     AreaBindingStatus,
+    area_binding_allows_review,
     area_binding_status,
-    binding_for_floor_plan,
+    binding_for_area,
 )
 from .area_selector import MaticAreaSelector
 from .client.commands import CleaningMode, CoverageSetting
@@ -613,12 +614,13 @@ class MaticAreasView(HomeAssistantView):
         areas = []
         for area_id, area in runtime.cleaning_plans.areas(serial_number).items():
             status = area_binding_status(area, floor_plan)
+            can_rebind = area_binding_allows_review(area, floor_plan)
             areas.append(
                 {
                     "id": area_id,
                     "name": str(area.get("name", area_id)),
                     "circles": area.get("circles", [])
-                    if status is AreaBindingStatus.CURRENT
+                    if status is AreaBindingStatus.CURRENT or can_rebind
                     else [],
                     "cleaning_mode": area.get(
                         "cleaning_mode", CleaningMode.VACUUM.value
@@ -627,6 +629,7 @@ class MaticAreasView(HomeAssistantView):
                         "coverage_setting", CoverageSetting.OPTIMAL.value
                     ),
                     "status": status.value,
+                    "can_rebind": can_rebind,
                 }
             )
         return self.json(
@@ -668,7 +671,7 @@ class MaticAreasView(HomeAssistantView):
             circles = MaticAreaSelector({"rooms": rooms})(body["circles"])
             cleaning_mode = CleaningMode(str(body["cleaning_mode"]))
             coverage_setting = CoverageSetting(str(body["coverage_setting"]))
-            binding = binding_for_floor_plan(floor_plan)
+            binding = binding_for_area(floor_plan, circles)
         except KeyError, TypeError, ValueError, vol.Invalid:
             return web.Response(
                 status=HTTPStatus.BAD_REQUEST, headers=PRIVATE_NO_STORE_HEADERS

--- a/custom_components/matic_robot/strings.json
+++ b/custom_components/matic_robot/strings.json
@@ -9,6 +9,7 @@
     "area_layer_photo": "Photo",
     "area_layer_rooms": "Rooms",
     "area_confirm_delete": "Confirm delete",
+    "area_confirm_current": "Confirm on current map",
     "area_delete": "Delete",
     "area_map": "Custom cleaning area map",
     "area_map_controls": "Map controls",
@@ -26,6 +27,8 @@
     "area_photo_ready": "Private photo map",
     "area_photo_refresh": "Refresh photo map",
     "area_photo_unavailable": "Photo map unavailable · showing rooms",
+    "area_redraw_required": "Redraw this area on the current map before saving.",
+    "area_review_required": "Review the saved outline, then confirm it on the current map.",
     "area_run": "Clean now",
     "area_save": "Save area",
     "area_settings": "Cleaning settings",
@@ -804,8 +807,8 @@
       "description": "The device at the configured Matic address presented a TLS certificate that does not match the pinned robot identity. Communication is blocked until the certificate matches again. If the robot was factory reset or replaced, re-pair it through **Settings > Devices & Services > Matic Robot > Reconfigure**."
     },
     "custom_area_map_changed": {
-      "title": "Matic custom areas need to be redrawn",
-      "description": "Saved custom areas requiring redraw: {count}. Their map identity no longer matches the robot's current room map, so Home Assistant will not start them. Open **Settings > Devices & services > Matic Robot > Configure > Custom cleaning areas**, redraw each marked area, and save it again."
+      "title": "Matic custom areas need map review",
+      "description": "Saved custom areas requiring review: {count}. Their mission, partition, or nearby map geometry no longer matches the robot's current room map, so Home Assistant will not start them. Open **Matic Map > Custom areas**, review and confirm the saved outline when offered, or redraw it on the current map."
     }
   },
   "services": {

--- a/custom_components/matic_robot/translations/en.json
+++ b/custom_components/matic_robot/translations/en.json
@@ -9,6 +9,7 @@
     "area_layer_photo": "Photo",
     "area_layer_rooms": "Rooms",
     "area_confirm_delete": "Confirm delete",
+    "area_confirm_current": "Confirm on current map",
     "area_delete": "Delete",
     "area_map": "Custom cleaning area map",
     "area_map_controls": "Map controls",
@@ -26,6 +27,8 @@
     "area_photo_ready": "Private photo map",
     "area_photo_refresh": "Refresh photo map",
     "area_photo_unavailable": "Photo map unavailable · showing rooms",
+    "area_redraw_required": "Redraw this area on the current map before saving.",
+    "area_review_required": "Review the saved outline, then confirm it on the current map.",
     "area_run": "Clean now",
     "area_save": "Save area",
     "area_settings": "Cleaning settings",
@@ -804,8 +807,8 @@
       "description": "The device at the configured Matic address presented a TLS certificate that does not match the pinned robot identity. Communication is blocked until the certificate matches again. If the robot was factory reset or replaced, re-pair it through **Settings > Devices & Services > Matic Robot > Reconfigure**."
     },
     "custom_area_map_changed": {
-      "title": "Matic custom areas need to be redrawn",
-      "description": "Saved custom areas requiring redraw: {count}. Their map identity no longer matches the robot's current room map, so Home Assistant will not start them. Open **Settings > Devices & services > Matic Robot > Configure > Custom cleaning areas**, redraw each marked area, and save it again."
+      "title": "Matic custom areas need map review",
+      "description": "Saved custom areas requiring review: {count}. Their mission, partition, or nearby map geometry no longer matches the robot's current room map, so Home Assistant will not start them. Open **Matic Map > Custom areas**, review and confirm the saved outline when offered, or redraw it on the current map."
     }
   },
   "services": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,8 @@ the integration so instructions and behavior stay aligned with each release.
   discovery, passkey, room-mapping, firmware, and Bluetooth constraints.
 - [Firmware compatibility](firmware-compatibility.md) — Track observed robot
   versions, validation status, regressions, and newly discovered capabilities.
+- [Release notes — 0.3.3](release-notes-0.3.3.md) — Automatic custom-area map
+  revalidation with safe review when nearby geometry changes
 - [Release notes — 0.3.2](release-notes-0.3.2.md) — Native mobile gestures and
   a touch-first Map Studio and custom-area workspace
 - [Release notes — 0.3.1](release-notes-0.3.1.md) — Quick, Optimal, and Heavy

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -102,9 +102,18 @@ Home Assistant stores the geometry locally and the action accepts only its
 name. The saved record also binds it to the exact coverage mission, standard
 partition, and canonical room geometry it was drawn on. A legacy unbound area,
 remap, floor change, or geometry mismatch is blocked before any robot command.
-Home Assistant raises one privacy-safe Repair with only the number of affected
-areas and directs an administrator to **Matic Map → Cleaning areas**.
-Editing preserves name/mode/coverage but requires redrawing on the live map; no
+Newly confirmed areas also retain a private signature of mapped geometry only
+within a 25 cm margin of their painted marks. Changes elsewhere on the floor
+and sub-centimeter boundary jitter revalidate automatically while mission,
+partition, and nearby-geometry changes still fail closed. An exactly current
+legacy binding upgrades to this scoped signature safely at
+integration startup, so an area does not need to be repainted just to migrate.
+Home Assistant raises
+one privacy-safe Repair with only the number of affected areas and directs an
+administrator to **Matic Map → Custom areas**. A same-mission area whose saved
+marks remain valid is shown for review and can be rebound with **Confirm on
+current map** without repainting. A mission or partition change, invalid
+geometry, or marks outside the current floor still requires a redraw; no
 automatic coordinate transform or cross-floor migration is attempted. A
 temporarily unavailable live map reports that condition without creating or
 clearing mismatch state.

--- a/docs/release-notes-0.3.3.md
+++ b/docs/release-notes-0.3.3.md
@@ -1,0 +1,41 @@
+# Release notes — 0.3.3
+
+Released: 2026-08-07
+
+## Summary
+
+0.3.3 makes saved custom cleaning areas resilient to unrelated map redraws.
+Each newly confirmed area records a private signature of only the mapped
+geometry near its painted marks, allowing harmless changes elsewhere on the
+floor to revalidate automatically.
+
+## Safer map revalidation
+
+- Unrelated room-boundary changes and sub-centimeter decoder jitter no longer
+  invalidate every custom area on the floor.
+- Coverage mission, partition and nearby geometry changes still fail closed
+  before any robot command is sent.
+- A same-mission area with valid saved coordinates can be reviewed and rebound
+  with **Confirm on current map** without repainting it.
+- Areas whose coordinates are invalid or outside the current floor still
+  require a redraw; the integration never guesses a coordinate transform.
+- An exactly current legacy area binding upgrades automatically at integration
+  startup, preserving areas that were already cleared before this update.
+- The Repair now directs administrators to the Custom areas workspace and
+  reports only the affected count, never saved geometry.
+
+This release changes no robot protocol commands and sends no map data outside
+Home Assistant.
+
+## Verification
+
+The release candidate passes 875 Python tests / 8,137 statements at 100%
+coverage, 42 Chromium browser tests, three iPhone WebKit interaction tests,
+strict typing, lint and format checks, and the public-tree privacy gate.
+
+## Upgrading from 0.3.2
+
+Install 0.3.3 through HACS and restart Home Assistant. Existing entries, plans,
+custom areas, automations, map history and cleaning history are preserved.
+Current legacy custom-area bindings upgrade automatically; re-pairing is not
+required.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "matic-home-assistant"
-version = "0.3.2"
+version = "0.3.3"
 description = "Unofficial local-only Home Assistant integration for Matic robot vacuums"
 readme = "README.md"
 license = "MIT"

--- a/tests/browser/ui.spec.mjs
+++ b/tests/browser/ui.spec.mjs
@@ -803,6 +803,89 @@ test.describe("map studio", () => {
     await expect(studio.locator(".areas-status")).toHaveText("0 saved areas");
   });
 
+  test("confirms a reviewable stale area without repainting it", async ({ page }) => {
+    const sceneUrl = "/api/matic_robot/slam_scene/review";
+    const areasUrl = "/api/matic_robot/areas/review";
+    const circles = [{ x: 0.5, y: 0.5, radius: 0.35 }];
+    let confirmed;
+    await page.route("/api/matic_robot/slam_entries", async (route) => route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ entries: [{
+        entry_id: "review",
+        scene_url: sceneUrl,
+        areas_url: areasUrl,
+        plans_url: "/api/matic_robot/plans/review",
+        area_editor_url: "/matic_robot/test/room-plan-editor.js",
+        map_revision: 1,
+        map_complete: true,
+        map_health: "ready",
+      }] }),
+    }));
+    await page.route(sceneUrl, async (route) => route.fulfill({
+      status: 200,
+      contentType: "application/vnd.matic.slam-scene",
+      body: syntheticScene("Review room", 10),
+    }));
+    await page.route(areasUrl, async (route) => {
+      if (route.request().method() === "POST") {
+        confirmed = JSON.parse(route.request().postData());
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ id: "litter_box" }),
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          scene_url: sceneUrl,
+          rooms: ROOMS,
+          areas: [{
+            id: "litter_box",
+            name: "Litter box",
+            circles,
+            cleaning_mode: "vacuum",
+            coverage_setting: "standard",
+            status: confirmed ? "current" : "geometry_changed",
+            can_rebind: !confirmed,
+          }],
+        }),
+      });
+    });
+    const studio = await loadStudio(page, {
+      "vacuum.review": { attributes: { matic_entry_id: "review" } },
+    });
+
+    await studio.locator(".cleaning-areas").click();
+    await expect(studio.locator(".areas-list option").nth(1))
+      .toHaveText("⚠ Litter box");
+    await expect(studio.locator(".area-feedback")).toHaveText(
+      "Review the saved outline, then confirm it on the current map.",
+    );
+    await expect(studio.locator(".area-save")).toHaveText(
+      "Confirm on current map",
+    );
+    await expect(studio.locator(".area-save")).toBeEnabled();
+    await expect(studio.locator(".area-run")).toBeHidden();
+    expect(await studio.locator("ha-selector-matic-area").evaluate(
+      (editor) => editor.value,
+    )).toEqual(circles);
+
+    await studio.locator(".area-save").click();
+
+    await expect(studio.locator(".area-feedback")).toHaveText("Area saved");
+    await expect(studio.locator(".area-save")).toHaveText("Save area");
+    await expect(studio.locator(".area-run")).toBeVisible();
+    expect(confirmed).toMatchObject({
+      area_id: "litter_box",
+      name: "Litter box",
+      circles,
+    });
+  });
+
   test("streams bounded scene deltas without refetching the full map", async ({ page }) => {
     await installBrowserDoubles(page, { webgl: true });
     const initial = syntheticScene("Initial room", 10);

--- a/tests/test_area_binding.py
+++ b/tests/test_area_binding.py
@@ -10,10 +10,14 @@ import pytest
 from custom_components.matic_robot.area_binding import (
     AREA_SCHEMA_VERSION,
     MAP_BINDING_VERSION,
+    SCOPED_MAP_BINDING_VERSION,
     AreaBindingStatus,
+    area_binding_allows_review,
     area_binding_status,
+    area_geometry_fingerprint,
     async_delete_custom_area_issue,
     async_sync_custom_area_issue,
+    binding_for_area,
     binding_for_floor_plan,
     custom_area_issue_id,
     floor_plan_geometry_fingerprint,
@@ -54,6 +58,19 @@ def _area(floor_plan: FloorPlan | None = None) -> dict[str, object]:
     return {
         "schema_version": AREA_SCHEMA_VERSION,
         "map_binding": binding_for_floor_plan(floor_plan or _floor_plan()),
+    }
+
+
+def _scoped_area(
+    floor_plan: FloorPlan | None = None,
+    circles: list[dict[str, float]] | None = None,
+) -> dict[str, object]:
+    plan = floor_plan or _floor_plan()
+    saved_circles = circles or [{"x": 0.5, "y": 0.5, "radius": 0.1}]
+    return {
+        "schema_version": AREA_SCHEMA_VERSION,
+        "circles": saved_circles,
+        "map_binding": binding_for_area(plan, saved_circles),
     }
 
 
@@ -216,6 +233,127 @@ def test_binding_contains_only_versioned_current_map_identity() -> None:
         "partition_id": "synthetic-partition",
         "geometry_sha256": floor_plan_geometry_fingerprint(floor_plan),
     }
+
+
+def test_scoped_binding_contains_private_local_geometry_signature() -> None:
+    floor_plan = _floor_plan()
+    circles = [
+        {"x": 0.5, "y": 0.5, "radius": 0.1},
+        {"x": 0.7, "y": 0.5, "radius": 0.15},
+    ]
+
+    assert binding_for_area(floor_plan, circles) == {
+        "version": SCOPED_MAP_BINDING_VERSION,
+        "mission_id": 42,
+        "partition_id": "synthetic-partition",
+        "geometry_sha256": floor_plan_geometry_fingerprint(floor_plan),
+        "local_geometry_sha256": area_geometry_fingerprint(floor_plan, circles),
+    }
+    assert area_geometry_fingerprint(floor_plan, circles) == (
+        area_geometry_fingerprint(floor_plan, list(reversed(circles)))
+    )
+
+
+def test_scoped_binding_automatically_accepts_unrelated_geometry_changes() -> None:
+    floor_plan = _floor_plan()
+    area = _scoped_area(floor_plan)
+    kitchen, study = floor_plan.rooms
+    changed_elsewhere = replace(
+        floor_plan,
+        rooms=(
+            replace(
+                kitchen,
+                boundary=((0.0, 0.0), (2.2, 0.0), (2.2, 1.5), (0.0, 1.5)),
+            ),
+            replace(
+                study,
+                boundary=((2.2, 0.0), (3.2, 0.0), (3.2, 1.0), (2.2, 1.0)),
+            ),
+        ),
+    )
+
+    assert floor_plan_geometry_fingerprint(changed_elsewhere) != (
+        floor_plan_geometry_fingerprint(floor_plan)
+    )
+    assert area_binding_status(area, changed_elsewhere) is AreaBindingStatus.CURRENT
+
+
+def test_scoped_binding_tolerates_local_subcentimeter_jitter() -> None:
+    floor_plan = _floor_plan()
+    circles = [{"x": 0.1, "y": 0.5, "radius": 0.05}]
+    area = _scoped_area(floor_plan, circles)
+    kitchen, study = floor_plan.rooms
+    jittered = replace(
+        floor_plan,
+        rooms=(
+            replace(
+                kitchen,
+                boundary=((0.004, 0.0), *kitchen.boundary[1:]),
+            ),
+            study,
+        ),
+    )
+
+    assert floor_plan_geometry_fingerprint(jittered) != (
+        floor_plan_geometry_fingerprint(floor_plan)
+    )
+    assert area_binding_status(area, jittered) is AreaBindingStatus.CURRENT
+
+
+def test_scoped_binding_blocks_nearby_geometry_and_circle_changes() -> None:
+    floor_plan = _floor_plan()
+    circles = [{"x": 0.1, "y": 0.5, "radius": 0.05}]
+    area = _scoped_area(floor_plan, circles)
+    kitchen, study = floor_plan.rooms
+    nearby_change = replace(
+        floor_plan,
+        rooms=(
+            replace(
+                kitchen,
+                boundary=((0.05, 0.0), *kitchen.boundary[1:]),
+            ),
+            study,
+        ),
+    )
+
+    assert (
+        area_binding_status(area, nearby_change) is AreaBindingStatus.GEOMETRY_CHANGED
+    )
+    changed_circles = {**area, "circles": [{"x": 0.2, "y": 0.5, "radius": 0.05}]}
+    assert area_binding_status(changed_circles, floor_plan) is AreaBindingStatus.INVALID
+    missing_circles = {key: value for key, value in area.items() if key != "circles"}
+    assert area_binding_status(missing_circles, floor_plan) is AreaBindingStatus.INVALID
+
+
+def test_stale_same_map_area_can_be_reviewed_without_blind_rebinding() -> None:
+    floor_plan = _floor_plan()
+    circles = [{"x": 0.5, "y": 0.5, "radius": 0.1}]
+    area = {**_area(floor_plan), "circles": circles}
+    changed = replace(
+        floor_plan,
+        rooms=(
+            replace(
+                floor_plan.rooms[0],
+                boundary=((0.01, 0.0), *floor_plan.rooms[0].boundary[1:]),
+            ),
+            floor_plan.rooms[1],
+        ),
+    )
+
+    assert area_binding_allows_review(area, changed) is True
+    assert (
+        area_binding_allows_review(
+            area, replace(changed, mission_id=changed.mission_id + 1)
+        )
+        is False
+    )
+    assert (
+        area_binding_allows_review(
+            {**area, "circles": [{"x": 20.0, "y": 20.0, "radius": 0.1}]},
+            changed,
+        )
+        is False
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -19,6 +19,7 @@ from zeroconf import ServiceStateChange
 from custom_components.matic_robot import config_flow as flow_module
 from custom_components.matic_robot.area_binding import (
     AREA_SCHEMA_VERSION,
+    binding_for_area,
     binding_for_floor_plan,
 )
 from custom_components.matic_robot.client.exceptions import CannotConnectError
@@ -1126,8 +1127,8 @@ async def test_options_flow_draws_edits_and_deletes_custom_area(hass) -> None:
     saved = manager.area("synthetic-serial", "Litter box")
     assert saved["circles"] == [{"x": 0.5, "y": 0.5, "radius": 0.35}]
     assert saved["schema_version"] == AREA_SCHEMA_VERSION
-    assert saved["map_binding"] == binding_for_floor_plan(
-        entry.runtime_data.coordinator.data.floor_plan
+    assert saved["map_binding"] == binding_for_area(
+        entry.runtime_data.coordinator.data.floor_plan, saved["circles"]
     )
 
     result = await _select_menu_step(hass, result, "edit_area")
@@ -1184,7 +1185,10 @@ async def test_custom_area_editor_blocks_map_changes_and_rebinds_after_redraw(
     )
     assert result["step_id"] == "area_menu"
     assert manager.area("synthetic-serial", "table")["map_binding"] == (
-        binding_for_floor_plan(entry.runtime_data.coordinator.data.floor_plan)
+        binding_for_area(
+            entry.runtime_data.coordinator.data.floor_plan,
+            manager.area("synthetic-serial", "table")["circles"],
+        )
     )
 
 
@@ -1274,9 +1278,53 @@ async def test_legacy_area_is_labeled_and_must_be_redrawn_on_current_map(hass) -
     saved = manager.area("synthetic-serial", "litter_box")
     assert saved["circles"] == [{"x": 0.6, "y": 0.5, "radius": 0.4}]
     assert saved["schema_version"] == AREA_SCHEMA_VERSION
-    assert saved["map_binding"] == binding_for_floor_plan(
-        entry.runtime_data.coordinator.data.floor_plan
+    assert saved["map_binding"] == binding_for_area(
+        entry.runtime_data.coordinator.data.floor_plan, saved["circles"]
     )
+
+
+async def test_geometry_changed_area_can_be_confirmed_without_redrawing(hass) -> None:
+    entry, manager = await _options_entry(hass)
+    floor_plan = entry.runtime_data.coordinator.data.floor_plan
+    saved_floor_plan = replace(
+        floor_plan,
+        rooms=(
+            replace(
+                floor_plan.rooms[0],
+                boundary=((0.01, 0.0), *floor_plan.rooms[0].boundary[1:]),
+            ),
+        ),
+    )
+    circles = [{"x": 0.5, "y": 0.5, "radius": 0.35}]
+    await manager.async_save_area(
+        "synthetic-serial",
+        "litter_box",
+        {
+            "schema_version": AREA_SCHEMA_VERSION,
+            "name": "Litter box",
+            "circles": circles,
+            "cleaning_mode": "vacuum_and_mop",
+            "coverage_setting": "quick",
+            "map_binding": binding_for_floor_plan(saved_floor_plan),
+        },
+    )
+    flow = _direct_options_flow(hass, entry)
+    flow._area_id = "litter_box"
+
+    form = await flow.async_step_edit_area()
+
+    assert _form_defaults(form)["area_editor"] == circles
+    result = await flow.async_step_edit_area(
+        {
+            "name": "Litter box",
+            "area_editor": circles,
+            "cleaning_mode": "vacuum_and_mop",
+            "coverage_setting": "quick",
+        }
+    )
+    assert result["step_id"] == "area_menu"
+    saved = manager.area("synthetic-serial", "litter_box")
+    assert saved["map_binding"] == binding_for_area(floor_plan, circles)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -131,6 +131,7 @@ async def test_setup_refreshes_before_forwarding_platforms(
     plans = MagicMock()
     plans.areas.return_value = {}
     plans.async_add_listener.return_value = plan_unsubscribe
+    plans.async_upgrade_area_bindings = AsyncMock(return_value=0)
     plans.async_import_native_history = AsyncMock(return_value=False)
     hass = SimpleNamespace(
         config=SimpleNamespace(time_zone="America/Los_Angeles"),
@@ -193,6 +194,7 @@ async def test_setup_refreshes_before_forwarding_platforms(
 
     decode.assert_called_once_with("test-credential")
     coordinator.async_config_entry_first_refresh.assert_awaited_once()
+    plans.async_upgrade_area_bindings.assert_awaited_once_with("synthetic-serial", None)
     if native_history_error:
         plans.async_import_native_history.assert_not_awaited()
     else:
@@ -303,6 +305,7 @@ async def test_revoked_credential_enters_reauthentication_before_setup() -> None
 
 async def test_setup_closes_client_when_platform_forwarding_fails() -> None:
     plans = MagicMock()
+    plans.async_upgrade_area_bindings = AsyncMock(return_value=0)
     plans.async_import_native_history = AsyncMock(return_value=False)
     hass = SimpleNamespace(
         config=SimpleNamespace(time_zone="UTC"),

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -12,6 +12,8 @@ from homeassistant.util import dt as dt_util
 
 from custom_components.matic_robot.area_binding import (
     AREA_SCHEMA_VERSION,
+    SCOPED_MAP_BINDING_VERSION,
+    binding_for_area,
     binding_for_floor_plan,
 )
 from custom_components.matic_robot.client.commands import UserCommand
@@ -234,6 +236,65 @@ async def test_custom_areas_round_trip_by_id_and_name_without_snapshot(hass) -> 
 
     await manager.async_delete_area("serial", "litter_box")
     assert manager.areas("serial") == {}
+
+
+async def test_current_v1_area_bindings_upgrade_automatically(hass) -> None:
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    listener = MagicMock()
+    manager.async_add_listener("serial", listener)
+    floor_plan = FloorPlan(
+        42,
+        "synthetic-partition",
+        b"synthetic-partition",
+        (Room("room", "Room", "protocol", b"room", ((0, 0), (2, 0), (0, 2))),),
+    )
+    circles = [{"x": 0.5, "y": 0.5, "radius": 0.2}]
+    robot = manager._robot("serial")
+    robot["areas"] = {
+        "current": {
+            "schema_version": AREA_SCHEMA_VERSION,
+            "circles": circles,
+            "map_binding": binding_for_floor_plan(floor_plan),
+        },
+        "already_scoped": {
+            "schema_version": AREA_SCHEMA_VERSION,
+            "circles": circles,
+            "map_binding": binding_for_area(floor_plan, circles),
+        },
+        "different_mission": {
+            "schema_version": AREA_SCHEMA_VERSION,
+            "circles": circles,
+            "map_binding": binding_for_floor_plan(
+                FloorPlan(
+                    43,
+                    floor_plan.partition_protocol_id,
+                    floor_plan.partition_id_wire,
+                    floor_plan.rooms,
+                )
+            ),
+        },
+        "missing_circles": {
+            "schema_version": AREA_SCHEMA_VERSION,
+            "map_binding": binding_for_floor_plan(floor_plan),
+        },
+        "unbound": {"schema_version": 0, "circles": circles},
+        "corrupt": "not-an-area",
+    }
+
+    assert await manager.async_upgrade_area_bindings("serial", floor_plan) == 1
+    assert robot["areas"]["current"]["map_binding"]["version"] == (
+        SCOPED_MAP_BINDING_VERSION
+    )
+    manager._store.async_save.assert_awaited_once()
+    listener.assert_called_once()
+
+    manager._store.async_save.reset_mock()
+    listener.reset_mock()
+    assert await manager.async_upgrade_area_bindings("serial", floor_plan) == 0
+    assert await manager.async_upgrade_area_bindings("serial", None) == 0
+    manager._store.async_save.assert_not_awaited()
+    listener.assert_not_called()
 
 
 async def test_native_history_import_recovers_only_explicit_room_completions(

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -28,7 +28,7 @@ def test_release_versions_and_links_are_consistent() -> None:
     hacs = json.loads((ROOT / "hacs.json").read_text())
     project = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]
 
-    assert manifest["version"] == "0.3.2"
+    assert manifest["version"] == "0.3.3"
     assert project["version"] == manifest["version"]
     assert hacs["homeassistant"] == "2026.7.0"
     assert manifest["documentation"].startswith("https://github.com/")

--- a/tests/test_slam_scene.py
+++ b/tests/test_slam_scene.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from dataclasses import replace
 from datetime import UTC, datetime
 from http import HTTPStatus
 from types import SimpleNamespace
@@ -18,6 +19,7 @@ from homeassistant.helpers.http import KEY_HASS
 
 from custom_components.matic_robot.area_binding import (
     AREA_SCHEMA_VERSION,
+    binding_for_area,
     binding_for_floor_plan,
 )
 from custom_components.matic_robot.client.exceptions import CannotConnectError
@@ -648,6 +650,29 @@ async def test_area_workspace_lists_current_and_stale_private_areas() -> None:
             "map_binding": current_binding,
             "schema_version": AREA_SCHEMA_VERSION,
         },
+        "review": {
+            "name": "Review",
+            "circles": [{"x": 0.1, "y": 0.1, "radius": 0.1}],
+            "cleaning_mode": "vacuum_and_mop",
+            "coverage_setting": "standard",
+            "map_binding": binding_for_floor_plan(
+                replace(
+                    runtime.coordinator.data.floor_plan,
+                    rooms=(
+                        replace(
+                            runtime.coordinator.data.floor_plan.rooms[0],
+                            boundary=(
+                                (0.01, 0.0),
+                                (0.3, 0.0),
+                                (0.3, 0.3),
+                                (0.0, 0.3),
+                            ),
+                        ),
+                    ),
+                )
+            ),
+            "schema_version": AREA_SCHEMA_VERSION,
+        },
         "legacy": {"name": "Legacy"},
     }
     hass = _hass(_entry(runtime))
@@ -672,6 +697,16 @@ async def test_area_workspace_lists_current_and_stale_private_areas() -> None:
                 "cleaning_mode": "vacuum",
                 "coverage_setting": "quick",
                 "status": "current",
+                "can_rebind": False,
+            },
+            {
+                "id": "review",
+                "name": "Review",
+                "circles": [{"x": 0.1, "y": 0.1, "radius": 0.1}],
+                "cleaning_mode": "vacuum_and_mop",
+                "coverage_setting": "standard",
+                "status": "geometry_changed",
+                "can_rebind": True,
             },
             {
                 "id": "legacy",
@@ -680,6 +715,7 @@ async def test_area_workspace_lists_current_and_stale_private_areas() -> None:
                 "cleaning_mode": "vacuum",
                 "coverage_setting": "standard",
                 "status": "legacy",
+                "can_rebind": False,
             },
         ],
     }
@@ -782,7 +818,9 @@ async def test_area_workspace_saves_updates_and_deletes_validated_areas() -> Non
             "circles": [{"x": 0.1, "y": 0.1, "radius": 0.2}],
             "cleaning_mode": "vacuum_and_mop",
             "coverage_setting": "standard",
-            "map_binding": binding_for_floor_plan(runtime.coordinator.data.floor_plan),
+            "map_binding": binding_for_area(
+                runtime.coordinator.data.floor_plan, values["circles"]
+            ),
         },
     )
 


### PR DESCRIPTION
## What changed

- Add scoped v2 custom-area map bindings that fingerprint geometry near each painted area.
- Automatically tolerate unrelated redraws and sub-centimeter boundary jitter.
- Preserve same-map stale outlines for one-click confirmation while keeping unsafe changes fail-closed.
- Migrate exactly current v1 bindings automatically at integration startup.
- Publish 0.3.3 metadata, documentation, release notes, and full regression coverage.

## Why

The previous v1 binding fingerprinted every room polygon on the floor at millimeter precision. Any map redraw or harmless geometry drift therefore invalidated every saved custom area, even when the painted location was unaffected.

## Impact

Existing current areas migrate automatically after upgrade. Unrelated map changes stop generating redraw repairs. Mission, partition, nearby geometry, invalid coordinates, and out-of-floor marks remain blocked before a robot command. No protocol commands changed, no coordinate transform is guessed, and no map data leaves Home Assistant.

## Validation

- 875 Python tests / 8,137 statements at 100% coverage.
- 42 Chromium browser tests and 3 mobile WebKit tests.
- Ruff lint and formatting.
- Strict MyPy.
- Public-tree privacy gate.
- Release archive parity.
- Clean-wheel import.