### PR TITLE
Address 0.3.3 area binding review findings

### DIFF
--- a/custom_components/matic_robot/__init__.py
+++ b/custom_components/matic_robot/__init__.py
@@ -182,12 +182,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: MaticConfigEntry) -> boo
                     assert latest_floor_plan is not None
                     _schedule_area_binding_upgrade(latest_floor_plan)
 
-        def _async_sync_area_issue(*, allow_upgrade: bool = True) -> None:
+        def _async_sync_area_issue() -> None:
             nonlocal area_binding_upgrade_in_progress
             floor_plan = coordinator.data.floor_plan
             if (
-                allow_upgrade
-                and area_binding_upgrade_pending
+                area_binding_upgrade_pending
                 and not area_binding_upgrade_in_progress
                 and floor_plan != area_binding_upgrade_last_floor_plan
                 and _floor_plan_supports_area_binding(floor_plan)
@@ -205,7 +204,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: MaticConfigEntry) -> boo
         entry.async_on_unload(
             plans.async_add_listener(serial_number, _async_sync_area_issue)
         )
-        _async_sync_area_issue(allow_upgrade=False)
+        _async_sync_area_issue()
     except BaseException:
         if slam_history is not None:
             await slam_history.async_shutdown()

--- a/custom_components/matic_robot/__init__.py
+++ b/custom_components/matic_robot/__init__.py
@@ -15,11 +15,13 @@ from homeassistant.util import dt as dt_util
 from .area_binding import (
     async_delete_custom_area_issue,
     async_sync_custom_area_issue,
+    binding_for_floor_plan,
 )
 from .client.api import MaticHermesClient
 from .client.auth import HermesCredential
 from .client.commands import CleaningMode, CoverageSetting
 from .client.exceptions import MaticError
+from .client.models import FloorPlan
 from .const import (
     CONF_CERTIFICATE_FINGERPRINT,
     CONF_CLEANING_MODE,
@@ -109,7 +111,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: MaticConfigEntry) -> boo
         await plans.async_upgrade_area_bindings(
             serial_number, coordinator.data.floor_plan
         )
-        area_binding_upgrade_pending = coordinator.data.floor_plan is None
+        area_binding_upgrade_pending = not _floor_plan_supports_area_binding(
+            coordinator.data.floor_plan
+        )
         try:
             native_history = await client.async_get_cleaning_session_records()
         except MaticError as err:
@@ -152,7 +156,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: MaticConfigEntry) -> boo
         def _async_sync_area_issue() -> None:
             nonlocal area_binding_upgrade_pending
             floor_plan = coordinator.data.floor_plan
-            if area_binding_upgrade_pending and floor_plan is not None:
+            if area_binding_upgrade_pending and _floor_plan_supports_area_binding(
+                floor_plan
+            ):
                 area_binding_upgrade_pending = False
                 entry.async_create_background_task(
                     hass,
@@ -178,6 +184,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: MaticConfigEntry) -> boo
             await slam_map.async_shutdown()
         client.close()
         raise
+    return True
+
+
+def _floor_plan_supports_area_binding(floor_plan: FloorPlan | None) -> bool:
+    """Return whether a floor plan can safely produce an area binding."""
+    if floor_plan is None:
+        return False
+    try:
+        binding_for_floor_plan(floor_plan)
+    except OverflowError, TypeError, ValueError:
+        return False
     return True
 
 

--- a/custom_components/matic_robot/__init__.py
+++ b/custom_components/matic_robot/__init__.py
@@ -109,6 +109,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: MaticConfigEntry) -> boo
         await plans.async_upgrade_area_bindings(
             serial_number, coordinator.data.floor_plan
         )
+        area_binding_upgrade_pending = coordinator.data.floor_plan is None
         try:
             native_history = await client.async_get_cleaning_session_records()
         except MaticError as err:
@@ -149,11 +150,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: MaticConfigEntry) -> boo
         )
 
         def _async_sync_area_issue() -> None:
+            nonlocal area_binding_upgrade_pending
+            floor_plan = coordinator.data.floor_plan
+            if area_binding_upgrade_pending and floor_plan is not None:
+                area_binding_upgrade_pending = False
+                entry.async_create_background_task(
+                    hass,
+                    plans.async_upgrade_area_bindings(serial_number, floor_plan),
+                    f"{DOMAIN} custom area binding upgrade",
+                )
             async_sync_custom_area_issue(
                 hass,
                 entry.entry_id,
                 plans.areas(serial_number),
-                coordinator.data.floor_plan,
+                floor_plan,
             )
 
         entry.async_on_unload(coordinator.async_add_listener(_async_sync_area_issue))

--- a/custom_components/matic_robot/__init__.py
+++ b/custom_components/matic_robot/__init__.py
@@ -152,6 +152,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: MaticConfigEntry) -> boo
             f"{DOMAIN} map history collector",
         )
 
+        def _schedule_area_binding_upgrade(floor_plan: FloorPlan) -> None:
+            nonlocal area_binding_upgrade_in_progress
+            area_binding_upgrade_in_progress = True
+            entry.async_create_background_task(
+                hass,
+                _async_upgrade_area_bindings(floor_plan),
+                f"{DOMAIN} custom area binding upgrade",
+            )
+
         async def _async_upgrade_area_bindings(floor_plan: FloorPlan) -> None:
             nonlocal area_binding_upgrade_in_progress, area_binding_upgrade_pending
             try:
@@ -161,6 +170,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: MaticConfigEntry) -> boo
                 area_binding_upgrade_pending = result.pending
             finally:
                 area_binding_upgrade_in_progress = False
+                latest_floor_plan = coordinator.data.floor_plan
+                if (
+                    area_binding_upgrade_pending
+                    and latest_floor_plan != floor_plan
+                    and _floor_plan_supports_area_binding(latest_floor_plan)
+                ):
+                    assert latest_floor_plan is not None
+                    _schedule_area_binding_upgrade(latest_floor_plan)
 
         def _async_sync_area_issue(*, allow_upgrade: bool = True) -> None:
             nonlocal area_binding_upgrade_in_progress
@@ -171,13 +188,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: MaticConfigEntry) -> boo
                 and not area_binding_upgrade_in_progress
                 and _floor_plan_supports_area_binding(floor_plan)
             ):
-                area_binding_upgrade_in_progress = True
                 assert floor_plan is not None
-                entry.async_create_background_task(
-                    hass,
-                    _async_upgrade_area_bindings(floor_plan),
-                    f"{DOMAIN} custom area binding upgrade",
-                )
+                _schedule_area_binding_upgrade(floor_plan)
             async_sync_custom_area_issue(
                 hass,
                 entry.entry_id,

--- a/custom_components/matic_robot/__init__.py
+++ b/custom_components/matic_robot/__init__.py
@@ -113,6 +113,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: MaticConfigEntry) -> boo
         )
         area_binding_upgrade_pending = area_binding_upgrade.pending
         area_binding_upgrade_in_progress = False
+        area_binding_upgrade_last_floor_plan = coordinator.data.floor_plan
         try:
             native_history = await client.async_get_cleaning_session_records()
         except MaticError as err:
@@ -154,7 +155,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: MaticConfigEntry) -> boo
 
         def _schedule_area_binding_upgrade(floor_plan: FloorPlan) -> None:
             nonlocal area_binding_upgrade_in_progress
+            nonlocal area_binding_upgrade_last_floor_plan
             area_binding_upgrade_in_progress = True
+            area_binding_upgrade_last_floor_plan = floor_plan
             entry.async_create_background_task(
                 hass,
                 _async_upgrade_area_bindings(floor_plan),
@@ -186,6 +189,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: MaticConfigEntry) -> boo
                 allow_upgrade
                 and area_binding_upgrade_pending
                 and not area_binding_upgrade_in_progress
+                and floor_plan != area_binding_upgrade_last_floor_plan
                 and _floor_plan_supports_area_binding(floor_plan)
             ):
                 assert floor_plan is not None

--- a/custom_components/matic_robot/__init__.py
+++ b/custom_components/matic_robot/__init__.py
@@ -108,12 +108,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: MaticConfigEntry) -> boo
         await coordinator.async_config_entry_first_refresh()
         plans = hass.data[DOMAIN][DATA_PLAN_MANAGER]
         serial_number = str(entry.data[CONF_SERIAL_NUMBER])
-        await plans.async_upgrade_area_bindings(
+        area_binding_upgrade = await plans.async_upgrade_area_bindings(
             serial_number, coordinator.data.floor_plan
         )
-        area_binding_upgrade_pending = not _floor_plan_supports_area_binding(
-            coordinator.data.floor_plan
-        )
+        area_binding_upgrade_pending = area_binding_upgrade.pending
+        area_binding_upgrade_in_progress = False
         try:
             native_history = await client.async_get_cleaning_session_records()
         except MaticError as err:
@@ -153,16 +152,30 @@ async def async_setup_entry(hass: HomeAssistant, entry: MaticConfigEntry) -> boo
             f"{DOMAIN} map history collector",
         )
 
-        def _async_sync_area_issue() -> None:
-            nonlocal area_binding_upgrade_pending
+        async def _async_upgrade_area_bindings(floor_plan: FloorPlan) -> None:
+            nonlocal area_binding_upgrade_in_progress, area_binding_upgrade_pending
+            try:
+                result = await plans.async_upgrade_area_bindings(
+                    serial_number, floor_plan
+                )
+                area_binding_upgrade_pending = result.pending
+            finally:
+                area_binding_upgrade_in_progress = False
+
+        def _async_sync_area_issue(*, allow_upgrade: bool = True) -> None:
+            nonlocal area_binding_upgrade_in_progress
             floor_plan = coordinator.data.floor_plan
-            if area_binding_upgrade_pending and _floor_plan_supports_area_binding(
-                floor_plan
+            if (
+                allow_upgrade
+                and area_binding_upgrade_pending
+                and not area_binding_upgrade_in_progress
+                and _floor_plan_supports_area_binding(floor_plan)
             ):
-                area_binding_upgrade_pending = False
+                area_binding_upgrade_in_progress = True
+                assert floor_plan is not None
                 entry.async_create_background_task(
                     hass,
-                    plans.async_upgrade_area_bindings(serial_number, floor_plan),
+                    _async_upgrade_area_bindings(floor_plan),
                     f"{DOMAIN} custom area binding upgrade",
                 )
             async_sync_custom_area_issue(
@@ -176,7 +189,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: MaticConfigEntry) -> boo
         entry.async_on_unload(
             plans.async_add_listener(serial_number, _async_sync_area_issue)
         )
-        _async_sync_area_issue()
+        _async_sync_area_issue(allow_upgrade=False)
     except BaseException:
         if slam_history is not None:
             await slam_history.async_shutdown()

--- a/custom_components/matic_robot/area_binding.py
+++ b/custom_components/matic_robot/area_binding.py
@@ -19,11 +19,13 @@ from .const import DOMAIN
 
 AREA_SCHEMA_VERSION = 1
 MAP_BINDING_VERSION = 1
-SCOPED_MAP_BINDING_VERSION = 2
+HASH_ONLY_SCOPED_MAP_BINDING_VERSION = 2
+SCOPED_MAP_BINDING_VERSION = 3
 _FINGERPRINT_DOMAIN = b"matic-area-geometry\0"
 _SCOPED_FINGERPRINT_DOMAIN = b"matic-area-local-geometry\0"
 _AREA_SHAPE_FINGERPRINT_DOMAIN = b"matic-area-shape\0"
 _MILLIMETERS_PER_METER = 1_000
+_LEGACY_LOCAL_UNITS_PER_METER = 100
 _LOCAL_GEOMETRY_MARGIN_METERS = 0.25
 _LOCAL_GEOMETRY_TOLERANCE_MILLIMETERS = 10
 _MIN_SIGNED_64 = -(1 << 63)
@@ -186,6 +188,84 @@ def area_geometry_fingerprint(
     return _local_geometry_fingerprint(*_area_geometry_components(floor_plan, circles))
 
 
+def _hash_only_area_geometry_fingerprint(
+    floor_plan: FloorPlan, circles: Sequence[Mapping[str, Any]]
+) -> str:
+    """Reproduce the short-lived hash-only v2 signature for safe migration."""
+    normalized = _validate_area_circles(floor_plan, circles)
+    ordered = sorted(
+        (
+            float(circle["x"]),
+            float(circle["y"]),
+            float(circle["radius"]),
+        )
+        for circle in normalized
+    )
+    neighborhood = (
+        min(x - radius for x, _y, radius in ordered) - _LOCAL_GEOMETRY_MARGIN_METERS,
+        min(y - radius for _x, y, radius in ordered) - _LOCAL_GEOMETRY_MARGIN_METERS,
+        max(x + radius for x, _y, radius in ordered) + _LOCAL_GEOMETRY_MARGIN_METERS,
+        max(y + radius for _x, y, radius in ordered) + _LOCAL_GEOMETRY_MARGIN_METERS,
+    )
+    room_boundaries = tuple(
+        [list(point) for point in room.boundary] for room in floor_plan.rooms
+    )
+    segments: set[_LocalSegment] = set()
+    for room in floor_plan.rooms:
+        boundary = room.boundary
+        for start, end in zip(boundary, (*boundary[1:], boundary[0]), strict=True):
+            clipped = _clip_segment(start, end, neighborhood)
+            if clipped is None:
+                continue
+            first = (
+                _quantize(clipped[0][0], _LEGACY_LOCAL_UNITS_PER_METER),
+                _quantize(clipped[0][1], _LEGACY_LOCAL_UNITS_PER_METER),
+            )
+            second = (
+                _quantize(clipped[1][0], _LEGACY_LOCAL_UNITS_PER_METER),
+                _quantize(clipped[1][1], _LEGACY_LOCAL_UNITS_PER_METER),
+            )
+            if second < first:
+                first, second = second, first
+            segments.add((*first, *second))
+
+    digest = hashlib.sha256()
+    digest.update(_SCOPED_FINGERPRINT_DOMAIN)
+    digest.update(struct.pack(">H", HASH_ONLY_SCOPED_MAP_BINDING_VERSION))
+    digest.update(struct.pack(">I", len(ordered)))
+    for x, y, radius in ordered:
+        digest.update(
+            struct.pack(
+                ">qqq",
+                _quantize_coordinate(x),
+                _quantize_coordinate(y),
+                _quantize_coordinate(radius),
+            )
+        )
+        probe_radius = radius + _LOCAL_GEOMETRY_MARGIN_METERS
+        diagonal = probe_radius / math.sqrt(2)
+        probes = (
+            (x, y),
+            (x - probe_radius, y),
+            (x + probe_radius, y),
+            (x, y - probe_radius),
+            (x, y + probe_radius),
+            (x - diagonal, y - diagonal),
+            (x - diagonal, y + diagonal),
+            (x + diagonal, y - diagonal),
+            (x + diagonal, y + diagonal),
+        )
+        occupancy = sum(
+            int(_point_in_floor(probe_x, probe_y, room_boundaries)) << index
+            for index, (probe_x, probe_y) in enumerate(probes)
+        )
+        digest.update(struct.pack(">H", occupancy))
+    digest.update(struct.pack(">I", len(segments)))
+    for segment in sorted(segments):
+        digest.update(struct.pack(">qqqq", *segment))
+    return digest.hexdigest()
+
+
 def _area_geometry_components(
     floor_plan: FloorPlan, circles: Sequence[Mapping[str, Any]]
 ) -> _LocalGeometry:
@@ -207,15 +287,14 @@ def _area_geometry_components(
         )
         for x, y, radius in ordered_float
     )
-    neighborhood = (
-        min(x - radius for x, _y, radius in ordered_float)
-        - _LOCAL_GEOMETRY_MARGIN_METERS,
-        min(y - radius for _x, y, radius in ordered_float)
-        - _LOCAL_GEOMETRY_MARGIN_METERS,
-        max(x + radius for x, _y, radius in ordered_float)
-        + _LOCAL_GEOMETRY_MARGIN_METERS,
-        max(y + radius for _x, y, radius in ordered_float)
-        + _LOCAL_GEOMETRY_MARGIN_METERS,
+    neighborhoods = tuple(
+        (
+            x - radius - _LOCAL_GEOMETRY_MARGIN_METERS,
+            y - radius - _LOCAL_GEOMETRY_MARGIN_METERS,
+            x + radius + _LOCAL_GEOMETRY_MARGIN_METERS,
+            y + radius + _LOCAL_GEOMETRY_MARGIN_METERS,
+        )
+        for x, y, radius in ordered_float
     )
     room_boundaries = tuple(
         [list(point) for point in room.boundary] for room in floor_plan.rooms
@@ -225,20 +304,21 @@ def _area_geometry_components(
     for room in floor_plan.rooms:
         boundary = room.boundary
         for start, end in zip(boundary, (*boundary[1:], boundary[0]), strict=True):
-            clipped = _clip_segment(start, end, neighborhood)
-            if clipped is None:
-                continue
-            first = (
-                _quantize_coordinate(clipped[0][0]),
-                _quantize_coordinate(clipped[0][1]),
-            )
-            second = (
-                _quantize_coordinate(clipped[1][0]),
-                _quantize_coordinate(clipped[1][1]),
-            )
-            if second < first:
-                first, second = second, first
-            segments.add((*first, *second))
+            for neighborhood in neighborhoods:
+                clipped = _clip_segment(start, end, neighborhood)
+                if clipped is None:
+                    continue
+                first = (
+                    _quantize_coordinate(clipped[0][0]),
+                    _quantize_coordinate(clipped[0][1]),
+                )
+                second = (
+                    _quantize_coordinate(clipped[1][0]),
+                    _quantize_coordinate(clipped[1][1]),
+                )
+                if second < first:
+                    first, second = second, first
+                segments.add((*first, *second))
 
     occupancy_values = []
     for x, y, radius in ordered_float:
@@ -323,6 +403,18 @@ def area_binding_status(
         if saved_geometry != current["geometry_sha256"]:
             return AreaBindingStatus.GEOMETRY_CHANGED
         return AreaBindingStatus.CURRENT
+    if saved["version"] == HASH_ONLY_SCOPED_MAP_BINDING_VERSION:
+        try:
+            local_geometry = _hash_only_area_geometry_fingerprint(
+                floor_plan, area["circles"]
+            )
+        except KeyError, OverflowError, TypeError, ValueError:
+            return AreaBindingStatus.INVALID
+        if str(saved["local_geometry_sha256"]).casefold() == local_geometry:
+            return AreaBindingStatus.CURRENT
+        if saved_geometry != current["geometry_sha256"]:
+            return AreaBindingStatus.GEOMETRY_CHANGED
+        return AreaBindingStatus.INVALID
 
     try:
         shape, occupancy, segments = _area_geometry_components(
@@ -368,24 +460,30 @@ def _valid_saved_binding(binding: Mapping[str, Any]) -> bool:
     version = binding.get("version")
     if isinstance(version, bool) or not isinstance(version, int):
         return False
-    expected_fields = (
-        base_fields
-        if version == MAP_BINDING_VERSION
-        else {
+    if version == MAP_BINDING_VERSION:
+        expected_fields = base_fields
+    elif version == HASH_ONLY_SCOPED_MAP_BINDING_VERSION:
+        expected_fields = {*base_fields, "local_geometry_sha256"}
+    else:
+        expected_fields = {
             *base_fields,
             "area_shape_sha256",
             "local_geometry_sha256",
             "local_occupancy",
             "local_segments_mm",
         }
-    )
     if set(binding) != expected_fields:
         return False
     mission_id = binding["mission_id"]
     partition_id = binding["partition_id"]
     geometry = binding["geometry_sha256"]
     return (
-        version in {MAP_BINDING_VERSION, SCOPED_MAP_BINDING_VERSION}
+        version
+        in {
+            MAP_BINDING_VERSION,
+            HASH_ONLY_SCOPED_MAP_BINDING_VERSION,
+            SCOPED_MAP_BINDING_VERSION,
+        }
         and not isinstance(mission_id, bool)
         and isinstance(mission_id, int)
         and 0 <= mission_id <= 0xFFFFFFFF
@@ -397,7 +495,12 @@ def _valid_saved_binding(binding: Mapping[str, Any]) -> bool:
         and (
             version == MAP_BINDING_VERSION
             or (
-                _valid_digest(binding["area_shape_sha256"])
+                version == HASH_ONLY_SCOPED_MAP_BINDING_VERSION
+                and _valid_digest(binding["local_geometry_sha256"])
+            )
+            or (
+                version == SCOPED_MAP_BINDING_VERSION
+                and _valid_digest(binding["area_shape_sha256"])
                 and _valid_digest(binding["local_geometry_sha256"])
                 and _valid_local_occupancy(binding["local_occupancy"])
                 and _valid_local_segments(binding["local_segments_mm"])

--- a/custom_components/matic_robot/area_binding.py
+++ b/custom_components/matic_robot/area_binding.py
@@ -427,10 +427,10 @@ def area_binding_status(
     local_geometry = _local_geometry_fingerprint(shape, occupancy, segments)
     if str(saved["local_geometry_sha256"]).casefold() == local_geometry:
         return AreaBindingStatus.CURRENT
+    saved_segments = tuple(tuple(segment) for segment in saved["local_segments_mm"])
+    if _local_segments_match(saved_segments, segments):
+        return AreaBindingStatus.CURRENT
     if saved_geometry != current["geometry_sha256"]:
-        saved_segments = tuple(tuple(segment) for segment in saved["local_segments_mm"])
-        if _local_segments_match(saved_segments, segments):
-            return AreaBindingStatus.CURRENT
         return AreaBindingStatus.GEOMETRY_CHANGED
     return AreaBindingStatus.INVALID
 

--- a/custom_components/matic_robot/area_binding.py
+++ b/custom_components/matic_robot/area_binding.py
@@ -672,28 +672,20 @@ def _occupancy_changes_are_explained(
     ):
         return False
 
-    saved_by_neighborhood: list[list[tuple[_LocalSegment, _SegmentContext]]] = [
-        [] for _ in shape
-    ]
-    current_by_neighborhood: list[list[tuple[_LocalSegment, _SegmentContext]]] = [
-        [] for _ in shape
-    ]
-    for segment in saved_segments:
-        context = _segment_context(segment, shape)
-        for neighborhood in context[1]:
-            saved_by_neighborhood[neighborhood].append((segment, context))
-    for segment in current_segments:
-        context = _segment_context(segment, shape)
-        for neighborhood in context[1]:
-            current_by_neighborhood[neighborhood].append((segment, context))
+    saved_contexts = tuple(
+        _segment_context(segment, shape) for segment in saved_segments
+    )
+    current_contexts = tuple(
+        _segment_context(segment, shape) for segment in current_segments
+    )
+    saved_by_cell = _segment_indices_by_spatial_cell(saved_contexts)
+    current_by_cell = _segment_indices_by_spatial_cell(current_contexts)
 
-    for neighborhood, (
+    for (
         (x, y, radius),
         saved_value,
         current_value,
-    ) in enumerate(
-        zip(ordered_circles, saved_occupancy, current_occupancy, strict=True)
-    ):
+    ) in zip(ordered_circles, saved_occupancy, current_occupancy, strict=True):
         changed = saved_value ^ current_value
         if not changed:
             continue
@@ -704,23 +696,48 @@ def _occupancy_changes_are_explained(
         for probe_index, probe in enumerate(probes):
             if not changed & (1 << probe_index):
                 continue
+            probe_cell = (
+                math.floor(probe[0] / _SPATIAL_INDEX_CELL_MILLIMETERS),
+                math.floor(probe[1] / _SPATIAL_INDEX_CELL_MILLIMETERS),
+            )
+            saved_candidates = {
+                index
+                for cell_x in range(probe_cell[0] - 1, probe_cell[0] + 2)
+                for cell_y in range(probe_cell[1] - 1, probe_cell[1] + 2)
+                for index in saved_by_cell.get((cell_x, cell_y), ())
+            }
+            current_candidates = {
+                index
+                for cell_x in range(probe_cell[0] - 1, probe_cell[0] + 2)
+                for cell_y in range(probe_cell[1] - 1, probe_cell[1] + 2)
+                for index in current_by_cell.get((cell_x, cell_y), ())
+            }
             if not any(
                 _wall_pair_explains_probe(
-                    saved_segment,
-                    saved_context,
-                    current_segment,
-                    current_context,
+                    saved_segments[saved_index],
+                    saved_contexts[saved_index],
+                    current_segments[current_index],
+                    current_contexts[current_index],
                     probe,
                     shape,
                     allow_quantized_identity,
                 )
-                for saved_segment, saved_context in saved_by_neighborhood[neighborhood]
-                for current_segment, current_context in current_by_neighborhood[
-                    neighborhood
-                ]
+                for saved_index in saved_candidates
+                for current_index in current_candidates
             ):
                 return False
     return True
+
+
+def _segment_indices_by_spatial_cell(
+    contexts: Sequence[_SegmentContext],
+) -> dict[tuple[int, int], list[int]]:
+    """Index precomputed segment contexts by their local spatial cells."""
+    by_cell: dict[tuple[int, int], list[int]] = {}
+    for index, context in enumerate(contexts):
+        for cell in context[3]:
+            by_cell.setdefault(cell, []).append(index)
+    return by_cell
 
 
 def _wall_pair_explains_probe(

--- a/custom_components/matic_robot/area_binding.py
+++ b/custom_components/matic_robot/area_binding.py
@@ -462,7 +462,6 @@ def area_binding_status(
             segments,
             shape,
             area["circles"],
-            saved_geometry == current["geometry_sha256"],
         )
     ):
         return AreaBindingStatus.CURRENT
@@ -654,7 +653,6 @@ def _occupancy_changes_are_explained(
     current_segments: Sequence[_LocalSegment],
     shape: _AreaShape,
     circles: Sequence[Mapping[str, Any]],
-    allow_quantized_identity: bool,
 ) -> bool:
     """Return whether every changed probe is explained by a moving wall pair."""
     ordered_circles = sorted(
@@ -720,7 +718,6 @@ def _occupancy_changes_are_explained(
                     current_contexts[current_index],
                     probe,
                     shape,
-                    allow_quantized_identity,
                 )
                 for saved_index in saved_candidates
                 for current_index in current_candidates
@@ -747,11 +744,8 @@ def _wall_pair_explains_probe(
     current_context: _SegmentContext,
     probe: tuple[float, float],
     shape: _AreaShape,
-    allow_quantized_identity: bool,
 ) -> bool:
     """Return whether one compatible wall pair can cross an occupancy probe."""
-    if saved == current and not allow_quantized_identity:
-        return False
     if not _point_near_segment(probe, saved) or not _point_near_segment(probe, current):
         return False
     if not _local_segment_contexts_match(
@@ -762,6 +756,16 @@ def _wall_pair_explains_probe(
     current_distance = _signed_distance_to_supporting_line(probe, current)
     if saved_distance is None or current_distance is None:
         return False
+    if saved == current:
+        return abs(saved_distance) <= _SEGMENT_QUANTIZATION_ERROR_MILLIMETERS
+    saved_direction = (saved[2] - saved[0], saved[3] - saved[1])
+    current_direction = (current[2] - current[0], current[3] - current[1])
+    if (
+        saved_direction[0] * current_direction[0]
+        + saved_direction[1] * current_direction[1]
+        < 0
+    ):
+        current_distance = -current_distance
     return (
         saved_distance * current_distance <= 0
         or abs(saved_distance) <= _SEGMENT_QUANTIZATION_ERROR_MILLIMETERS
@@ -772,7 +776,7 @@ def _wall_pair_explains_probe(
 def _signed_distance_to_supporting_line(
     point: tuple[float, float], segment: _LocalSegment
 ) -> float | None:
-    """Return a consistently oriented point-to-source-wall distance."""
+    """Return an oriented point-to-source-wall distance."""
     start_x, start_y, end_x, end_y = segment
     delta_x = end_x - start_x
     delta_y = end_y - start_y

--- a/custom_components/matic_robot/area_binding.py
+++ b/custom_components/matic_robot/area_binding.py
@@ -32,7 +32,12 @@ _LOCAL_GEOMETRY_TOLERANCE_MILLIMETERS = 10
 _LOCAL_GEOMETRY_TOLERANCE_METERS = (
     _LOCAL_GEOMETRY_TOLERANCE_MILLIMETERS / _MILLIMETERS_PER_METER
 )
-_SEGMENT_QUANTIZATION_ERROR_MILLIMETERS = math.sqrt(0.5)
+_COORDINATE_QUANTIZATION_ERROR_MILLIMETERS = 0.5
+_SEGMENT_QUANTIZATION_ERROR_MILLIMETERS = math.sqrt(
+    2 * _COORDINATE_QUANTIZATION_ERROR_MILLIMETERS**2
+)
+_SPATIAL_INDEX_CELL_MILLIMETERS = 100
+_SPATIAL_INDEX_SAMPLE_MILLIMETERS = _SPATIAL_INDEX_CELL_MILLIMETERS // 2
 _MIN_SIGNED_64 = -(1 << 63)
 _MAX_SIGNED_64 = (1 << 63) - 1
 _AREA_REPAIR_LEARN_MORE_URL = (
@@ -46,7 +51,12 @@ _CanonicalPolygon = tuple[_QuantizedPoint, ...]
 _LocalSegment = tuple[int, int, int, int]
 _AreaShape = tuple[tuple[int, int, int], ...]
 _LocalGeometry = tuple[_AreaShape, tuple[int, ...], tuple[_LocalSegment, ...]]
-_SegmentContext = tuple[frozenset[int], frozenset[int], tuple[tuple[int, int], ...]]
+_SegmentContext = tuple[
+    frozenset[int],
+    frozenset[int],
+    tuple[tuple[int, int], ...],
+    frozenset[tuple[int, int]],
+]
 
 
 class AreaBindingStatus(StrEnum):
@@ -598,13 +608,10 @@ def _local_segments_match(
     current_contexts = tuple(_segment_context(segment, shape) for segment in current)
     saved_local = tuple(bool(context[0]) for context in saved_contexts)
     current_local = tuple(bool(context[0]) for context in current_contexts)
-    current_by_semantic: list[list[int]] = [[] for _ in shape]
-    current_by_guard: list[list[int]] = [[] for _ in shape]
-    for current_index, (semantic, guard, _endpoints) in enumerate(current_contexts):
-        for neighborhood in semantic:
-            current_by_semantic[neighborhood].append(current_index)
-        for neighborhood in guard:
-            current_by_guard[neighborhood].append(current_index)
+    current_by_cell: dict[tuple[int, int], list[int]] = {}
+    for current_index, context in enumerate(current_contexts):
+        for cell in context[3]:
+            current_by_cell.setdefault(cell, []).append(current_index)
 
     node_count = len(saved) + len(current) + 2
     source = node_count - 2
@@ -616,17 +623,13 @@ def _local_segments_match(
     for saved_index, (saved_segment, saved_context) in enumerate(
         zip(saved, saved_contexts, strict=True)
     ):
-        saved_semantic, saved_guard, _endpoints = saved_context
         candidates = {
             current_index
-            for neighborhood in saved_semantic
-            for current_index in current_by_guard[neighborhood]
+            for cell_x, cell_y in saved_context[3]
+            for neighbor_x in range(cell_x - 1, cell_x + 2)
+            for neighbor_y in range(cell_y - 1, cell_y + 2)
+            for current_index in current_by_cell.get((neighbor_x, neighbor_y), ())
         }
-        candidates.update(
-            current_index
-            for neighborhood in saved_guard
-            for current_index in current_by_semantic[neighborhood]
-        )
         for current_index in candidates:
             if _local_segment_contexts_match(
                 saved_segment,
@@ -715,6 +718,7 @@ def _segment_context(segment: _LocalSegment, shape: _AreaShape) -> _SegmentConte
     end = (segment[2], segment[3])
     semantic: set[int] = set()
     guard: set[int] = set()
+    guard_pieces: list[tuple[tuple[float, float], tuple[float, float]]] = []
     local_endpoints: set[tuple[int, int]] = set()
     for index, (center_x, center_y, radius) in enumerate(shape):
         semantic_bounds = (
@@ -737,9 +741,77 @@ def _segment_context(segment: _LocalSegment, shape: _AreaShape) -> _SegmentConte
             center_x + radius + guard_margin,
             center_y + radius + guard_margin,
         )
-        if _clip_segment(start, end, guard_bounds) is not None:
+        guard_piece = _clip_segment(start, end, guard_bounds)
+        if guard_piece is not None:
             guard.add(index)
-    return frozenset(semantic), frozenset(guard), tuple(sorted(local_endpoints))
+            guard_pieces.append(guard_piece)
+    return (
+        frozenset(semantic),
+        frozenset(guard),
+        tuple(sorted(local_endpoints)),
+        _segment_spatial_cells(start, end, guard_pieces),
+    )
+
+
+def _segment_spatial_cells(
+    start: tuple[int, int],
+    end: tuple[int, int],
+    pieces: Sequence[tuple[tuple[float, float], tuple[float, float]]],
+) -> frozenset[tuple[int, int]]:
+    """Index the union of guard-clipped wall intervals into fixed cells."""
+    delta_x = end[0] - start[0]
+    delta_y = end[1] - start[1]
+    length_squared = delta_x * delta_x + delta_y * delta_y
+    if not length_squared:
+        return frozenset(
+            {
+                (
+                    math.floor(start[0] / _SPATIAL_INDEX_CELL_MILLIMETERS),
+                    math.floor(start[1] / _SPATIAL_INDEX_CELL_MILLIMETERS),
+                )
+            }
+            if pieces
+            else set()
+        )
+
+    intervals = sorted(
+        (
+            ((piece[0][0] - start[0]) * delta_x + (piece[0][1] - start[1]) * delta_y)
+            / length_squared,
+            ((piece[1][0] - start[0]) * delta_x + (piece[1][1] - start[1]) * delta_y)
+            / length_squared,
+        )
+        for piece in pieces
+    )
+    merged: list[list[float]] = []
+    for lower, upper in intervals:
+        if merged and lower <= merged[-1][1]:
+            merged[-1][1] = max(merged[-1][1], upper)
+        else:
+            merged.append([lower, upper])
+
+    cells: set[tuple[int, int]] = set()
+    maximum_delta = max(abs(delta_x), abs(delta_y))
+    for lower, upper in merged:
+        steps = max(
+            1,
+            math.ceil(
+                maximum_delta * (upper - lower) / _SPATIAL_INDEX_SAMPLE_MILLIMETERS
+            ),
+        )
+        for step in range(steps + 1):
+            ratio = lower + (upper - lower) * step / steps
+            cells.add(
+                (
+                    math.floor(
+                        (start[0] + ratio * delta_x) / _SPATIAL_INDEX_CELL_MILLIMETERS
+                    ),
+                    math.floor(
+                        (start[1] + ratio * delta_y) / _SPATIAL_INDEX_CELL_MILLIMETERS
+                    ),
+                )
+            )
+    return frozenset(cells)
 
 
 def _local_segment_geometries_match(
@@ -767,8 +839,10 @@ def _local_segment_contexts_match(
         (_LOCAL_GEOMETRY_MARGIN_METERS + _LOCAL_GEOMETRY_TOLERANCE_METERS)
         * _MILLIMETERS_PER_METER
     )
-    saved_semantic, saved_guard, saved_local_endpoints = saved_context
-    current_semantic, current_guard, current_local_endpoints = current_context
+    saved_semantic, saved_guard, saved_local_endpoints, _saved_cells = saved_context
+    current_semantic, current_guard, current_local_endpoints, _current_cells = (
+        current_context
+    )
     relevant = saved_semantic | current_semantic
     if not relevant or not relevant <= saved_guard & current_guard:
         return False
@@ -814,7 +888,10 @@ def _point_near_supporting_line(
     if not length_squared:
         return _points_within_tolerance(point, line_start)
     cross = delta_x * (point[1] - line_start[1]) - delta_y * (point[0] - line_start[0])
-    tolerance = _LOCAL_GEOMETRY_TOLERANCE_MILLIMETERS
+    tolerance = (
+        _LOCAL_GEOMETRY_TOLERANCE_MILLIMETERS
+        + 2 * _SEGMENT_QUANTIZATION_ERROR_MILLIMETERS
+    )
     return cross * cross <= tolerance * tolerance * length_squared
 
 
@@ -857,9 +934,13 @@ def _endpoints_covered(
 def _points_within_tolerance(
     first: tuple[float, float], second: tuple[int, int]
 ) -> bool:
-    """Return whether both point coordinates differ by at most 10 mm."""
+    """Compare endpoint coordinates with the two-wall rounding allowance."""
+    tolerance = (
+        _LOCAL_GEOMETRY_TOLERANCE_MILLIMETERS
+        + 2 * _COORDINATE_QUANTIZATION_ERROR_MILLIMETERS
+    )
     return all(
-        abs(saved - current) <= _LOCAL_GEOMETRY_TOLERANCE_MILLIMETERS
+        abs(saved - current) <= tolerance
         for saved, current in zip(first, second, strict=True)
     )
 

--- a/custom_components/matic_robot/area_binding.py
+++ b/custom_components/matic_robot/area_binding.py
@@ -446,7 +446,13 @@ def area_binding_status(
     if str(saved["local_geometry_sha256"]).casefold() == local_geometry:
         return AreaBindingStatus.CURRENT
     saved_segments = tuple(tuple(segment) for segment in saved["local_segments_mm"])
-    if _local_segments_match(saved_segments, segments, shape):
+    saved_occupancy = tuple(saved["local_occupancy"])
+    if _local_segments_match(saved_segments, segments, shape) and (
+        saved_occupancy == occupancy
+        or _occupancy_changes_are_explained(
+            saved_occupancy, occupancy, saved_segments, segments, shape
+        )
+    ):
         return AreaBindingStatus.CURRENT
     if saved_geometry != current["geometry_sha256"]:
         return AreaBindingStatus.GEOMETRY_CHANGED
@@ -636,6 +642,62 @@ def _local_segments_match(
     return -_minimum_cost_maximum_flow(graph, source, sink) == required_score
 
 
+def _occupancy_changes_are_explained(
+    saved_occupancy: Sequence[int],
+    current_occupancy: Sequence[int],
+    saved_segments: Sequence[_LocalSegment],
+    current_segments: Sequence[_LocalSegment],
+    shape: _AreaShape,
+) -> bool:
+    """Return whether every changed probe is near old and new local walls."""
+    if len(saved_occupancy) != len(shape) or len(current_occupancy) != len(shape):
+        return False
+
+    saved_by_neighborhood: list[list[_LocalSegment]] = [[] for _ in shape]
+    current_by_neighborhood: list[list[_LocalSegment]] = [[] for _ in shape]
+    for segment in saved_segments:
+        for neighborhood in _segment_context(segment, shape)[1]:
+            saved_by_neighborhood[neighborhood].append(segment)
+    for segment in current_segments:
+        for neighborhood in _segment_context(segment, shape)[1]:
+            current_by_neighborhood[neighborhood].append(segment)
+
+    semantic_margin = round(_LOCAL_GEOMETRY_MARGIN_METERS * _MILLIMETERS_PER_METER)
+    for neighborhood, (
+        (center_x, center_y, radius),
+        saved_value,
+        current_value,
+    ) in enumerate(zip(shape, saved_occupancy, current_occupancy, strict=True)):
+        changed = saved_value ^ current_value
+        if not changed:
+            continue
+        probe_radius = radius + semantic_margin
+        diagonal = probe_radius / math.sqrt(2)
+        probes = (
+            (center_x, center_y),
+            (center_x - probe_radius, center_y),
+            (center_x + probe_radius, center_y),
+            (center_x, center_y - probe_radius),
+            (center_x, center_y + probe_radius),
+            (center_x - diagonal, center_y - diagonal),
+            (center_x - diagonal, center_y + diagonal),
+            (center_x + diagonal, center_y - diagonal),
+            (center_x + diagonal, center_y + diagonal),
+        )
+        for probe_index, probe in enumerate(probes):
+            if not changed & (1 << probe_index):
+                continue
+            if not any(
+                _point_near_segment(probe, segment)
+                for segment in saved_by_neighborhood[neighborhood]
+            ) or not any(
+                _point_near_segment(probe, segment)
+                for segment in current_by_neighborhood[neighborhood]
+            ):
+                return False
+    return True
+
+
 def _segment_context(segment: _LocalSegment, shape: _AreaShape) -> _SegmentContext:
     """Precompute the local neighborhoods and endpoints for one source wall."""
     semantic_margin = round(_LOCAL_GEOMETRY_MARGIN_METERS * _MILLIMETERS_PER_METER)
@@ -748,6 +810,30 @@ def _point_near_supporting_line(
     cross = delta_x * (point[1] - line_start[1]) - delta_y * (point[0] - line_start[0])
     tolerance = _LOCAL_GEOMETRY_TOLERANCE_MILLIMETERS
     return cross * cross <= tolerance * tolerance * length_squared
+
+
+def _point_near_segment(point: tuple[float, float], segment: _LocalSegment) -> bool:
+    """Return whether a point is within tolerance of a finite source wall."""
+    start_x, start_y, end_x, end_y = segment
+    delta_x = end_x - start_x
+    delta_y = end_y - start_y
+    length_squared = delta_x * delta_x + delta_y * delta_y
+    nearest_x: float
+    nearest_y: float
+    if not length_squared:
+        nearest_x = start_x
+        nearest_y = start_y
+    else:
+        projection = (
+            (point[0] - start_x) * delta_x + (point[1] - start_y) * delta_y
+        ) / length_squared
+        projection = min(1.0, max(0.0, projection))
+        nearest_x = start_x + projection * delta_x
+        nearest_y = start_y + projection * delta_y
+    distance_x = point[0] - nearest_x
+    distance_y = point[1] - nearest_y
+    tolerance = _LOCAL_GEOMETRY_TOLERANCE_MILLIMETERS
+    return distance_x * distance_x + distance_y * distance_y <= tolerance * tolerance
 
 
 def _endpoints_covered(

--- a/custom_components/matic_robot/area_binding.py
+++ b/custom_components/matic_robot/area_binding.py
@@ -284,10 +284,15 @@ def _hash_only_area_geometry_fingerprint(
 
 
 def _area_geometry_components(
-    floor_plan: FloorPlan, circles: Sequence[Mapping[str, Any]]
+    floor_plan: FloorPlan,
+    circles: Sequence[Mapping[str, Any]],
+    *,
+    center_tolerance: float = 0.0,
 ) -> _LocalGeometry:
     """Return canonical private area shape, occupancy, and nearby segments."""
-    normalized = _validate_area_circles(floor_plan, circles)
+    normalized = _validate_area_circles(
+        floor_plan, circles, center_tolerance=center_tolerance
+    )
     ordered_float = sorted(
         (
             float(circle["x"]),
@@ -455,7 +460,9 @@ def area_binding_status(
 
     try:
         shape, occupancy, segments = _area_geometry_components(
-            floor_plan, area["circles"]
+            floor_plan,
+            area["circles"],
+            center_tolerance=_LOCAL_GEOMETRY_TOLERANCE_METERS,
         )
     except KeyError, OverflowError, TypeError, ValueError:
         return AreaBindingStatus.INVALID
@@ -1109,7 +1116,10 @@ def _minimum_cost_maximum_flow(
 
 
 def _validate_area_circles(
-    floor_plan: FloorPlan, circles: Sequence[Mapping[str, Any]]
+    floor_plan: FloorPlan,
+    circles: Sequence[Mapping[str, Any]],
+    *,
+    center_tolerance: float = 0.0,
 ) -> list[dict[str, float]]:
     """Validate saved circles against the mapped floor without exposing them."""
     rooms = [
@@ -1121,7 +1131,9 @@ def _validate_area_circles(
         for room in floor_plan.rooms
     ]
     try:
-        return MaticAreaSelector({"rooms": rooms})(circles)
+        return MaticAreaSelector({"rooms": rooms}).validate(
+            circles, center_tolerance=center_tolerance
+        )
     except vol.Invalid as err:
         raise ValueError("area circles are invalid for the mapped floor") from err
 

--- a/custom_components/matic_robot/area_binding.py
+++ b/custom_components/matic_robot/area_binding.py
@@ -39,6 +39,15 @@ _SEGMENT_QUANTIZATION_ERROR_MILLIMETERS = math.sqrt(
 _NEIGHBORHOOD_QUANTIZATION_ERROR_MILLIMETERS = (
     3 * _COORDINATE_QUANTIZATION_ERROR_MILLIMETERS
 )
+_SEMANTIC_MARGIN_MILLIMETERS = math.ceil(
+    _LOCAL_GEOMETRY_MARGIN_METERS * _MILLIMETERS_PER_METER
+    + _NEIGHBORHOOD_QUANTIZATION_ERROR_MILLIMETERS
+)
+_GUARD_MARGIN_MILLIMETERS = math.ceil(
+    (_LOCAL_GEOMETRY_MARGIN_METERS + _LOCAL_GEOMETRY_TOLERANCE_METERS)
+    * _MILLIMETERS_PER_METER
+    + _NEIGHBORHOOD_QUANTIZATION_ERROR_MILLIMETERS
+)
 _SPATIAL_INDEX_CELL_MILLIMETERS = 100
 _SPATIAL_INDEX_SAMPLE_MILLIMETERS = _SPATIAL_INDEX_CELL_MILLIMETERS // 2
 _MIN_SIGNED_64 = -(1 << 63)
@@ -812,15 +821,6 @@ def _signed_distance_to_supporting_line(
 
 def _segment_context(segment: _LocalSegment, shape: _AreaShape) -> _SegmentContext:
     """Precompute the local neighborhoods and endpoints for one source wall."""
-    semantic_margin = math.ceil(
-        _LOCAL_GEOMETRY_MARGIN_METERS * _MILLIMETERS_PER_METER
-        + _NEIGHBORHOOD_QUANTIZATION_ERROR_MILLIMETERS
-    )
-    guard_margin = math.ceil(
-        (_LOCAL_GEOMETRY_MARGIN_METERS + _LOCAL_GEOMETRY_TOLERANCE_METERS)
-        * _MILLIMETERS_PER_METER
-        + _NEIGHBORHOOD_QUANTIZATION_ERROR_MILLIMETERS
-    )
     start = (segment[0], segment[1])
     end = (segment[2], segment[3])
     semantic: set[int] = set()
@@ -829,10 +829,10 @@ def _segment_context(segment: _LocalSegment, shape: _AreaShape) -> _SegmentConte
     local_endpoints: set[tuple[int, int]] = set()
     for index, (center_x, center_y, radius) in enumerate(shape):
         semantic_bounds = (
-            center_x - radius - semantic_margin,
-            center_y - radius - semantic_margin,
-            center_x + radius + semantic_margin,
-            center_y + radius + semantic_margin,
+            center_x - radius - _SEMANTIC_MARGIN_MILLIMETERS,
+            center_y - radius - _SEMANTIC_MARGIN_MILLIMETERS,
+            center_x + radius + _SEMANTIC_MARGIN_MILLIMETERS,
+            center_y + radius + _SEMANTIC_MARGIN_MILLIMETERS,
         )
         if _clip_segment(start, end, semantic_bounds) is not None:
             semantic.add(index)
@@ -843,10 +843,10 @@ def _segment_context(segment: _LocalSegment, shape: _AreaShape) -> _SegmentConte
             ):
                 local_endpoints.add(point)
         guard_bounds = (
-            center_x - radius - guard_margin,
-            center_y - radius - guard_margin,
-            center_x + radius + guard_margin,
-            center_y + radius + guard_margin,
+            center_x - radius - _GUARD_MARGIN_MILLIMETERS,
+            center_y - radius - _GUARD_MARGIN_MILLIMETERS,
+            center_x + radius + _GUARD_MARGIN_MILLIMETERS,
+            center_y + radius + _GUARD_MARGIN_MILLIMETERS,
         )
         guard_piece = _clip_segment(start, end, guard_bounds)
         if guard_piece is not None:
@@ -942,10 +942,6 @@ def _local_segment_contexts_match(
     shape: _AreaShape,
 ) -> bool:
     """Compare two walls using their precomputed relevant neighborhoods."""
-    guard_margin = round(
-        (_LOCAL_GEOMETRY_MARGIN_METERS + _LOCAL_GEOMETRY_TOLERANCE_METERS)
-        * _MILLIMETERS_PER_METER
-    )
     saved_semantic, saved_guard, saved_local_endpoints, _saved_cells = saved_context
     current_semantic, current_guard, current_local_endpoints, _current_cells = (
         current_context
@@ -961,10 +957,10 @@ def _local_segment_contexts_match(
     for neighborhood in relevant:
         center_x, center_y, radius = shape[neighborhood]
         guard_bounds = (
-            center_x - radius - guard_margin,
-            center_y - radius - guard_margin,
-            center_x + radius + guard_margin,
-            center_y + radius + guard_margin,
+            center_x - radius - _GUARD_MARGIN_MILLIMETERS,
+            center_y - radius - _GUARD_MARGIN_MILLIMETERS,
+            center_x + radius + _GUARD_MARGIN_MILLIMETERS,
+            center_y + radius + _GUARD_MARGIN_MILLIMETERS,
         )
         saved_piece = _clip_segment(saved_start, saved_end, guard_bounds)
         current_piece = _clip_segment(current_start, current_end, guard_bounds)

--- a/custom_components/matic_robot/area_binding.py
+++ b/custom_components/matic_robot/area_binding.py
@@ -462,6 +462,7 @@ def area_binding_status(
             segments,
             shape,
             area["circles"],
+            saved_geometry == current["geometry_sha256"],
         )
     ):
         return AreaBindingStatus.CURRENT
@@ -653,8 +654,9 @@ def _occupancy_changes_are_explained(
     current_segments: Sequence[_LocalSegment],
     shape: _AreaShape,
     circles: Sequence[Mapping[str, Any]],
+    allow_quantized_identity: bool,
 ) -> bool:
-    """Return whether every changed probe is near old and new local walls."""
+    """Return whether every changed probe is explained by a moving wall pair."""
     ordered_circles = sorted(
         (
             float(circle["x"]),
@@ -670,14 +672,20 @@ def _occupancy_changes_are_explained(
     ):
         return False
 
-    saved_by_neighborhood: list[list[_LocalSegment]] = [[] for _ in shape]
-    current_by_neighborhood: list[list[_LocalSegment]] = [[] for _ in shape]
+    saved_by_neighborhood: list[list[tuple[_LocalSegment, _SegmentContext]]] = [
+        [] for _ in shape
+    ]
+    current_by_neighborhood: list[list[tuple[_LocalSegment, _SegmentContext]]] = [
+        [] for _ in shape
+    ]
     for segment in saved_segments:
-        for neighborhood in _segment_context(segment, shape)[1]:
-            saved_by_neighborhood[neighborhood].append(segment)
+        context = _segment_context(segment, shape)
+        for neighborhood in context[1]:
+            saved_by_neighborhood[neighborhood].append((segment, context))
     for segment in current_segments:
-        for neighborhood in _segment_context(segment, shape)[1]:
-            current_by_neighborhood[neighborhood].append(segment)
+        context = _segment_context(segment, shape)
+        for neighborhood in context[1]:
+            current_by_neighborhood[neighborhood].append((segment, context))
 
     for neighborhood, (
         (x, y, radius),
@@ -697,14 +705,64 @@ def _occupancy_changes_are_explained(
             if not changed & (1 << probe_index):
                 continue
             if not any(
-                _point_near_segment(probe, segment)
-                for segment in saved_by_neighborhood[neighborhood]
-            ) or not any(
-                _point_near_segment(probe, segment)
-                for segment in current_by_neighborhood[neighborhood]
+                _wall_pair_explains_probe(
+                    saved_segment,
+                    saved_context,
+                    current_segment,
+                    current_context,
+                    probe,
+                    shape,
+                    allow_quantized_identity,
+                )
+                for saved_segment, saved_context in saved_by_neighborhood[neighborhood]
+                for current_segment, current_context in current_by_neighborhood[
+                    neighborhood
+                ]
             ):
                 return False
     return True
+
+
+def _wall_pair_explains_probe(
+    saved: _LocalSegment,
+    saved_context: _SegmentContext,
+    current: _LocalSegment,
+    current_context: _SegmentContext,
+    probe: tuple[float, float],
+    shape: _AreaShape,
+    allow_quantized_identity: bool,
+) -> bool:
+    """Return whether one compatible wall pair can cross an occupancy probe."""
+    if saved == current and not allow_quantized_identity:
+        return False
+    if not _point_near_segment(probe, saved) or not _point_near_segment(probe, current):
+        return False
+    if not _local_segment_contexts_match(
+        saved, saved_context, current, current_context, shape
+    ):
+        return False
+    saved_distance = _signed_distance_to_supporting_line(probe, saved)
+    current_distance = _signed_distance_to_supporting_line(probe, current)
+    if saved_distance is None or current_distance is None:
+        return False
+    return (
+        saved_distance * current_distance <= 0
+        or abs(saved_distance) <= _SEGMENT_QUANTIZATION_ERROR_MILLIMETERS
+        or abs(current_distance) <= _SEGMENT_QUANTIZATION_ERROR_MILLIMETERS
+    )
+
+
+def _signed_distance_to_supporting_line(
+    point: tuple[float, float], segment: _LocalSegment
+) -> float | None:
+    """Return a consistently oriented point-to-source-wall distance."""
+    start_x, start_y, end_x, end_y = segment
+    delta_x = end_x - start_x
+    delta_y = end_y - start_y
+    length = math.hypot(delta_x, delta_y)
+    if not length:
+        return None
+    return (delta_x * (point[1] - start_y) - delta_y * (point[0] - start_x)) / length
 
 
 def _segment_context(segment: _LocalSegment, shape: _AreaShape) -> _SegmentContext:

--- a/custom_components/matic_robot/area_binding.py
+++ b/custom_components/matic_robot/area_binding.py
@@ -746,6 +746,12 @@ def _occupancy_changes_are_explained(
         )
         if segment_matches is None:
             return False
+    matches_by_cell: dict[tuple[int, int], set[_SegmentMatch]] = {}
+    for match in segment_matches:
+        saved_index, current_index = match
+        cells = saved_contexts[saved_index][3] | current_contexts[current_index][3]
+        for cell in cells:
+            matches_by_cell.setdefault(cell, set()).add(match)
 
     for (
         (x, y, radius),
@@ -762,6 +768,14 @@ def _occupancy_changes_are_explained(
         for probe_index, probe in enumerate(probes):
             if not changed & (1 << probe_index):
                 continue
+            probe_cell_x = math.floor(probe[0] / _SPATIAL_INDEX_CELL_MILLIMETERS)
+            probe_cell_y = math.floor(probe[1] / _SPATIAL_INDEX_CELL_MILLIMETERS)
+            candidates = {
+                match
+                for cell_x in range(probe_cell_x - 1, probe_cell_x + 2)
+                for cell_y in range(probe_cell_y - 1, probe_cell_y + 2)
+                for match in matches_by_cell.get((cell_x, cell_y), ())
+            }
             if not any(
                 _wall_pair_explains_probe(
                     saved_segments[saved_index],
@@ -771,7 +785,7 @@ def _occupancy_changes_are_explained(
                     probe,
                     shape,
                 )
-                for saved_index, current_index in segment_matches
+                for saved_index, current_index in candidates
             ):
                 return False
     return True

--- a/custom_components/matic_robot/area_binding.py
+++ b/custom_components/matic_robot/area_binding.py
@@ -321,16 +321,15 @@ def _area_geometry_components(
         boundary = room.boundary
         for start, end in zip(boundary, (*boundary[1:], boundary[0]), strict=True):
             for neighborhood in neighborhoods:
-                clipped = _clip_segment(start, end, neighborhood)
-                if clipped is None:
+                if _clip_segment(start, end, neighborhood) is None:
                     continue
                 first = (
-                    _quantize_coordinate(clipped[0][0]),
-                    _quantize_coordinate(clipped[0][1]),
+                    _quantize_coordinate(start[0]),
+                    _quantize_coordinate(start[1]),
                 )
                 second = (
-                    _quantize_coordinate(clipped[1][0]),
-                    _quantize_coordinate(clipped[1][1]),
+                    _quantize_coordinate(end[0]),
+                    _quantize_coordinate(end[1]),
                 )
                 if second < first:
                     first, second = second, first
@@ -598,15 +597,7 @@ def _local_segments_match(
         _add_flow_edge(graph, source, index, -int(is_local))
     for saved_index, saved_segment in enumerate(saved):
         for current_index, current_segment in enumerate(current):
-            reversed_current = (
-                current_segment[2],
-                current_segment[3],
-                current_segment[0],
-                current_segment[1],
-            )
-            if _segment_within_tolerance(
-                saved_segment, current_segment
-            ) or _segment_within_tolerance(saved_segment, reversed_current):
+            if _local_segment_geometries_match(saved_segment, current_segment, shape):
                 _add_flow_edge(graph, saved_index, len(saved) + current_index, 0)
     for index, is_local in enumerate(current_local):
         _add_flow_edge(graph, len(saved) + index, sink, -int(is_local))
@@ -633,6 +624,105 @@ def _segment_intersects_area(segment: _LocalSegment, shape: _AreaShape) -> bool:
         )
         is not None
         for center_x, center_y, radius in shape
+    )
+
+
+def _local_segment_geometries_match(
+    saved: _LocalSegment, current: _LocalSegment, shape: _AreaShape
+) -> bool:
+    """Compare source walls inside local guard boxes without clip artifacts."""
+    margin = round(
+        (_LOCAL_GEOMETRY_MARGIN_METERS + _LOCAL_GEOMETRY_TOLERANCE_METERS)
+        * _MILLIMETERS_PER_METER
+    )
+    saved_start = (saved[0], saved[1])
+    saved_end = (saved[2], saved[3])
+    current_start = (current[0], current[1])
+    current_end = (current[2], current[3])
+    compared = False
+    for center_x, center_y, radius in shape:
+        bounds = (
+            center_x - radius - margin,
+            center_y - radius - margin,
+            center_x + radius + margin,
+            center_y + radius + margin,
+        )
+        saved_piece = _clip_segment(saved_start, saved_end, bounds)
+        current_piece = _clip_segment(current_start, current_end, bounds)
+        if saved_piece is None and current_piece is None:
+            continue
+        if saved_piece is None or current_piece is None:
+            return False
+        compared = True
+        if not all(
+            _point_near_supporting_line(point, current_start, current_end)
+            for point in saved_piece
+        ) or not all(
+            _point_near_supporting_line(point, saved_start, saved_end)
+            for point in current_piece
+        ):
+            return False
+
+    if not compared:
+        return False
+    saved_local_endpoints = tuple(
+        point
+        for point in (saved_start, saved_end)
+        if _point_intersects_area(point, shape)
+    )
+    current_local_endpoints = tuple(
+        point
+        for point in (current_start, current_end)
+        if _point_intersects_area(point, shape)
+    )
+    return _endpoints_covered(saved_local_endpoints, (current_start, current_end)) and (
+        _endpoints_covered(current_local_endpoints, (saved_start, saved_end))
+    )
+
+
+def _point_near_supporting_line(
+    point: tuple[float, float],
+    line_start: tuple[int, int],
+    line_end: tuple[int, int],
+) -> bool:
+    """Return whether a point is within tolerance of an infinite source line."""
+    delta_x = line_end[0] - line_start[0]
+    delta_y = line_end[1] - line_start[1]
+    length_squared = delta_x * delta_x + delta_y * delta_y
+    if not length_squared:
+        return _points_within_tolerance(point, line_start)
+    cross = delta_x * (point[1] - line_start[1]) - delta_y * (point[0] - line_start[0])
+    tolerance = _LOCAL_GEOMETRY_TOLERANCE_MILLIMETERS
+    return cross * cross <= tolerance * tolerance * length_squared
+
+
+def _point_intersects_area(point: tuple[int, int], shape: _AreaShape) -> bool:
+    """Return whether an original source endpoint is semantically local."""
+    margin = round(_LOCAL_GEOMETRY_MARGIN_METERS * _MILLIMETERS_PER_METER)
+    return any(
+        center_x - radius - margin <= point[0] <= center_x + radius + margin
+        and center_y - radius - margin <= point[1] <= center_y + radius + margin
+        for center_x, center_y, radius in shape
+    )
+
+
+def _endpoints_covered(
+    required: Sequence[tuple[int, int]], candidates: Sequence[tuple[int, int]]
+) -> bool:
+    """Return whether every local source endpoint has a tolerant counterpart."""
+    return all(
+        any(_points_within_tolerance(point, candidate) for candidate in candidates)
+        for point in required
+    )
+
+
+def _points_within_tolerance(
+    first: tuple[float, float], second: tuple[int, int]
+) -> bool:
+    """Return whether both point coordinates differ by at most 10 mm."""
+    return all(
+        abs(saved - current) <= _LOCAL_GEOMETRY_TOLERANCE_MILLIMETERS
+        for saved, current in zip(first, second, strict=True)
     )
 
 
@@ -686,14 +776,6 @@ def _minimum_cost_maximum_flow(
             graph[node][edge[1]][2] = 1
             total_cost += edge[3]
             node = previous
-
-
-def _segment_within_tolerance(first: _LocalSegment, second: _LocalSegment) -> bool:
-    """Return whether every endpoint coordinate differs by at most 10 mm."""
-    return all(
-        abs(saved - current) <= _LOCAL_GEOMETRY_TOLERANCE_MILLIMETERS
-        for saved, current in zip(first, second, strict=True)
-    )
 
 
 def _validate_area_circles(

--- a/custom_components/matic_robot/area_binding.py
+++ b/custom_components/matic_robot/area_binding.py
@@ -51,6 +51,7 @@ _CanonicalPolygon = tuple[_QuantizedPoint, ...]
 _LocalSegment = tuple[int, int, int, int]
 _AreaShape = tuple[tuple[int, int, int], ...]
 _LocalGeometry = tuple[_AreaShape, tuple[int, ...], tuple[_LocalSegment, ...]]
+_SegmentMatch = tuple[int, int]
 _SegmentContext = tuple[
     frozenset[int],
     frozenset[int],
@@ -453,7 +454,8 @@ def area_binding_status(
         return AreaBindingStatus.CURRENT
     saved_segments = tuple(tuple(segment) for segment in saved["local_segments_mm"])
     saved_occupancy = tuple(saved["local_occupancy"])
-    if _local_segments_match(saved_segments, segments, shape) and (
+    segment_matches = _local_segment_correspondence(saved_segments, segments, shape)
+    if segment_matches is not None and (
         saved_occupancy == occupancy
         or _occupancy_changes_are_explained(
             saved_occupancy,
@@ -462,6 +464,7 @@ def area_binding_status(
             segments,
             shape,
             area["circles"],
+            segment_matches,
         )
     ):
         return AreaBindingStatus.CURRENT
@@ -597,6 +600,15 @@ def _local_segments_match(
     current: Sequence[_LocalSegment],
     shape: _AreaShape,
 ) -> bool:
+    """Return whether all semantically local walls have a correspondence."""
+    return _local_segment_correspondence(saved, current, shape) is not None
+
+
+def _local_segment_correspondence(
+    saved: Sequence[_LocalSegment],
+    current: Sequence[_LocalSegment],
+    shape: _AreaShape,
+) -> tuple[_SegmentMatch, ...] | None:
     """Find a tolerant one-to-one match for all semantically local segments.
 
     Segments in the 10 mm selection guard band may appear or disappear without
@@ -613,13 +625,8 @@ def _local_segments_match(
         for cell in context[3]:
             current_by_cell.setdefault(cell, []).append(current_index)
 
-    node_count = len(saved) + len(current) + 2
-    source = node_count - 2
-    sink = node_count - 1
-    graph: list[list[list[int]]] = [[] for _ in range(node_count)]
-
-    for index, is_local in enumerate(saved_local):
-        _add_flow_edge(graph, source, index, -int(is_local))
+    compatible: list[tuple[int, int, int]] = []
+    maximum_pair_cost = 0
     for saved_index, (saved_segment, saved_context) in enumerate(
         zip(saved, saved_contexts, strict=True)
     ):
@@ -638,12 +645,49 @@ def _local_segments_match(
                 current_contexts[current_index],
                 shape,
             ):
-                _add_flow_edge(graph, saved_index, len(saved) + current_index, 0)
-    for index, is_local in enumerate(current_local):
-        _add_flow_edge(graph, len(saved) + index, sink, -int(is_local))
+                pair_cost = _segment_pair_cost(saved_segment, current[current_index])
+                compatible.append((saved_index, current_index, pair_cost))
+                maximum_pair_cost = max(maximum_pair_cost, pair_cost)
 
+    node_count = len(saved) + len(current) + 2
+    source = node_count - 2
+    sink = node_count - 1
+    graph: list[list[list[int]]] = [[] for _ in range(node_count)]
+    local_reward = maximum_pair_cost * (min(len(saved), len(current)) + 1) + 1
+
+    for index, is_local in enumerate(saved_local):
+        _add_flow_edge(graph, source, index, -local_reward * int(is_local))
+    for saved_index, current_index, pair_cost in compatible:
+        _add_flow_edge(graph, saved_index, len(saved) + current_index, pair_cost)
+    for index, is_local in enumerate(current_local):
+        _add_flow_edge(
+            graph,
+            len(saved) + index,
+            sink,
+            -local_reward * int(is_local),
+        )
+
+    _minimum_cost_maximum_flow(graph, source, sink, stop_at_nonnegative=True)
+    matches = tuple(
+        (saved_index, edge[0] - len(saved))
+        for saved_index in range(len(saved))
+        for edge in graph[saved_index]
+        if len(saved) <= edge[0] < len(saved) + len(current) and edge[2] == 0
+    )
     required_score = sum(saved_local) + sum(current_local)
-    return -_minimum_cost_maximum_flow(graph, source, sink) == required_score
+    matched_score = sum(
+        int(saved_local[saved_index]) + int(current_local[current_index])
+        for saved_index, current_index in matches
+    )
+    return matches if matched_score == required_score else None
+
+
+def _segment_pair_cost(saved: _LocalSegment, current: _LocalSegment) -> int:
+    """Return the endpoint distance for the closer wall orientation."""
+    direct = sum(abs(saved[index] - current[index]) for index in range(4))
+    reversed_current = (current[2], current[3], current[0], current[1])
+    reverse = sum(abs(saved[index] - reversed_current[index]) for index in range(4))
+    return min(direct, reverse)
 
 
 def _occupancy_changes_are_explained(
@@ -653,6 +697,7 @@ def _occupancy_changes_are_explained(
     current_segments: Sequence[_LocalSegment],
     shape: _AreaShape,
     circles: Sequence[Mapping[str, Any]],
+    segment_matches: Sequence[_SegmentMatch] | None = None,
 ) -> bool:
     """Return whether every changed probe is explained by a moving wall pair."""
     ordered_circles = sorted(
@@ -676,8 +721,12 @@ def _occupancy_changes_are_explained(
     current_contexts = tuple(
         _segment_context(segment, shape) for segment in current_segments
     )
-    saved_by_cell = _segment_indices_by_spatial_cell(saved_contexts)
-    current_by_cell = _segment_indices_by_spatial_cell(current_contexts)
+    if segment_matches is None:
+        segment_matches = _local_segment_correspondence(
+            saved_segments, current_segments, shape
+        )
+        if segment_matches is None:
+            return False
 
     for (
         (x, y, radius),
@@ -694,22 +743,6 @@ def _occupancy_changes_are_explained(
         for probe_index, probe in enumerate(probes):
             if not changed & (1 << probe_index):
                 continue
-            probe_cell = (
-                math.floor(probe[0] / _SPATIAL_INDEX_CELL_MILLIMETERS),
-                math.floor(probe[1] / _SPATIAL_INDEX_CELL_MILLIMETERS),
-            )
-            saved_candidates = {
-                index
-                for cell_x in range(probe_cell[0] - 1, probe_cell[0] + 2)
-                for cell_y in range(probe_cell[1] - 1, probe_cell[1] + 2)
-                for index in saved_by_cell.get((cell_x, cell_y), ())
-            }
-            current_candidates = {
-                index
-                for cell_x in range(probe_cell[0] - 1, probe_cell[0] + 2)
-                for cell_y in range(probe_cell[1] - 1, probe_cell[1] + 2)
-                for index in current_by_cell.get((cell_x, cell_y), ())
-            }
             if not any(
                 _wall_pair_explains_probe(
                     saved_segments[saved_index],
@@ -719,22 +752,10 @@ def _occupancy_changes_are_explained(
                     probe,
                     shape,
                 )
-                for saved_index in saved_candidates
-                for current_index in current_candidates
+                for saved_index, current_index in segment_matches
             ):
                 return False
     return True
-
-
-def _segment_indices_by_spatial_cell(
-    contexts: Sequence[_SegmentContext],
-) -> dict[tuple[int, int], list[int]]:
-    """Index precomputed segment contexts by their local spatial cells."""
-    by_cell: dict[tuple[int, int], list[int]] = {}
-    for index, context in enumerate(contexts):
-        for cell in context[3]:
-            by_cell.setdefault(cell, []).append(index)
-    return by_cell
 
 
 def _wall_pair_explains_probe(
@@ -1033,7 +1054,11 @@ def _add_flow_edge(
 
 
 def _minimum_cost_maximum_flow(
-    graph: list[list[list[int]]], source: int, sink: int
+    graph: list[list[list[int]]],
+    source: int,
+    sink: int,
+    *,
+    stop_at_nonnegative: bool = False,
 ) -> int:
     """Return the cost of a unit-capacity minimum-cost maximum flow."""
     total_cost = 0
@@ -1064,6 +1089,10 @@ def _minimum_cost_maximum_flow(
                         queue.append(target)
                         queued[target] = True
         if previous_nodes[sink] == -1:
+            return total_cost
+        sink_distance = distances[sink]
+        assert sink_distance is not None
+        if stop_at_nonnegative and sink_distance >= 0:
             return total_cost
 
         node = sink

--- a/custom_components/matic_robot/area_binding.py
+++ b/custom_components/matic_robot/area_binding.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import math
 import struct
+from collections import deque
 from collections.abc import Mapping, Sequence
 from enum import StrEnum
 from typing import Any
@@ -443,7 +444,7 @@ def area_binding_status(
     if str(saved["local_geometry_sha256"]).casefold() == local_geometry:
         return AreaBindingStatus.CURRENT
     saved_segments = tuple(tuple(segment) for segment in saved["local_segments_mm"])
-    if _local_segments_match(saved_segments, segments):
+    if _local_segments_match(saved_segments, segments, shape):
         return AreaBindingStatus.CURRENT
     if saved_geometry != current["geometry_sha256"]:
         return AreaBindingStatus.GEOMETRY_CHANGED
@@ -573,14 +574,30 @@ def _stored_local_geometry_is_intact(binding: Mapping[str, Any]) -> bool:
 
 
 def _local_segments_match(
-    saved: Sequence[_LocalSegment], current: Sequence[_LocalSegment]
+    saved: Sequence[_LocalSegment],
+    current: Sequence[_LocalSegment],
+    shape: _AreaShape,
 ) -> bool:
-    """Match unordered local segments with an explicit coordinate tolerance."""
-    if len(saved) != len(current):
-        return False
-    unmatched = list(current)
-    for saved_segment in saved:
-        for index, current_segment in enumerate(unmatched):
+    """Find a tolerant one-to-one match for all semantically local segments.
+
+    Segments in the 10 mm selection guard band may appear or disappear without
+    invalidating an area, but a segment touching the original 25 cm
+    neighborhood must be covered. Minimum-cost maximum matching avoids a
+    first-fit choice consuming the wrong nearby segment.
+    """
+    saved_local = tuple(_segment_intersects_area(segment, shape) for segment in saved)
+    current_local = tuple(
+        _segment_intersects_area(segment, shape) for segment in current
+    )
+    node_count = len(saved) + len(current) + 2
+    source = node_count - 2
+    sink = node_count - 1
+    graph: list[list[list[int]]] = [[] for _ in range(node_count)]
+
+    for index, is_local in enumerate(saved_local):
+        _add_flow_edge(graph, source, index, -int(is_local))
+    for saved_index, saved_segment in enumerate(saved):
+        for current_index, current_segment in enumerate(current):
             reversed_current = (
                 current_segment[2],
                 current_segment[3],
@@ -590,11 +607,85 @@ def _local_segments_match(
             if _segment_within_tolerance(
                 saved_segment, current_segment
             ) or _segment_within_tolerance(saved_segment, reversed_current):
-                unmatched.pop(index)
-                break
-        else:
-            return False
-    return True
+                _add_flow_edge(graph, saved_index, len(saved) + current_index, 0)
+    for index, is_local in enumerate(current_local):
+        _add_flow_edge(graph, len(saved) + index, sink, -int(is_local))
+
+    required_score = sum(saved_local) + sum(current_local)
+    return -_minimum_cost_maximum_flow(graph, source, sink) == required_score
+
+
+def _segment_intersects_area(segment: _LocalSegment, shape: _AreaShape) -> bool:
+    """Return whether a segment touches the original semantic neighborhood."""
+    margin = round(_LOCAL_GEOMETRY_MARGIN_METERS * _MILLIMETERS_PER_METER)
+    start = (segment[0], segment[1])
+    end = (segment[2], segment[3])
+    return any(
+        _clip_segment(
+            start,
+            end,
+            (
+                center_x - radius - margin,
+                center_y - radius - margin,
+                center_x + radius + margin,
+                center_y + radius + margin,
+            ),
+        )
+        is not None
+        for center_x, center_y, radius in shape
+    )
+
+
+def _add_flow_edge(
+    graph: list[list[list[int]]], source: int, target: int, cost: int
+) -> None:
+    """Add one unit-capacity edge and its residual reverse edge."""
+    graph[source].append([target, len(graph[target]), 1, cost])
+    graph[target].append([source, len(graph[source]) - 1, 0, -cost])
+
+
+def _minimum_cost_maximum_flow(
+    graph: list[list[list[int]]], source: int, sink: int
+) -> int:
+    """Return the cost of a unit-capacity minimum-cost maximum flow."""
+    total_cost = 0
+    while True:
+        distances: list[int | None] = [None] * len(graph)
+        previous_nodes = [-1] * len(graph)
+        previous_edges = [-1] * len(graph)
+        distances[source] = 0
+        queue = deque([source])
+        queued = [False] * len(graph)
+        queued[source] = True
+        while queue:
+            node = queue.popleft()
+            queued[node] = False
+            distance = distances[node]
+            assert distance is not None
+            for edge_index, edge in enumerate(graph[node]):
+                target, _reverse, capacity, cost = edge
+                candidate = distance + cost
+                target_distance = distances[target]
+                if capacity and (
+                    target_distance is None or candidate < target_distance
+                ):
+                    distances[target] = candidate
+                    previous_nodes[target] = node
+                    previous_edges[target] = edge_index
+                    if not queued[target]:
+                        queue.append(target)
+                        queued[target] = True
+        if previous_nodes[sink] == -1:
+            return total_cost
+
+        node = sink
+        while node != source:
+            previous = previous_nodes[node]
+            edge = graph[previous][previous_edges[node]]
+            edge[2] = 0
+            graph[node][edge[1]][2] = 1
+            total_cost += edge[3]
+            node = previous
 
 
 def _segment_within_tolerance(first: _LocalSegment, second: _LocalSegment) -> bool:

--- a/custom_components/matic_robot/area_binding.py
+++ b/custom_components/matic_robot/area_binding.py
@@ -36,6 +36,9 @@ _COORDINATE_QUANTIZATION_ERROR_MILLIMETERS = 0.5
 _SEGMENT_QUANTIZATION_ERROR_MILLIMETERS = math.sqrt(
     2 * _COORDINATE_QUANTIZATION_ERROR_MILLIMETERS**2
 )
+_NEIGHBORHOOD_QUANTIZATION_ERROR_MILLIMETERS = (
+    3 * _COORDINATE_QUANTIZATION_ERROR_MILLIMETERS
+)
 _SPATIAL_INDEX_CELL_MILLIMETERS = 100
 _SPATIAL_INDEX_SAMPLE_MILLIMETERS = _SPATIAL_INDEX_CELL_MILLIMETERS // 2
 _MIN_SIGNED_64 = -(1 << 63)
@@ -809,10 +812,14 @@ def _signed_distance_to_supporting_line(
 
 def _segment_context(segment: _LocalSegment, shape: _AreaShape) -> _SegmentContext:
     """Precompute the local neighborhoods and endpoints for one source wall."""
-    semantic_margin = round(_LOCAL_GEOMETRY_MARGIN_METERS * _MILLIMETERS_PER_METER)
-    guard_margin = round(
+    semantic_margin = math.ceil(
+        _LOCAL_GEOMETRY_MARGIN_METERS * _MILLIMETERS_PER_METER
+        + _NEIGHBORHOOD_QUANTIZATION_ERROR_MILLIMETERS
+    )
+    guard_margin = math.ceil(
         (_LOCAL_GEOMETRY_MARGIN_METERS + _LOCAL_GEOMETRY_TOLERANCE_METERS)
         * _MILLIMETERS_PER_METER
+        + _NEIGHBORHOOD_QUANTIZATION_ERROR_MILLIMETERS
     )
     start = (segment[0], segment[1])
     end = (segment[2], segment[3])

--- a/custom_components/matic_robot/area_binding.py
+++ b/custom_components/matic_robot/area_binding.py
@@ -45,6 +45,7 @@ _CanonicalPolygon = tuple[_QuantizedPoint, ...]
 _LocalSegment = tuple[int, int, int, int]
 _AreaShape = tuple[tuple[int, int, int], ...]
 _LocalGeometry = tuple[_AreaShape, tuple[int, ...], tuple[_LocalSegment, ...]]
+_SegmentContext = tuple[frozenset[int], frozenset[int], tuple[tuple[int, int], ...]]
 
 
 class AreaBindingStatus(StrEnum):
@@ -586,10 +587,18 @@ def _local_segments_match(
     neighborhood must be covered. Minimum-cost maximum matching avoids a
     first-fit choice consuming the wrong nearby segment.
     """
-    saved_local = tuple(_segment_intersects_area(segment, shape) for segment in saved)
-    current_local = tuple(
-        _segment_intersects_area(segment, shape) for segment in current
-    )
+    saved_contexts = tuple(_segment_context(segment, shape) for segment in saved)
+    current_contexts = tuple(_segment_context(segment, shape) for segment in current)
+    saved_local = tuple(bool(context[0]) for context in saved_contexts)
+    current_local = tuple(bool(context[0]) for context in current_contexts)
+    current_by_semantic: list[list[int]] = [[] for _ in shape]
+    current_by_guard: list[list[int]] = [[] for _ in shape]
+    for current_index, (semantic, guard, _endpoints) in enumerate(current_contexts):
+        for neighborhood in semantic:
+            current_by_semantic[neighborhood].append(current_index)
+        for neighborhood in guard:
+            current_by_guard[neighborhood].append(current_index)
+
     node_count = len(saved) + len(current) + 2
     source = node_count - 2
     sink = node_count - 1
@@ -597,9 +606,28 @@ def _local_segments_match(
 
     for index, is_local in enumerate(saved_local):
         _add_flow_edge(graph, source, index, -int(is_local))
-    for saved_index, saved_segment in enumerate(saved):
-        for current_index, current_segment in enumerate(current):
-            if _local_segment_geometries_match(saved_segment, current_segment, shape):
+    for saved_index, (saved_segment, saved_context) in enumerate(
+        zip(saved, saved_contexts, strict=True)
+    ):
+        saved_semantic, saved_guard, _endpoints = saved_context
+        candidates = {
+            current_index
+            for neighborhood in saved_semantic
+            for current_index in current_by_guard[neighborhood]
+        }
+        candidates.update(
+            current_index
+            for neighborhood in saved_guard
+            for current_index in current_by_semantic[neighborhood]
+        )
+        for current_index in candidates:
+            if _local_segment_contexts_match(
+                saved_segment,
+                saved_context,
+                current[current_index],
+                current_contexts[current_index],
+                shape,
+            ):
                 _add_flow_edge(graph, saved_index, len(saved) + current_index, 0)
     for index, is_local in enumerate(current_local):
         _add_flow_edge(graph, len(saved) + index, sink, -int(is_local))
@@ -608,53 +636,81 @@ def _local_segments_match(
     return -_minimum_cost_maximum_flow(graph, source, sink) == required_score
 
 
-def _segment_intersects_area(segment: _LocalSegment, shape: _AreaShape) -> bool:
-    """Return whether a segment touches the original semantic neighborhood."""
-    margin = round(_LOCAL_GEOMETRY_MARGIN_METERS * _MILLIMETERS_PER_METER)
-    start = (segment[0], segment[1])
-    end = (segment[2], segment[3])
-    return any(
-        _clip_segment(
-            start,
-            end,
-            (
-                center_x - radius - margin,
-                center_y - radius - margin,
-                center_x + radius + margin,
-                center_y + radius + margin,
-            ),
-        )
-        is not None
-        for center_x, center_y, radius in shape
-    )
-
-
-def _local_segment_geometries_match(
-    saved: _LocalSegment, current: _LocalSegment, shape: _AreaShape
-) -> bool:
-    """Compare source walls inside local guard boxes without clip artifacts."""
+def _segment_context(segment: _LocalSegment, shape: _AreaShape) -> _SegmentContext:
+    """Precompute the local neighborhoods and endpoints for one source wall."""
     semantic_margin = round(_LOCAL_GEOMETRY_MARGIN_METERS * _MILLIMETERS_PER_METER)
     guard_margin = round(
         (_LOCAL_GEOMETRY_MARGIN_METERS + _LOCAL_GEOMETRY_TOLERANCE_METERS)
         * _MILLIMETERS_PER_METER
     )
-    saved_start = (saved[0], saved[1])
-    saved_end = (saved[2], saved[3])
-    current_start = (current[0], current[1])
-    current_end = (current[2], current[3])
-    compared = False
-    for center_x, center_y, radius in shape:
+    start = (segment[0], segment[1])
+    end = (segment[2], segment[3])
+    semantic: set[int] = set()
+    guard: set[int] = set()
+    local_endpoints: set[tuple[int, int]] = set()
+    for index, (center_x, center_y, radius) in enumerate(shape):
         semantic_bounds = (
             center_x - radius - semantic_margin,
             center_y - radius - semantic_margin,
             center_x + radius + semantic_margin,
             center_y + radius + semantic_margin,
         )
-        if (
-            _clip_segment(saved_start, saved_end, semantic_bounds) is None
-            and _clip_segment(current_start, current_end, semantic_bounds) is None
-        ):
-            continue
+        if _clip_segment(start, end, semantic_bounds) is not None:
+            semantic.add(index)
+        for point in (start, end):
+            if (
+                semantic_bounds[0] <= point[0] <= semantic_bounds[2]
+                and semantic_bounds[1] <= point[1] <= semantic_bounds[3]
+            ):
+                local_endpoints.add(point)
+        guard_bounds = (
+            center_x - radius - guard_margin,
+            center_y - radius - guard_margin,
+            center_x + radius + guard_margin,
+            center_y + radius + guard_margin,
+        )
+        if _clip_segment(start, end, guard_bounds) is not None:
+            guard.add(index)
+    return frozenset(semantic), frozenset(guard), tuple(sorted(local_endpoints))
+
+
+def _local_segment_geometries_match(
+    saved: _LocalSegment, current: _LocalSegment, shape: _AreaShape
+) -> bool:
+    """Compare source walls inside local guard boxes without clip artifacts."""
+    return _local_segment_contexts_match(
+        saved,
+        _segment_context(saved, shape),
+        current,
+        _segment_context(current, shape),
+        shape,
+    )
+
+
+def _local_segment_contexts_match(
+    saved: _LocalSegment,
+    saved_context: _SegmentContext,
+    current: _LocalSegment,
+    current_context: _SegmentContext,
+    shape: _AreaShape,
+) -> bool:
+    """Compare two walls using their precomputed relevant neighborhoods."""
+    guard_margin = round(
+        (_LOCAL_GEOMETRY_MARGIN_METERS + _LOCAL_GEOMETRY_TOLERANCE_METERS)
+        * _MILLIMETERS_PER_METER
+    )
+    saved_semantic, saved_guard, saved_local_endpoints = saved_context
+    current_semantic, current_guard, current_local_endpoints = current_context
+    relevant = saved_semantic | current_semantic
+    if not relevant or not relevant <= saved_guard & current_guard:
+        return False
+
+    saved_start = (saved[0], saved[1])
+    saved_end = (saved[2], saved[3])
+    current_start = (current[0], current[1])
+    current_end = (current[2], current[3])
+    for neighborhood in relevant:
+        center_x, center_y, radius = shape[neighborhood]
         guard_bounds = (
             center_x - radius - guard_margin,
             center_y - radius - guard_margin,
@@ -663,9 +719,7 @@ def _local_segment_geometries_match(
         )
         saved_piece = _clip_segment(saved_start, saved_end, guard_bounds)
         current_piece = _clip_segment(current_start, current_end, guard_bounds)
-        if saved_piece is None or current_piece is None:
-            return False
-        compared = True
+        assert saved_piece is not None and current_piece is not None
         if not all(
             _point_near_supporting_line(point, current_start, current_end)
             for point in saved_piece
@@ -675,18 +729,6 @@ def _local_segment_geometries_match(
         ):
             return False
 
-    if not compared:
-        return False
-    saved_local_endpoints = tuple(
-        point
-        for point in (saved_start, saved_end)
-        if _point_intersects_area(point, shape)
-    )
-    current_local_endpoints = tuple(
-        point
-        for point in (current_start, current_end)
-        if _point_intersects_area(point, shape)
-    )
     return _endpoints_covered(saved_local_endpoints, (current_start, current_end)) and (
         _endpoints_covered(current_local_endpoints, (saved_start, saved_end))
     )
@@ -706,16 +748,6 @@ def _point_near_supporting_line(
     cross = delta_x * (point[1] - line_start[1]) - delta_y * (point[0] - line_start[0])
     tolerance = _LOCAL_GEOMETRY_TOLERANCE_MILLIMETERS
     return cross * cross <= tolerance * tolerance * length_squared
-
-
-def _point_intersects_area(point: tuple[int, int], shape: _AreaShape) -> bool:
-    """Return whether an original source endpoint is semantically local."""
-    margin = round(_LOCAL_GEOMETRY_MARGIN_METERS * _MILLIMETERS_PER_METER)
-    return any(
-        center_x - radius - margin <= point[0] <= center_x + radius + margin
-        and center_y - radius - margin <= point[1] <= center_y + radius + margin
-        for center_x, center_y, radius in shape
-    )
 
 
 def _endpoints_covered(

--- a/custom_components/matic_robot/area_binding.py
+++ b/custom_components/matic_robot/area_binding.py
@@ -28,6 +28,9 @@ _MILLIMETERS_PER_METER = 1_000
 _LEGACY_LOCAL_UNITS_PER_METER = 100
 _LOCAL_GEOMETRY_MARGIN_METERS = 0.25
 _LOCAL_GEOMETRY_TOLERANCE_MILLIMETERS = 10
+_LOCAL_GEOMETRY_TOLERANCE_METERS = (
+    _LOCAL_GEOMETRY_TOLERANCE_MILLIMETERS / _MILLIMETERS_PER_METER
+)
 _MIN_SIGNED_64 = -(1 << 63)
 _MAX_SIGNED_64 = (1 << 63) - 1
 _AREA_REPAIR_LEARN_MORE_URL = (
@@ -180,10 +183,10 @@ def area_geometry_fingerprint(
     """Fingerprint map geometry only near one painted cleaning area.
 
     The fingerprint includes the immutable saved circles, mapped-floor
-    occupancy probes, and room-boundary segments within a small safety margin.
-    Geometry elsewhere on the floor cannot invalidate the area. Binding status
-    compares the private millimeter components with an explicit tolerance when
-    the exact digest changes.
+    occupancy probes, and room-boundary segments within a small safety margin
+    plus a tolerance guard band. Geometry elsewhere on the floor cannot
+    invalidate the area. Binding status compares the private millimeter
+    components with an explicit tolerance when the exact digest changes.
     """
     return _local_geometry_fingerprint(*_area_geometry_components(floor_plan, circles))
 
@@ -289,10 +292,22 @@ def _area_geometry_components(
     )
     neighborhoods = tuple(
         (
-            x - radius - _LOCAL_GEOMETRY_MARGIN_METERS,
-            y - radius - _LOCAL_GEOMETRY_MARGIN_METERS,
-            x + radius + _LOCAL_GEOMETRY_MARGIN_METERS,
-            y + radius + _LOCAL_GEOMETRY_MARGIN_METERS,
+            x
+            - radius
+            - _LOCAL_GEOMETRY_MARGIN_METERS
+            - _LOCAL_GEOMETRY_TOLERANCE_METERS,
+            y
+            - radius
+            - _LOCAL_GEOMETRY_MARGIN_METERS
+            - _LOCAL_GEOMETRY_TOLERANCE_METERS,
+            x
+            + radius
+            + _LOCAL_GEOMETRY_MARGIN_METERS
+            + _LOCAL_GEOMETRY_TOLERANCE_METERS,
+            y
+            + radius
+            + _LOCAL_GEOMETRY_MARGIN_METERS
+            + _LOCAL_GEOMETRY_TOLERANCE_METERS,
         )
         for x, y, radius in ordered_float
     )

--- a/custom_components/matic_robot/area_binding.py
+++ b/custom_components/matic_robot/area_binding.py
@@ -22,9 +22,10 @@ MAP_BINDING_VERSION = 1
 SCOPED_MAP_BINDING_VERSION = 2
 _FINGERPRINT_DOMAIN = b"matic-area-geometry\0"
 _SCOPED_FINGERPRINT_DOMAIN = b"matic-area-local-geometry\0"
+_AREA_SHAPE_FINGERPRINT_DOMAIN = b"matic-area-shape\0"
 _MILLIMETERS_PER_METER = 1_000
-_LOCAL_UNITS_PER_METER = 100
 _LOCAL_GEOMETRY_MARGIN_METERS = 0.25
+_LOCAL_GEOMETRY_TOLERANCE_MILLIMETERS = 10
 _MIN_SIGNED_64 = -(1 << 63)
 _MAX_SIGNED_64 = (1 << 63) - 1
 _AREA_REPAIR_LEARN_MORE_URL = (
@@ -32,9 +33,12 @@ _AREA_REPAIR_LEARN_MORE_URL = (
     "blob/main/docs/automation.md#drawn-custom-areas"
 )
 
-MapBinding = dict[str, int | str]
+MapBinding = dict[str, Any]
 _QuantizedPoint = tuple[int, int]
 _CanonicalPolygon = tuple[_QuantizedPoint, ...]
+_LocalSegment = tuple[int, int, int, int]
+_AreaShape = tuple[tuple[int, int, int], ...]
+_LocalGeometry = tuple[_AreaShape, tuple[int, ...], tuple[_LocalSegment, ...]]
 
 
 class AreaBindingStatus(StrEnum):
@@ -136,10 +140,16 @@ def binding_for_area(
     floor_plan: FloorPlan, circles: Sequence[Mapping[str, Any]]
 ) -> MapBinding:
     """Bind an area to its map identity and nearby room geometry."""
+    shape, occupancy, segments = _area_geometry_components(floor_plan, circles)
     return {
         "version": SCOPED_MAP_BINDING_VERSION,
         **_floor_plan_binding(floor_plan),
-        "local_geometry_sha256": area_geometry_fingerprint(floor_plan, circles),
+        "area_shape_sha256": _area_shape_fingerprint(shape),
+        "local_geometry_sha256": _local_geometry_fingerprint(
+            shape, occupancy, segments
+        ),
+        "local_occupancy": list(occupancy),
+        "local_segments_mm": [list(segment) for segment in segments],
     }
 
 
@@ -169,12 +179,19 @@ def area_geometry_fingerprint(
 
     The fingerprint includes the immutable saved circles, mapped-floor
     occupancy probes, and room-boundary segments within a small safety margin.
-    Geometry elsewhere on the floor cannot invalidate the area. Local boundary
-    coordinates are quantized to centimeters so sub-centimeter decoder jitter
-    does not create a Repair.
+    Geometry elsewhere on the floor cannot invalidate the area. Binding status
+    compares the private millimeter components with an explicit tolerance when
+    the exact digest changes.
     """
+    return _local_geometry_fingerprint(*_area_geometry_components(floor_plan, circles))
+
+
+def _area_geometry_components(
+    floor_plan: FloorPlan, circles: Sequence[Mapping[str, Any]]
+) -> _LocalGeometry:
+    """Return canonical private area shape, occupancy, and nearby segments."""
     normalized = _validate_area_circles(floor_plan, circles)
-    ordered = sorted(
+    ordered_float = sorted(
         (
             float(circle["x"]),
             float(circle["y"]),
@@ -182,17 +199,29 @@ def area_geometry_fingerprint(
         )
         for circle in normalized
     )
+    shape = tuple(
+        (
+            _quantize_coordinate(x),
+            _quantize_coordinate(y),
+            _quantize_coordinate(radius),
+        )
+        for x, y, radius in ordered_float
+    )
     neighborhood = (
-        min(x - radius for x, _y, radius in ordered) - _LOCAL_GEOMETRY_MARGIN_METERS,
-        min(y - radius for _x, y, radius in ordered) - _LOCAL_GEOMETRY_MARGIN_METERS,
-        max(x + radius for x, _y, radius in ordered) + _LOCAL_GEOMETRY_MARGIN_METERS,
-        max(y + radius for _x, y, radius in ordered) + _LOCAL_GEOMETRY_MARGIN_METERS,
+        min(x - radius for x, _y, radius in ordered_float)
+        - _LOCAL_GEOMETRY_MARGIN_METERS,
+        min(y - radius for _x, y, radius in ordered_float)
+        - _LOCAL_GEOMETRY_MARGIN_METERS,
+        max(x + radius for x, _y, radius in ordered_float)
+        + _LOCAL_GEOMETRY_MARGIN_METERS,
+        max(y + radius for _x, y, radius in ordered_float)
+        + _LOCAL_GEOMETRY_MARGIN_METERS,
     )
     room_boundaries = tuple(
         [list(point) for point in room.boundary] for room in floor_plan.rooms
     )
 
-    segments: set[tuple[int, int, int, int]] = set()
+    segments: set[_LocalSegment] = set()
     for room in floor_plan.rooms:
         boundary = room.boundary
         for start, end in zip(boundary, (*boundary[1:], boundary[0]), strict=True):
@@ -200,30 +229,19 @@ def area_geometry_fingerprint(
             if clipped is None:
                 continue
             first = (
-                _quantize_local(clipped[0][0]),
-                _quantize_local(clipped[0][1]),
+                _quantize_coordinate(clipped[0][0]),
+                _quantize_coordinate(clipped[0][1]),
             )
             second = (
-                _quantize_local(clipped[1][0]),
-                _quantize_local(clipped[1][1]),
+                _quantize_coordinate(clipped[1][0]),
+                _quantize_coordinate(clipped[1][1]),
             )
             if second < first:
                 first, second = second, first
             segments.add((*first, *second))
 
-    digest = hashlib.sha256()
-    digest.update(_SCOPED_FINGERPRINT_DOMAIN)
-    digest.update(struct.pack(">H", SCOPED_MAP_BINDING_VERSION))
-    digest.update(struct.pack(">I", len(ordered)))
-    for x, y, radius in ordered:
-        digest.update(
-            struct.pack(
-                ">qqq",
-                _quantize_coordinate(x),
-                _quantize_coordinate(y),
-                _quantize_coordinate(radius),
-            )
-        )
+    occupancy_values = []
+    for x, y, radius in ordered_float:
         probe_radius = radius + _LOCAL_GEOMETRY_MARGIN_METERS
         diagonal = probe_radius / math.sqrt(2)
         probes = (
@@ -241,9 +259,35 @@ def area_geometry_fingerprint(
             int(_point_in_floor(probe_x, probe_y, room_boundaries)) << index
             for index, (probe_x, probe_y) in enumerate(probes)
         )
-        digest.update(struct.pack(">H", occupancy))
+        occupancy_values.append(occupancy)
+    return shape, tuple(occupancy_values), tuple(sorted(segments))
+
+
+def _area_shape_fingerprint(shape: _AreaShape) -> str:
+    """Fingerprint the immutable saved circles independently of the map."""
+    digest = hashlib.sha256()
+    digest.update(_AREA_SHAPE_FINGERPRINT_DOMAIN)
+    digest.update(struct.pack(">I", len(shape)))
+    for circle in shape:
+        digest.update(struct.pack(">qqq", *circle))
+    return digest.hexdigest()
+
+
+def _local_geometry_fingerprint(
+    shape: _AreaShape,
+    occupancy: Sequence[int],
+    segments: Sequence[_LocalSegment],
+) -> str:
+    """Fingerprint exact private components while retaining tolerant evidence."""
+    digest = hashlib.sha256()
+    digest.update(_SCOPED_FINGERPRINT_DOMAIN)
+    digest.update(struct.pack(">H", SCOPED_MAP_BINDING_VERSION))
+    digest.update(bytes.fromhex(_area_shape_fingerprint(shape)))
+    digest.update(struct.pack(">I", len(occupancy)))
+    for value in occupancy:
+        digest.update(struct.pack(">H", value))
     digest.update(struct.pack(">I", len(segments)))
-    for segment in sorted(segments):
+    for segment in segments:
         digest.update(struct.pack(">qqqq", *segment))
     return digest.hexdigest()
 
@@ -281,12 +325,23 @@ def area_binding_status(
         return AreaBindingStatus.CURRENT
 
     try:
-        local_geometry = area_geometry_fingerprint(floor_plan, area["circles"])
+        shape, occupancy, segments = _area_geometry_components(
+            floor_plan, area["circles"]
+        )
     except KeyError, OverflowError, TypeError, ValueError:
         return AreaBindingStatus.INVALID
+    if str(saved["area_shape_sha256"]).casefold() != _area_shape_fingerprint(shape):
+        return AreaBindingStatus.INVALID
+    local_geometry = _local_geometry_fingerprint(shape, occupancy, segments)
     if str(saved["local_geometry_sha256"]).casefold() == local_geometry:
         return AreaBindingStatus.CURRENT
     if saved_geometry != current["geometry_sha256"]:
+        saved_occupancy = tuple(saved["local_occupancy"])
+        saved_segments = tuple(tuple(segment) for segment in saved["local_segments_mm"])
+        if saved_occupancy == occupancy and _local_segments_match(
+            saved_segments, segments
+        ):
+            return AreaBindingStatus.CURRENT
         return AreaBindingStatus.GEOMETRY_CHANGED
     return AreaBindingStatus.INVALID
 
@@ -316,7 +371,13 @@ def _valid_saved_binding(binding: Mapping[str, Any]) -> bool:
     expected_fields = (
         base_fields
         if version == MAP_BINDING_VERSION
-        else {*base_fields, "local_geometry_sha256"}
+        else {
+            *base_fields,
+            "area_shape_sha256",
+            "local_geometry_sha256",
+            "local_occupancy",
+            "local_segments_mm",
+        }
     )
     if set(binding) != expected_fields:
         return False
@@ -335,7 +396,13 @@ def _valid_saved_binding(binding: Mapping[str, Any]) -> bool:
         and all(character in "0123456789abcdefABCDEF" for character in geometry)
         and (
             version == MAP_BINDING_VERSION
-            or _valid_digest(binding["local_geometry_sha256"])
+            or (
+                _valid_digest(binding["area_shape_sha256"])
+                and _valid_digest(binding["local_geometry_sha256"])
+                and _valid_local_occupancy(binding["local_occupancy"])
+                and _valid_local_segments(binding["local_segments_mm"])
+                and _stored_local_geometry_is_intact(binding)
+            )
         )
     )
 
@@ -346,6 +413,80 @@ def _valid_digest(value: Any) -> bool:
         isinstance(value, str)
         and len(value) == 64
         and all(character in "0123456789abcdefABCDEF" for character in value)
+    )
+
+
+def _valid_local_occupancy(value: Any) -> bool:
+    """Return whether saved occupancy probes have their bounded list shape."""
+    return isinstance(value, list) and all(
+        not isinstance(item, bool) and isinstance(item, int) and 0 <= item < 1 << 9
+        for item in value
+    )
+
+
+def _valid_local_segments(value: Any) -> bool:
+    """Return whether saved millimeter segments have a bounded numeric shape."""
+    return isinstance(value, list) and all(
+        isinstance(segment, list)
+        and len(segment) == 4
+        and all(
+            not isinstance(coordinate, bool)
+            and isinstance(coordinate, int)
+            and _MIN_SIGNED_64 <= coordinate <= _MAX_SIGNED_64
+            for coordinate in segment
+        )
+        for segment in value
+    )
+
+
+def _stored_local_geometry_is_intact(binding: Mapping[str, Any]) -> bool:
+    """Verify that the private tolerant evidence still matches its digest."""
+    shape_digest = str(binding["area_shape_sha256"]).casefold()
+    digest = hashlib.sha256()
+    digest.update(_SCOPED_FINGERPRINT_DOMAIN)
+    digest.update(struct.pack(">H", SCOPED_MAP_BINDING_VERSION))
+    digest.update(bytes.fromhex(shape_digest))
+    occupancy = binding["local_occupancy"]
+    digest.update(struct.pack(">I", len(occupancy)))
+    for value in occupancy:
+        digest.update(struct.pack(">H", value))
+    segments = binding["local_segments_mm"]
+    digest.update(struct.pack(">I", len(segments)))
+    for segment in segments:
+        digest.update(struct.pack(">qqqq", *segment))
+    return digest.hexdigest() == str(binding["local_geometry_sha256"]).casefold()
+
+
+def _local_segments_match(
+    saved: Sequence[_LocalSegment], current: Sequence[_LocalSegment]
+) -> bool:
+    """Match unordered local segments with an explicit coordinate tolerance."""
+    if len(saved) != len(current):
+        return False
+    unmatched = list(current)
+    for saved_segment in saved:
+        for index, current_segment in enumerate(unmatched):
+            reversed_current = (
+                current_segment[2],
+                current_segment[3],
+                current_segment[0],
+                current_segment[1],
+            )
+            if _segment_within_tolerance(
+                saved_segment, current_segment
+            ) or _segment_within_tolerance(saved_segment, reversed_current):
+                unmatched.pop(index)
+                break
+        else:
+            return False
+    return True
+
+
+def _segment_within_tolerance(first: _LocalSegment, second: _LocalSegment) -> bool:
+    """Return whether every endpoint coordinate differs by at most 10 mm."""
+    return all(
+        abs(saved - current) <= _LOCAL_GEOMETRY_TOLERANCE_MILLIMETERS
+        for saved, current in zip(first, second, strict=True)
     )
 
 
@@ -439,11 +580,6 @@ def _smallest_rotation(points: _CanonicalPolygon) -> _CanonicalPolygon:
 def _quantize_coordinate(value: float) -> int:
     """Convert finite meters to signed millimeters, normalizing negative zero."""
     return _quantize(value, _MILLIMETERS_PER_METER)
-
-
-def _quantize_local(value: float) -> int:
-    """Convert a local boundary coordinate to signed centimeters."""
-    return _quantize(value, _LOCAL_UNITS_PER_METER)
 
 
 def _quantize(value: float, units_per_meter: int) -> int:

--- a/custom_components/matic_robot/area_binding.py
+++ b/custom_components/matic_robot/area_binding.py
@@ -428,11 +428,8 @@ def area_binding_status(
     if str(saved["local_geometry_sha256"]).casefold() == local_geometry:
         return AreaBindingStatus.CURRENT
     if saved_geometry != current["geometry_sha256"]:
-        saved_occupancy = tuple(saved["local_occupancy"])
         saved_segments = tuple(tuple(segment) for segment in saved["local_segments_mm"])
-        if saved_occupancy == occupancy and _local_segments_match(
-            saved_segments, segments
-        ):
+        if _local_segments_match(saved_segments, segments):
             return AreaBindingStatus.CURRENT
         return AreaBindingStatus.GEOMETRY_CHANGED
     return AreaBindingStatus.INVALID

--- a/custom_components/matic_robot/area_binding.py
+++ b/custom_components/matic_robot/area_binding.py
@@ -32,6 +32,7 @@ _LOCAL_GEOMETRY_TOLERANCE_MILLIMETERS = 10
 _LOCAL_GEOMETRY_TOLERANCE_METERS = (
     _LOCAL_GEOMETRY_TOLERANCE_MILLIMETERS / _MILLIMETERS_PER_METER
 )
+_SEGMENT_QUANTIZATION_ERROR_MILLIMETERS = math.sqrt(0.5)
 _MIN_SIGNED_64 = -(1 << 63)
 _MAX_SIGNED_64 = (1 << 63) - 1
 _AREA_REPAIR_LEARN_MORE_URL = (
@@ -247,19 +248,7 @@ def _hash_only_area_geometry_fingerprint(
                 _quantize_coordinate(radius),
             )
         )
-        probe_radius = radius + _LOCAL_GEOMETRY_MARGIN_METERS
-        diagonal = probe_radius / math.sqrt(2)
-        probes = (
-            (x, y),
-            (x - probe_radius, y),
-            (x + probe_radius, y),
-            (x, y - probe_radius),
-            (x, y + probe_radius),
-            (x - diagonal, y - diagonal),
-            (x - diagonal, y + diagonal),
-            (x + diagonal, y - diagonal),
-            (x + diagonal, y + diagonal),
-        )
+        probes = _occupancy_probes(x, y, radius)
         occupancy = sum(
             int(_point_in_floor(probe_x, probe_y, room_boundaries)) << index
             for index, (probe_x, probe_y) in enumerate(probes)
@@ -340,25 +329,32 @@ def _area_geometry_components(
 
     occupancy_values = []
     for x, y, radius in ordered_float:
-        probe_radius = radius + _LOCAL_GEOMETRY_MARGIN_METERS
-        diagonal = probe_radius / math.sqrt(2)
-        probes = (
-            (x, y),
-            (x - probe_radius, y),
-            (x + probe_radius, y),
-            (x, y - probe_radius),
-            (x, y + probe_radius),
-            (x - diagonal, y - diagonal),
-            (x - diagonal, y + diagonal),
-            (x + diagonal, y - diagonal),
-            (x + diagonal, y + diagonal),
-        )
+        probes = _occupancy_probes(x, y, radius)
         occupancy = sum(
             int(_point_in_floor(probe_x, probe_y, room_boundaries)) << index
             for index, (probe_x, probe_y) in enumerate(probes)
         )
         occupancy_values.append(occupancy)
     return shape, tuple(occupancy_values), tuple(sorted(segments))
+
+
+def _occupancy_probes(
+    x: float, y: float, radius: float
+) -> tuple[tuple[float, float], ...]:
+    """Return the exact floating-point probes used by occupancy evidence."""
+    probe_radius = radius + _LOCAL_GEOMETRY_MARGIN_METERS
+    diagonal = probe_radius / math.sqrt(2)
+    return (
+        (x, y),
+        (x - probe_radius, y),
+        (x + probe_radius, y),
+        (x, y - probe_radius),
+        (x, y + probe_radius),
+        (x - diagonal, y - diagonal),
+        (x - diagonal, y + diagonal),
+        (x + diagonal, y - diagonal),
+        (x + diagonal, y + diagonal),
+    )
 
 
 def _area_shape_fingerprint(shape: _AreaShape) -> str:
@@ -450,7 +446,12 @@ def area_binding_status(
     if _local_segments_match(saved_segments, segments, shape) and (
         saved_occupancy == occupancy
         or _occupancy_changes_are_explained(
-            saved_occupancy, occupancy, saved_segments, segments, shape
+            saved_occupancy,
+            occupancy,
+            saved_segments,
+            segments,
+            shape,
+            area["circles"],
         )
     ):
         return AreaBindingStatus.CURRENT
@@ -648,9 +649,22 @@ def _occupancy_changes_are_explained(
     saved_segments: Sequence[_LocalSegment],
     current_segments: Sequence[_LocalSegment],
     shape: _AreaShape,
+    circles: Sequence[Mapping[str, Any]],
 ) -> bool:
     """Return whether every changed probe is near old and new local walls."""
-    if len(saved_occupancy) != len(shape) or len(current_occupancy) != len(shape):
+    ordered_circles = sorted(
+        (
+            float(circle["x"]),
+            float(circle["y"]),
+            float(circle["radius"]),
+        )
+        for circle in circles
+    )
+    if (
+        len(saved_occupancy) != len(shape)
+        or len(current_occupancy) != len(shape)
+        or len(ordered_circles) != len(shape)
+    ):
         return False
 
     saved_by_neighborhood: list[list[_LocalSegment]] = [[] for _ in shape]
@@ -662,27 +676,19 @@ def _occupancy_changes_are_explained(
         for neighborhood in _segment_context(segment, shape)[1]:
             current_by_neighborhood[neighborhood].append(segment)
 
-    semantic_margin = round(_LOCAL_GEOMETRY_MARGIN_METERS * _MILLIMETERS_PER_METER)
     for neighborhood, (
-        (center_x, center_y, radius),
+        (x, y, radius),
         saved_value,
         current_value,
-    ) in enumerate(zip(shape, saved_occupancy, current_occupancy, strict=True)):
+    ) in enumerate(
+        zip(ordered_circles, saved_occupancy, current_occupancy, strict=True)
+    ):
         changed = saved_value ^ current_value
         if not changed:
             continue
-        probe_radius = radius + semantic_margin
-        diagonal = probe_radius / math.sqrt(2)
-        probes = (
-            (center_x, center_y),
-            (center_x - probe_radius, center_y),
-            (center_x + probe_radius, center_y),
-            (center_x, center_y - probe_radius),
-            (center_x, center_y + probe_radius),
-            (center_x - diagonal, center_y - diagonal),
-            (center_x - diagonal, center_y + diagonal),
-            (center_x + diagonal, center_y - diagonal),
-            (center_x + diagonal, center_y + diagonal),
+        probes = tuple(
+            (probe_x * _MILLIMETERS_PER_METER, probe_y * _MILLIMETERS_PER_METER)
+            for probe_x, probe_y in _occupancy_probes(x, y, radius)
         )
         for probe_index, probe in enumerate(probes):
             if not changed & (1 << probe_index):
@@ -813,7 +819,7 @@ def _point_near_supporting_line(
 
 
 def _point_near_segment(point: tuple[float, float], segment: _LocalSegment) -> bool:
-    """Return whether a point is within tolerance of a finite source wall."""
+    """Return whether a probe is near a millimeter-quantized source wall."""
     start_x, start_y, end_x, end_y = segment
     delta_x = end_x - start_x
     delta_y = end_y - start_y
@@ -832,7 +838,9 @@ def _point_near_segment(point: tuple[float, float], segment: _LocalSegment) -> b
         nearest_y = start_y + projection * delta_y
     distance_x = point[0] - nearest_x
     distance_y = point[1] - nearest_y
-    tolerance = _LOCAL_GEOMETRY_TOLERANCE_MILLIMETERS
+    tolerance = (
+        _LOCAL_GEOMETRY_TOLERANCE_MILLIMETERS + _SEGMENT_QUANTIZATION_ERROR_MILLIMETERS
+    )
     return distance_x * distance_x + distance_y * distance_y <= tolerance * tolerance
 
 

--- a/custom_components/matic_robot/area_binding.py
+++ b/custom_components/matic_robot/area_binding.py
@@ -316,24 +316,26 @@ def _area_geometry_components(
         [list(point) for point in room.boundary] for room in floor_plan.rooms
     )
 
-    segments: set[_LocalSegment] = set()
+    segments: list[_LocalSegment] = []
     for room in floor_plan.rooms:
         boundary = room.boundary
         for start, end in zip(boundary, (*boundary[1:], boundary[0]), strict=True):
-            for neighborhood in neighborhoods:
-                if _clip_segment(start, end, neighborhood) is None:
-                    continue
-                first = (
-                    _quantize_coordinate(start[0]),
-                    _quantize_coordinate(start[1]),
-                )
-                second = (
-                    _quantize_coordinate(end[0]),
-                    _quantize_coordinate(end[1]),
-                )
-                if second < first:
-                    first, second = second, first
-                segments.add((*first, *second))
+            if not any(
+                _clip_segment(start, end, neighborhood) is not None
+                for neighborhood in neighborhoods
+            ):
+                continue
+            first = (
+                _quantize_coordinate(start[0]),
+                _quantize_coordinate(start[1]),
+            )
+            second = (
+                _quantize_coordinate(end[0]),
+                _quantize_coordinate(end[1]),
+            )
+            if second < first:
+                first, second = second, first
+            segments.append((*first, *second))
 
     occupancy_values = []
     for x, y, radius in ordered_float:

--- a/custom_components/matic_robot/area_binding.py
+++ b/custom_components/matic_robot/area_binding.py
@@ -633,7 +633,8 @@ def _local_segment_geometries_match(
     saved: _LocalSegment, current: _LocalSegment, shape: _AreaShape
 ) -> bool:
     """Compare source walls inside local guard boxes without clip artifacts."""
-    margin = round(
+    semantic_margin = round(_LOCAL_GEOMETRY_MARGIN_METERS * _MILLIMETERS_PER_METER)
+    guard_margin = round(
         (_LOCAL_GEOMETRY_MARGIN_METERS + _LOCAL_GEOMETRY_TOLERANCE_METERS)
         * _MILLIMETERS_PER_METER
     )
@@ -643,16 +644,25 @@ def _local_segment_geometries_match(
     current_end = (current[2], current[3])
     compared = False
     for center_x, center_y, radius in shape:
-        bounds = (
-            center_x - radius - margin,
-            center_y - radius - margin,
-            center_x + radius + margin,
-            center_y + radius + margin,
+        semantic_bounds = (
+            center_x - radius - semantic_margin,
+            center_y - radius - semantic_margin,
+            center_x + radius + semantic_margin,
+            center_y + radius + semantic_margin,
         )
-        saved_piece = _clip_segment(saved_start, saved_end, bounds)
-        current_piece = _clip_segment(current_start, current_end, bounds)
-        if saved_piece is None and current_piece is None:
+        if (
+            _clip_segment(saved_start, saved_end, semantic_bounds) is None
+            and _clip_segment(current_start, current_end, semantic_bounds) is None
+        ):
             continue
+        guard_bounds = (
+            center_x - radius - guard_margin,
+            center_y - radius - guard_margin,
+            center_x + radius + guard_margin,
+            center_y + radius + guard_margin,
+        )
+        saved_piece = _clip_segment(saved_start, saved_end, guard_bounds)
+        current_piece = _clip_segment(current_start, current_end, guard_bounds)
         if saved_piece is None or current_piece is None:
             return False
         compared = True

--- a/custom_components/matic_robot/area_selector.py
+++ b/custom_components/matic_robot/area_selector.py
@@ -82,8 +82,64 @@ class MaticAreaSelector(Selector[MaticAreaSelectorConfig]):
             previous = current
         return inside
 
+    @staticmethod
+    def _point_near_segment(
+        x: float,
+        y: float,
+        start: list[float],
+        end: list[float],
+        tolerance: float,
+    ) -> bool:
+        """Return whether a point is within a distance of a polygon edge."""
+        start_x, start_y = (float(value) for value in start)
+        end_x, end_y = (float(value) for value in end)
+        delta_x = end_x - start_x
+        delta_y = end_y - start_y
+        length_squared = delta_x * delta_x + delta_y * delta_y
+        projection = (
+            0.0
+            if not length_squared
+            else min(
+                1.0,
+                max(
+                    0.0,
+                    ((x - start_x) * delta_x + (y - start_y) * delta_y)
+                    / length_squared,
+                ),
+            )
+        )
+        nearest_x = start_x + projection * delta_x
+        nearest_y = start_y + projection * delta_y
+        return math.hypot(x - nearest_x, y - nearest_y) <= tolerance
+
+    @classmethod
+    def _point_in_or_near_polygon(
+        cls,
+        x: float,
+        y: float,
+        boundary: list[list[float]],
+        tolerance: float,
+    ) -> bool:
+        """Return whether a point is inside or tolerably near a polygon."""
+        if cls._point_in_polygon(x, y, boundary):
+            return True
+        if not tolerance:
+            return False
+        return any(
+            cls._point_near_segment(x, y, previous, current, tolerance)
+            for previous, current in zip(
+                (boundary[-1], *boundary[:-1]), boundary, strict=True
+            )
+        )
+
     def __call__(self, data: Any) -> list[dict[str, float]]:
         """Validate and canonicalize drawn circles without exposing them."""
+        return self.validate(data)
+
+    def validate(
+        self, data: Any, *, center_tolerance: float = 0.0
+    ) -> list[dict[str, float]]:
+        """Validate circles with an optional saved-center boundary tolerance."""
         if not isinstance(data, list):
             raise vol.Invalid("Expected a list of drawn circles")
         if not 1 <= len(data) <= 512:
@@ -105,7 +161,12 @@ class MaticAreaSelector(Selector[MaticAreaSelectorConfig]):
             if not all(math.isfinite(value) for value in circle.values()):
                 raise vol.Invalid("Area circle values must be finite")
             if not any(
-                self._point_in_polygon(circle["x"], circle["y"], room["boundary"])
+                self._point_in_or_near_polygon(
+                    circle["x"],
+                    circle["y"],
+                    room["boundary"],
+                    center_tolerance,
+                )
                 for room in rooms
             ):
                 raise vol.Invalid("Area circle centers must be inside a mapped room")

--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -18,6 +18,7 @@ from homeassistant.helpers.storage import Store
 from homeassistant.util import dt as dt_util
 
 from .area_binding import (
+    HASH_ONLY_SCOPED_MAP_BINDING_VERSION,
     MAP_BINDING_VERSION,
     AreaBindingStatus,
     area_binding_status,
@@ -377,7 +378,11 @@ class CleaningPlanManager:
             binding = area.get("map_binding")
             if (
                 not isinstance(binding, Mapping)
-                or binding.get("version") != MAP_BINDING_VERSION
+                or binding.get("version")
+                not in {
+                    MAP_BINDING_VERSION,
+                    HASH_ONLY_SCOPED_MAP_BINDING_VERSION,
+                }
                 or area_binding_status(area, floor_plan)
                 is not AreaBindingStatus.CURRENT
             ):

--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -376,13 +376,14 @@ class CleaningPlanManager:
         upgraded = 0
         for area in self._robot(serial_number)["areas"].values():
             binding = area.get("map_binding")
+            if not isinstance(binding, Mapping):
+                continue
+            version = binding.get("version")
+            if isinstance(version, bool) or not isinstance(version, int):
+                continue
             if (
-                not isinstance(binding, Mapping)
-                or binding.get("version")
-                not in {
-                    MAP_BINDING_VERSION,
-                    HASH_ONLY_SCOPED_MAP_BINDING_VERSION,
-                }
+                version
+                not in {MAP_BINDING_VERSION, HASH_ONLY_SCOPED_MAP_BINDING_VERSION}
                 or area_binding_status(area, floor_plan)
                 is not AreaBindingStatus.CURRENT
             ):

--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -55,6 +55,14 @@ class PlanStopDecision:
     threshold: int | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class AreaBindingUpgradeResult:
+    """Outcome of one legacy-area migration attempt."""
+
+    upgraded: int
+    pending: bool
+
+
 class ManagedMotionReplacedError(HomeAssistantError):
     """A newer command superseded a managed plan command."""
 
@@ -369,11 +377,10 @@ class CleaningPlanManager:
 
     async def async_upgrade_area_bindings(
         self, serial_number: str, floor_plan: FloorPlan | None
-    ) -> int:
+    ) -> AreaBindingUpgradeResult:
         """Upgrade exactly current whole-map area bindings to scoped bindings."""
-        if floor_plan is None:
-            return 0
         upgraded = 0
+        pending = False
         for area in self._robot(serial_number)["areas"].values():
             binding = area.get("map_binding")
             if not isinstance(binding, Mapping):
@@ -381,21 +388,32 @@ class CleaningPlanManager:
             version = binding.get("version")
             if isinstance(version, bool) or not isinstance(version, int):
                 continue
-            if (
-                version
-                not in {MAP_BINDING_VERSION, HASH_ONLY_SCOPED_MAP_BINDING_VERSION}
-                or area_binding_status(area, floor_plan)
-                is not AreaBindingStatus.CURRENT
-            ):
+            if version not in {
+                MAP_BINDING_VERSION,
+                HASH_ONLY_SCOPED_MAP_BINDING_VERSION,
+            }:
+                continue
+            circles = area.get("circles")
+            if not isinstance(circles, list):
+                continue
+            if floor_plan is None:
+                pending = True
+                continue
+            status = area_binding_status(area, floor_plan)
+            if status is not AreaBindingStatus.CURRENT:
+                pending = pending or status in {
+                    AreaBindingStatus.GEOMETRY_CHANGED,
+                    AreaBindingStatus.INVALID,
+                }
                 continue
             try:
-                area["map_binding"] = binding_for_area(floor_plan, area["circles"])
+                area["map_binding"] = binding_for_area(floor_plan, circles)
             except KeyError, TypeError, ValueError:
                 continue
             upgraded += 1
         if upgraded:
             await self._async_save_and_notify(serial_number)
-        return upgraded
+        return AreaBindingUpgradeResult(upgraded, pending)
 
     def area(self, serial_number: str, reference: str | None = None) -> dict[str, Any]:
         """Return one locally saved area by stable ID or exact name."""

--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import math
-from collections.abc import AsyncIterator, Callable, Iterable, Mapping
+from collections.abc import AsyncIterator, Callable, Iterable, Mapping, MutableMapping
 from contextlib import asynccontextmanager
 from copy import deepcopy
 from dataclasses import asdict, dataclass
@@ -382,6 +382,8 @@ class CleaningPlanManager:
         upgraded = 0
         pending = False
         for area in self._robot(serial_number)["areas"].values():
+            if not isinstance(area, MutableMapping):
+                continue
             binding = area.get("map_binding")
             if not isinstance(binding, Mapping):
                 continue

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -103,9 +103,10 @@ name. The saved record also binds it to the exact coverage mission, standard
 partition, and canonical room geometry it was drawn on. A legacy unbound area,
 remap, floor change, or geometry mismatch is blocked before any robot command.
 Newly confirmed areas also retain a private signature of mapped geometry in
-the union of a 25 cm margin around each painted mark. An explicit 10 mm
-comparison tolerance lets changes elsewhere on the floor and sub-centimeter
-boundary jitter revalidate automatically while mission,
+the union of a 25 cm margin around each painted mark, with a 10 mm guard band
+for boundary selection. The same explicit 10 mm comparison tolerance lets
+changes elsewhere on the floor and sub-centimeter boundary jitter revalidate
+automatically while mission,
 partition, and nearby-geometry changes still fail closed. An exactly current
 legacy v1 or hash-only v2 binding upgrades to the v3 scoped signature safely at
 integration startup, so an area does not need to be repainted just to migrate.

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -103,8 +103,9 @@ name. The saved record also binds it to the exact coverage mission, standard
 partition, and canonical room geometry it was drawn on. A legacy unbound area,
 remap, floor change, or geometry mismatch is blocked before any robot command.
 Newly confirmed areas also retain a private signature of mapped geometry only
-within a 25 cm margin of their painted marks. Changes elsewhere on the floor
-and sub-centimeter boundary jitter revalidate automatically while mission,
+within a 25 cm margin of their painted marks. An explicit 10 mm comparison
+tolerance lets changes elsewhere on the floor and sub-centimeter boundary
+jitter revalidate automatically while mission,
 partition, and nearby-geometry changes still fail closed. An exactly current
 legacy binding upgrades to this scoped signature safely at
 integration startup, so an area does not need to be repainted just to migrate.

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -102,12 +102,12 @@ Home Assistant stores the geometry locally and the action accepts only its
 name. The saved record also binds it to the exact coverage mission, standard
 partition, and canonical room geometry it was drawn on. A legacy unbound area,
 remap, floor change, or geometry mismatch is blocked before any robot command.
-Newly confirmed areas also retain a private signature of mapped geometry only
-within a 25 cm margin of their painted marks. An explicit 10 mm comparison
-tolerance lets changes elsewhere on the floor and sub-centimeter boundary
-jitter revalidate automatically while mission,
+Newly confirmed areas also retain a private signature of mapped geometry in
+the union of a 25 cm margin around each painted mark. An explicit 10 mm
+comparison tolerance lets changes elsewhere on the floor and sub-centimeter
+boundary jitter revalidate automatically while mission,
 partition, and nearby-geometry changes still fail closed. An exactly current
-legacy binding upgrades to this scoped signature safely at
+legacy v1 or hash-only v2 binding upgrades to the v3 scoped signature safely at
 integration startup, so an area does not need to be repainted just to migrate.
 Home Assistant raises
 one privacy-safe Repair with only the number of affected areas and directs an

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -104,8 +104,9 @@ partition, and canonical room geometry it was drawn on. A legacy unbound area,
 remap, floor change, or geometry mismatch is blocked before any robot command.
 Newly confirmed areas also retain a private signature of mapped geometry in
 the union of a 25 cm margin around each painted mark, with a 10 mm guard band
-for boundary selection. The same explicit 10 mm comparison tolerance lets
-changes elsewhere on the floor and sub-centimeter boundary jitter revalidate
+for source-boundary selection. Supporting wall geometry is compared inside
+those local neighborhoods with the same explicit 10 mm tolerance, so changes
+elsewhere on the floor and sub-centimeter boundary jitter revalidate
 automatically while mission,
 partition, and nearby-geometry changes still fail closed. An exactly current
 legacy v1 or hash-only v2 binding upgrades to the v3 scoped signature safely at

--- a/docs/release-notes-0.3.3.md
+++ b/docs/release-notes-0.3.3.md
@@ -32,7 +32,7 @@ Home Assistant.
 
 ## Verification
 
-The release candidate passes 889 Python tests / 8,344 statements at 100%
+The release candidate passes 890 Python tests / 8,343 statements at 100%
 coverage, 42 Chromium browser tests, three iPhone WebKit interaction tests,
 strict typing, lint and format checks, and the public-tree privacy gate.
 

--- a/docs/release-notes-0.3.3.md
+++ b/docs/release-notes-0.3.3.md
@@ -32,7 +32,7 @@ Home Assistant.
 
 ## Verification
 
-The release candidate passes 907 Python tests / 8,507 statements at 100%
+The release candidate passes 908 Python tests / 8,508 statements at 100%
 coverage, 42 Chromium browser tests, three iPhone WebKit interaction tests,
 strict typing, lint and format checks, and the public-tree privacy gate.
 

--- a/docs/release-notes-0.3.3.md
+++ b/docs/release-notes-0.3.3.md
@@ -29,7 +29,7 @@ Home Assistant.
 
 ## Verification
 
-The release candidate passes 875 Python tests / 8,137 statements at 100%
+The release candidate passes 878 Python tests / 8,200 statements at 100%
 coverage, 42 Chromium browser tests, three iPhone WebKit interaction tests,
 strict typing, lint and format checks, and the public-tree privacy gate.
 

--- a/docs/release-notes-0.3.3.md
+++ b/docs/release-notes-0.3.3.md
@@ -32,7 +32,7 @@ Home Assistant.
 
 ## Verification
 
-The release candidate passes 910 Python tests / 8,527 statements at 100%
+The release candidate passes 912 Python tests / 8,538 statements at 100%
 coverage, 42 Chromium browser tests, three iPhone WebKit interaction tests,
 strict typing, lint and format checks, and the public-tree privacy gate.
 

--- a/docs/release-notes-0.3.3.md
+++ b/docs/release-notes-0.3.3.md
@@ -32,7 +32,7 @@ Home Assistant.
 
 ## Verification
 
-The release candidate passes 897 Python tests / 8,412 statements at 100%
+The release candidate passes 900 Python tests / 8,434 statements at 100%
 coverage, 42 Chromium browser tests, three iPhone WebKit interaction tests,
 strict typing, lint and format checks, and the public-tree privacy gate.
 

--- a/docs/release-notes-0.3.3.md
+++ b/docs/release-notes-0.3.3.md
@@ -30,7 +30,7 @@ Home Assistant.
 
 ## Verification
 
-The release candidate passes 881 Python tests / 8,257 statements at 100%
+The release candidate passes 882 Python tests / 8,257 statements at 100%
 coverage, 42 Chromium browser tests, three iPhone WebKit interaction tests,
 strict typing, lint and format checks, and the public-tree privacy gate.
 

--- a/docs/release-notes-0.3.3.md
+++ b/docs/release-notes-0.3.3.md
@@ -12,7 +12,9 @@ the floor—even between separated marks—to revalidate automatically.
 ## Safer map revalidation
 
 - Unrelated room-boundary changes and sub-centimeter decoder jitter no longer
-  invalidate every custom area on the floor.
+  invalidate every custom area on the floor; a 10 mm selection guard band also
+  prevents jitter at the edge of the local geometry margin from changing the
+  evidence set prematurely.
 - Coverage mission, partition and nearby geometry changes still fail closed
   before any robot command is sent.
 - A same-mission area with valid saved coordinates can be reviewed and rebound
@@ -30,7 +32,7 @@ Home Assistant.
 
 ## Verification
 
-The release candidate passes 882 Python tests / 8,257 statements at 100%
+The release candidate passes 883 Python tests / 8,258 statements at 100%
 coverage, 42 Chromium browser tests, three iPhone WebKit interaction tests,
 strict typing, lint and format checks, and the public-tree privacy gate.
 

--- a/docs/release-notes-0.3.3.md
+++ b/docs/release-notes-0.3.3.md
@@ -30,7 +30,7 @@ Home Assistant.
 
 ## Verification
 
-The release candidate passes 880 Python tests / 8,249 statements at 100%
+The release candidate passes 881 Python tests / 8,257 statements at 100%
 coverage, 42 Chromium browser tests, three iPhone WebKit interaction tests,
 strict typing, lint and format checks, and the public-tree privacy gate.
 

--- a/docs/release-notes-0.3.3.md
+++ b/docs/release-notes-0.3.3.md
@@ -32,7 +32,7 @@ Home Assistant.
 
 ## Verification
 
-The release candidate passes 883 Python tests / 8,258 statements at 100%
+The release candidate passes 884 Python tests / 8,309 statements at 100%
 coverage, 42 Chromium browser tests, three iPhone WebKit interaction tests,
 strict typing, lint and format checks, and the public-tree privacy gate.
 

--- a/docs/release-notes-0.3.3.md
+++ b/docs/release-notes-0.3.3.md
@@ -32,7 +32,7 @@ Home Assistant.
 
 ## Verification
 
-The release candidate passes 892 Python tests / 8,366 statements at 100%
+The release candidate passes 896 Python tests / 8,408 statements at 100%
 coverage, 42 Chromium browser tests, three iPhone WebKit interaction tests,
 strict typing, lint and format checks, and the public-tree privacy gate.
 

--- a/docs/release-notes-0.3.3.md
+++ b/docs/release-notes-0.3.3.md
@@ -32,7 +32,7 @@ Home Assistant.
 
 ## Verification
 
-The release candidate passes 905 Python tests / 8,485 statements at 100%
+The release candidate passes 905 Python tests / 8,487 statements at 100%
 coverage, 42 Chromium browser tests, three iPhone WebKit interaction tests,
 strict typing, lint and format checks, and the public-tree privacy gate.
 

--- a/docs/release-notes-0.3.3.md
+++ b/docs/release-notes-0.3.3.md
@@ -32,7 +32,7 @@ Home Assistant.
 
 ## Verification
 
-The release candidate passes 891 Python tests / 8,345 statements at 100%
+The release candidate passes 892 Python tests / 8,366 statements at 100%
 coverage, 42 Chromium browser tests, three iPhone WebKit interaction tests,
 strict typing, lint and format checks, and the public-tree privacy gate.
 

--- a/docs/release-notes-0.3.3.md
+++ b/docs/release-notes-0.3.3.md
@@ -32,7 +32,7 @@ Home Assistant.
 
 ## Verification
 
-The release candidate passes 896 Python tests / 8,408 statements at 100%
+The release candidate passes 897 Python tests / 8,407 statements at 100%
 coverage, 42 Chromium browser tests, three iPhone WebKit interaction tests,
 strict typing, lint and format checks, and the public-tree privacy gate.
 

--- a/docs/release-notes-0.3.3.md
+++ b/docs/release-notes-0.3.3.md
@@ -32,7 +32,7 @@ Home Assistant.
 
 ## Verification
 
-The release candidate passes 909 Python tests / 8,507 statements at 100%
+The release candidate passes 910 Python tests / 8,527 statements at 100%
 coverage, 42 Chromium browser tests, three iPhone WebKit interaction tests,
 strict typing, lint and format checks, and the public-tree privacy gate.
 

--- a/docs/release-notes-0.3.3.md
+++ b/docs/release-notes-0.3.3.md
@@ -32,7 +32,7 @@ Home Assistant.
 
 ## Verification
 
-The release candidate passes 905 Python tests / 8,487 statements at 100%
+The release candidate passes 906 Python tests / 8,491 statements at 100%
 coverage, 42 Chromium browser tests, three iPhone WebKit interaction tests,
 strict typing, lint and format checks, and the public-tree privacy gate.
 

--- a/docs/release-notes-0.3.3.md
+++ b/docs/release-notes-0.3.3.md
@@ -32,7 +32,7 @@ Home Assistant.
 
 ## Verification
 
-The release candidate passes 884 Python tests / 8,309 statements at 100%
+The release candidate passes 889 Python tests / 8,344 statements at 100%
 coverage, 42 Chromium browser tests, three iPhone WebKit interaction tests,
 strict typing, lint and format checks, and the public-tree privacy gate.
 

--- a/docs/release-notes-0.3.3.md
+++ b/docs/release-notes-0.3.3.md
@@ -32,7 +32,7 @@ Home Assistant.
 
 ## Verification
 
-The release candidate passes 908 Python tests / 8,508 statements at 100%
+The release candidate passes 909 Python tests / 8,507 statements at 100%
 coverage, 42 Chromium browser tests, three iPhone WebKit interaction tests,
 strict typing, lint and format checks, and the public-tree privacy gate.
 

--- a/docs/release-notes-0.3.3.md
+++ b/docs/release-notes-0.3.3.md
@@ -32,7 +32,7 @@ Home Assistant.
 
 ## Verification
 
-The release candidate passes 906 Python tests / 8,491 statements at 100%
+The release candidate passes 907 Python tests / 8,507 statements at 100%
 coverage, 42 Chromium browser tests, three iPhone WebKit interaction tests,
 strict typing, lint and format checks, and the public-tree privacy gate.
 

--- a/docs/release-notes-0.3.3.md
+++ b/docs/release-notes-0.3.3.md
@@ -5,9 +5,9 @@ Released: 2026-08-07
 ## Summary
 
 0.3.3 makes saved custom cleaning areas resilient to unrelated map redraws.
-Each newly confirmed area records a private signature of only the mapped
-geometry near its painted marks, allowing harmless changes elsewhere on the
-floor to revalidate automatically.
+Each newly confirmed area records a private signature of only the union of
+mapped geometry near its painted marks, allowing harmless changes elsewhere on
+the floor—even between separated marks—to revalidate automatically.
 
 ## Safer map revalidation
 
@@ -19,8 +19,9 @@ floor to revalidate automatically.
   with **Confirm on current map** without repainting it.
 - Areas whose coordinates are invalid or outside the current floor still
   require a redraw; the integration never guesses a coordinate transform.
-- An exactly current legacy area binding upgrades automatically at integration
-  startup, preserving areas that were already cleared before this update.
+- An exactly current legacy v1 or hash-only v2 area binding upgrades during
+  integration startup or as soon as a temporarily unavailable map returns,
+  preserving areas that were already cleared before this update.
 - The Repair now directs administrators to the Custom areas workspace and
   reports only the affected count, never saved geometry.
 
@@ -29,7 +30,7 @@ Home Assistant.
 
 ## Verification
 
-The release candidate passes 878 Python tests / 8,200 statements at 100%
+The release candidate passes 880 Python tests / 8,249 statements at 100%
 coverage, 42 Chromium browser tests, three iPhone WebKit interaction tests,
 strict typing, lint and format checks, and the public-tree privacy gate.
 

--- a/docs/release-notes-0.3.3.md
+++ b/docs/release-notes-0.3.3.md
@@ -32,7 +32,7 @@ Home Assistant.
 
 ## Verification
 
-The release candidate passes 897 Python tests / 8,407 statements at 100%
+The release candidate passes 897 Python tests / 8,412 statements at 100%
 coverage, 42 Chromium browser tests, three iPhone WebKit interaction tests,
 strict typing, lint and format checks, and the public-tree privacy gate.
 

--- a/docs/release-notes-0.3.3.md
+++ b/docs/release-notes-0.3.3.md
@@ -32,7 +32,7 @@ Home Assistant.
 
 ## Verification
 
-The release candidate passes 904 Python tests / 8,476 statements at 100%
+The release candidate passes 905 Python tests / 8,485 statements at 100%
 coverage, 42 Chromium browser tests, three iPhone WebKit interaction tests,
 strict typing, lint and format checks, and the public-tree privacy gate.
 

--- a/docs/release-notes-0.3.3.md
+++ b/docs/release-notes-0.3.3.md
@@ -32,7 +32,7 @@ Home Assistant.
 
 ## Verification
 
-The release candidate passes 900 Python tests / 8,434 statements at 100%
+The release candidate passes 904 Python tests / 8,476 statements at 100%
 coverage, 42 Chromium browser tests, three iPhone WebKit interaction tests,
 strict typing, lint and format checks, and the public-tree privacy gate.
 

--- a/docs/release-notes-0.3.3.md
+++ b/docs/release-notes-0.3.3.md
@@ -32,7 +32,7 @@ Home Assistant.
 
 ## Verification
 
-The release candidate passes 890 Python tests / 8,343 statements at 100%
+The release candidate passes 891 Python tests / 8,345 statements at 100%
 coverage, 42 Chromium browser tests, three iPhone WebKit interaction tests,
 strict typing, lint and format checks, and the public-tree privacy gate.
 

--- a/tests/test_area_binding.py
+++ b/tests/test_area_binding.py
@@ -242,13 +242,19 @@ def test_scoped_binding_contains_private_local_geometry_signature() -> None:
         {"x": 0.7, "y": 0.5, "radius": 0.15},
     ]
 
-    assert binding_for_area(floor_plan, circles) == {
+    binding = binding_for_area(floor_plan, circles)
+    assert binding == {
         "version": SCOPED_MAP_BINDING_VERSION,
         "mission_id": 42,
         "partition_id": "synthetic-partition",
         "geometry_sha256": floor_plan_geometry_fingerprint(floor_plan),
+        "area_shape_sha256": binding["area_shape_sha256"],
         "local_geometry_sha256": area_geometry_fingerprint(floor_plan, circles),
+        "local_occupancy": [511, 511],
+        "local_segments_mm": [],
     }
+    assert len(binding["area_shape_sha256"]) == 64
+    assert binding_for_area(floor_plan, list(reversed(circles))) == binding
     assert area_geometry_fingerprint(floor_plan, circles) == (
         area_geometry_fingerprint(floor_plan, list(reversed(circles)))
     )
@@ -279,7 +285,17 @@ def test_scoped_binding_automatically_accepts_unrelated_geometry_changes() -> No
 
 
 def test_scoped_binding_tolerates_local_subcentimeter_jitter() -> None:
-    floor_plan = _floor_plan()
+    original = _floor_plan()
+    floor_plan = replace(
+        original,
+        rooms=(
+            replace(
+                original.rooms[0],
+                boundary=((0.004, 0.0), *original.rooms[0].boundary[1:]),
+            ),
+            original.rooms[1],
+        ),
+    )
     circles = [{"x": 0.1, "y": 0.5, "radius": 0.05}]
     area = _scoped_area(floor_plan, circles)
     kitchen, study = floor_plan.rooms
@@ -288,7 +304,7 @@ def test_scoped_binding_tolerates_local_subcentimeter_jitter() -> None:
         rooms=(
             replace(
                 kitchen,
-                boundary=((0.004, 0.0), *kitchen.boundary[1:]),
+                boundary=((0.006, 0.0), *kitchen.boundary[1:]),
             ),
             study,
         ),
@@ -298,6 +314,72 @@ def test_scoped_binding_tolerates_local_subcentimeter_jitter() -> None:
         floor_plan_geometry_fingerprint(floor_plan)
     )
     assert area_binding_status(area, jittered) is AreaBindingStatus.CURRENT
+
+
+def test_scoped_binding_rejects_tampered_tolerance_evidence() -> None:
+    floor_plan = _floor_plan()
+    circles = [{"x": 0.1, "y": 0.5, "radius": 0.05}]
+    area = _scoped_area(floor_plan, circles)
+    binding = dict(area["map_binding"])
+    segments = [list(segment) for segment in binding["local_segments_mm"]]
+    assert segments
+    segments[0][0] += 1
+    binding["local_segments_mm"] = segments
+
+    assert (
+        area_binding_status({**area, "map_binding": binding}, floor_plan)
+        is AreaBindingStatus.INVALID
+    )
+
+
+def test_scoped_binding_rejects_self_consistent_wrong_local_evidence() -> None:
+    floor_plan = _floor_plan()
+    circles = [{"x": 0.1, "y": 0.5, "radius": 0.05}]
+    changed_floor = replace(
+        floor_plan,
+        rooms=(
+            replace(
+                floor_plan.rooms[0],
+                boundary=((0.05, 0.0), *floor_plan.rooms[0].boundary[1:]),
+            ),
+            floor_plan.rooms[1],
+        ),
+    )
+    wrong_binding = binding_for_area(changed_floor, circles)
+    wrong_binding["geometry_sha256"] = floor_plan_geometry_fingerprint(floor_plan)
+
+    assert (
+        area_binding_status(
+            {
+                "schema_version": AREA_SCHEMA_VERSION,
+                "circles": circles,
+                "map_binding": wrong_binding,
+            },
+            floor_plan,
+        )
+        is AreaBindingStatus.INVALID
+    )
+
+
+def test_scoped_binding_blocks_a_new_local_boundary() -> None:
+    floor_plan = _floor_plan()
+    circles = [{"x": 0.5, "y": 0.5, "radius": 0.1}]
+    area = _scoped_area(floor_plan, circles)
+    added_boundary = replace(
+        floor_plan,
+        rooms=(
+            *floor_plan.rooms,
+            _room(
+                "overlap",
+                "Overlap",
+                ((0.4, 0.4), (0.6, 0.4), (0.6, 0.6), (0.4, 0.6)),
+            ),
+        ),
+    )
+
+    assert (
+        area_binding_status(area, added_boundary) is AreaBindingStatus.GEOMETRY_CHANGED
+    )
 
 
 def test_scoped_binding_blocks_nearby_geometry_and_circle_changes() -> None:

--- a/tests/test_area_binding.py
+++ b/tests/test_area_binding.py
@@ -719,6 +719,44 @@ def test_scoped_binding_uses_expanded_guard_during_wall_comparison() -> None:
     assert area_binding_status(area, jittered) is AreaBindingStatus.CURRENT
 
 
+def test_scoped_binding_tolerates_saved_center_near_moved_boundary() -> None:
+    floor_plan = FloorPlan(
+        42,
+        "synthetic-partition",
+        b"synthetic-partition",
+        (
+            _room(
+                "boundary-center",
+                "Boundary Center",
+                ((0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)),
+            ),
+        ),
+    )
+    circles = [{"x": 1.0, "y": 0.5, "radius": 0.1}]
+    area = _scoped_area(floor_plan, circles)
+    jittered = replace(
+        floor_plan,
+        rooms=(
+            replace(
+                floor_plan.rooms[0],
+                boundary=((0.0, 0.0), (0.998, 0.0), (0.998, 1.0), (0.0, 1.0)),
+            ),
+        ),
+    )
+    moved = replace(
+        floor_plan,
+        rooms=(
+            replace(
+                floor_plan.rooms[0],
+                boundary=((0.0, 0.0), (0.98, 0.0), (0.98, 1.0), (0.0, 1.0)),
+            ),
+        ),
+    )
+
+    assert area_binding_status(area, jittered) is AreaBindingStatus.CURRENT
+    assert area_binding_status(area, moved) is AreaBindingStatus.INVALID
+
+
 def test_scoped_binding_ignores_jitter_at_guard_band_cutoff() -> None:
     floor_plan = _floor_plan()
     kitchen, study = floor_plan.rooms

--- a/tests/test_area_binding.py
+++ b/tests/test_area_binding.py
@@ -15,6 +15,7 @@ from custom_components.matic_robot.area_binding import (
     SCOPED_MAP_BINDING_VERSION,
     AreaBindingStatus,
     _hash_only_area_geometry_fingerprint,
+    _local_segment_correspondence,
     _local_segment_geometries_match,
     _local_segments_match,
     _occupancy_changes_are_explained,
@@ -751,6 +752,22 @@ def test_occupancy_explanation_indexes_overlapping_neighborhoods() -> None:
         )
 
     assert explains.call_count < len(saved) * len(current) // 8
+
+
+def test_occupancy_explanation_uses_one_to_one_wall_correspondence() -> None:
+    shape = ((0, 0, 100),)
+    circles = ({"x": 0.0, "y": 0.0, "radius": 0.1},)
+    segments = ((345, -100, 345, 100), (355, -100, 355, 100))
+
+    assert _local_segment_correspondence(segments, segments, shape) == ((0, 0),)
+    assert not _occupancy_changes_are_explained(
+        (0,),
+        (4,),
+        segments,
+        segments,
+        shape,
+        circles,
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_area_binding.py
+++ b/tests/test_area_binding.py
@@ -662,6 +662,22 @@ def test_local_segment_matching_restricts_spatial_candidates() -> None:
     assert matches.call_count == len(segments)
 
 
+def test_local_segment_matching_indexes_overlapping_neighborhoods() -> None:
+    shape = ((0, 0, 2500),) * 512
+    segments = tuple(
+        (center_x, -100, center_x, 100) for center_x in range(-2550, 2551, 20)
+    )
+
+    with patch.object(
+        area_binding_module,
+        "_local_segment_contexts_match",
+        wraps=area_binding_module._local_segment_contexts_match,
+    ) as matches:
+        assert _local_segments_match(segments, segments, shape)
+
+    assert matches.call_count < len(segments) ** 2 // 8
+
+
 @pytest.mark.parametrize(
     ("saved", "current", "shape", "expected"),
     [
@@ -674,6 +690,13 @@ def test_local_segment_matching_restricts_spatial_candidates() -> None:
         ((0, 0, 100, 0), (1000, 0, 1100, 0), ((50, 0, 0),), False),
         ((0, 0, 100, 0), (0, 1, 100, 1), ((1000, 1000, 0),), False),
         ((0, 0, 0, 0), (1, 1, 1, 1), ((0, 0, 0),), True),
+        (
+            (-997, -88, 996, 87),
+            (-998, -78, 995, 97),
+            ((0, 0, 2000),),
+            True,
+        ),
+        ((-1, 0, 100, 0), (10, 0, 111, 0), ((50, 0, 0),), True),
     ],
 )
 def test_local_segment_geometry_matching_edge_cases(

--- a/tests/test_area_binding.py
+++ b/tests/test_area_binding.py
@@ -532,6 +532,14 @@ def test_wall_pair_probe_explanation_rejects_incompatible_and_degenerate() -> No
     assert not _wall_pair_explains_probe(
         horizontal,
         _segment_context(horizontal, shape),
+        horizontal,
+        _segment_context(horizontal, shape),
+        (1000.0, 1000.0),
+        shape,
+    )
+    assert not _wall_pair_explains_probe(
+        horizontal,
+        _segment_context(horizontal, shape),
         vertical,
         _segment_context(vertical, shape),
         (0.0, 0.0),
@@ -857,6 +865,39 @@ def test_occupancy_explanation_indexes_overlapping_neighborhoods() -> None:
         )
 
     assert explains.call_count < len(saved) * len(current) // 8
+
+
+def test_occupancy_explanation_indexes_correspondence_by_probe() -> None:
+    shape = tuple((index * 1000, 0, 100) for index in range(512))
+    circles = tuple(
+        {"x": center_x / 1000, "y": 0.0, "radius": 0.1}
+        for center_x, _center_y, _radius in shape
+    )
+    saved = tuple(
+        (center_x, -350, center_x, 350) for center_x, _center_y, _radius in shape
+    )
+    current = tuple(
+        (center_x + 1, -350, center_x + 1, 350)
+        for center_x, _center_y, _radius in shape
+    )
+    matches = tuple((index, index) for index in range(len(shape)))
+
+    with patch.object(
+        area_binding_module,
+        "_wall_pair_explains_probe",
+        wraps=area_binding_module._wall_pair_explains_probe,
+    ) as explains:
+        assert _occupancy_changes_are_explained(
+            (0,) * len(shape),
+            (1,) * len(shape),
+            saved,
+            current,
+            shape,
+            circles,
+            matches,
+        )
+
+    assert explains.call_count <= len(shape) * 3
 
 
 def test_occupancy_explanation_uses_one_to_one_wall_correspondence() -> None:

--- a/tests/test_area_binding.py
+++ b/tests/test_area_binding.py
@@ -716,6 +716,30 @@ def test_local_segment_matching_indexes_overlapping_neighborhoods() -> None:
     assert matches.call_count < len(segments) ** 2 // 8
 
 
+def test_occupancy_explanation_indexes_overlapping_neighborhoods() -> None:
+    shape = ((0, 0, 2500),) * 512
+    circles = ({"x": 0.0, "y": 0.0, "radius": 2.5},) * len(shape)
+    saved = tuple((center, -2500, center, 2500) for center in range(-2550, 2551, 20))
+    current = tuple((-2500, center, 2500, center) for center in range(-2550, 2551, 20))
+
+    with patch.object(
+        area_binding_module,
+        "_wall_pair_explains_probe",
+        wraps=area_binding_module._wall_pair_explains_probe,
+    ) as explains:
+        assert not _occupancy_changes_are_explained(
+            (0,) * len(shape),
+            (1, *(0 for _ in shape[1:])),
+            saved,
+            current,
+            shape,
+            circles,
+            False,
+        )
+
+    assert explains.call_count < len(saved) * len(current) // 8
+
+
 @pytest.mark.parametrize(
     ("saved", "current", "shape", "expected"),
     [

--- a/tests/test_area_binding.py
+++ b/tests/test_area_binding.py
@@ -19,6 +19,8 @@ from custom_components.matic_robot.area_binding import (
     _local_segments_match,
     _occupancy_changes_are_explained,
     _point_near_segment,
+    _segment_context,
+    _wall_pair_explains_probe,
     area_binding_allows_review,
     area_binding_status,
     area_geometry_fingerprint,
@@ -450,11 +452,19 @@ def test_scoped_binding_tolerates_probe_occupancy_flip_at_jittered_wall() -> Non
     assert area_binding_status(area, jittered) is AreaBindingStatus.CURRENT
 
 
-def test_scoped_binding_rejects_unexplained_probe_occupancy_change() -> None:
+@pytest.mark.parametrize("narrow_half_width", [0.05, 0.34])
+def test_scoped_binding_rejects_unexplained_probe_occupancy_change(
+    narrow_half_width: float,
+) -> None:
     narrow = _room(
         "narrow",
         "Narrow",
-        ((-0.05, -0.05), (0.05, -0.05), (0.05, 0.05), (-0.05, 0.05)),
+        (
+            (-narrow_half_width, -narrow_half_width),
+            (narrow_half_width, -narrow_half_width),
+            (narrow_half_width, narrow_half_width),
+            (-narrow_half_width, narrow_half_width),
+        ),
     )
     enclosing = _room(
         "enclosing",
@@ -488,6 +498,7 @@ def test_occupancy_explanation_rejects_malformed_evidence() -> None:
         (),
         ((0, 0, 100),),
         ({"x": 0.0, "y": 0.0, "radius": 0.1},),
+        False,
     )
 
 
@@ -505,11 +516,38 @@ def test_occupancy_explanation_skips_unchanged_neighborhoods() -> None:
             {"x": 0.0, "y": 0.0, "radius": 0.1},
             {"x": 1.0, "y": 0.0, "radius": 0.1},
         ),
+        True,
     )
 
 
 def test_point_near_degenerate_segment() -> None:
     assert _point_near_segment((1.0, 1.0), (0, 0, 0, 0))
+
+
+def test_wall_pair_probe_explanation_rejects_incompatible_and_degenerate() -> None:
+    shape = ((0, 0, 100),)
+    horizontal = (0, 0, 100, 0)
+    vertical = (0, 0, 0, 100)
+    degenerate = (0, 0, 0, 0)
+
+    assert not _wall_pair_explains_probe(
+        horizontal,
+        _segment_context(horizontal, shape),
+        vertical,
+        _segment_context(vertical, shape),
+        (0.0, 0.0),
+        shape,
+        False,
+    )
+    assert not _wall_pair_explains_probe(
+        degenerate,
+        _segment_context(degenerate, shape),
+        (1, 1, 1, 1),
+        _segment_context((1, 1, 1, 1), shape),
+        (0.0, 0.0),
+        shape,
+        False,
+    )
 
 
 def test_scoped_binding_tolerates_probe_flip_with_unchanged_map_hash() -> None:

--- a/tests/test_area_binding.py
+++ b/tests/test_area_binding.py
@@ -593,6 +593,48 @@ def test_scoped_binding_tolerates_diagonal_clipping_amplification() -> None:
     assert area_binding_status(area, jittered) is AreaBindingStatus.CURRENT
 
 
+def test_scoped_binding_preserves_tolerant_shared_wall_multiplicity() -> None:
+    floor_plan = FloorPlan(
+        42,
+        "synthetic-partition",
+        b"synthetic-partition",
+        (
+            _room(
+                "left",
+                "Left",
+                ((0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)),
+            ),
+            _room(
+                "right",
+                "Right",
+                ((1.0, 0.0), (2.0, 0.0), (2.0, 1.0), (1.0, 1.0)),
+            ),
+        ),
+    )
+    circles = [{"x": 1.0, "y": 0.5, "radius": 0.1}]
+    area = _scoped_area(floor_plan, circles)
+    jittered = replace(
+        floor_plan,
+        rooms=(
+            floor_plan.rooms[0],
+            replace(
+                floor_plan.rooms[1],
+                boundary=(
+                    (1.002, 0.0),
+                    *floor_plan.rooms[1].boundary[1:-1],
+                    (1.002, 1.0),
+                ),
+            ),
+        ),
+    )
+
+    assert area["map_binding"]["local_segments_mm"] == [
+        [1000, 0, 1000, 1000],
+        [1000, 0, 1000, 1000],
+    ]
+    assert area_binding_status(area, jittered) is AreaBindingStatus.CURRENT
+
+
 def test_scoped_binding_rejects_tampered_tolerance_evidence() -> None:
     floor_plan = _floor_plan()
     circles = [{"x": 0.1, "y": 0.5, "radius": 0.05}]

--- a/tests/test_area_binding.py
+++ b/tests/test_area_binding.py
@@ -612,6 +612,34 @@ def test_scoped_binding_tolerates_quantized_probe_flip_with_distant_change() -> 
     assert area_binding_status(area, jittered) is AreaBindingStatus.CURRENT
 
 
+def test_scoped_binding_preserves_raw_semantic_bounds_after_quantization() -> None:
+    nearby = _room(
+        "nearby",
+        "Nearby",
+        ((0.0, -1.0), (0.15049, -1.0), (0.15049, 1.0), (0.0, 1.0)),
+    )
+    enclosing = _room(
+        "enclosing",
+        "Enclosing",
+        ((-2.0, -2.0), (2.0, -2.0), (2.0, 2.0), (-2.0, 2.0)),
+    )
+    floor_plan = FloorPlan(
+        42,
+        "synthetic-partition",
+        b"synthetic-partition",
+        (nearby, enclosing),
+    )
+    circles = [{"x": 0.50051, "y": 0.0, "radius": 0.10049}]
+    area = _scoped_area(floor_plan, circles)
+    changed = replace(floor_plan, rooms=(enclosing,))
+
+    current_binding = binding_for_area(changed, circles)
+    assert area["map_binding"]["local_segments_mm"]
+    assert current_binding["local_segments_mm"] == []
+    assert area["map_binding"]["local_occupancy"] == current_binding["local_occupancy"]
+    assert area_binding_status(area, changed) is AreaBindingStatus.GEOMETRY_CHANGED
+
+
 def test_scoped_binding_preserves_fractional_probe_tolerance() -> None:
     circle = {"x": 0.963543, "y": 0.0, "radius": 1.533657}
     saved_wall = 2.737451

--- a/tests/test_area_binding.py
+++ b/tests/test_area_binding.py
@@ -635,6 +635,46 @@ def test_scoped_binding_preserves_tolerant_shared_wall_multiplicity() -> None:
     assert area_binding_status(area, jittered) is AreaBindingStatus.CURRENT
 
 
+def test_scoped_binding_ignores_overlapping_circle_guard_cutoff() -> None:
+    floor_plan = _floor_plan()
+    kitchen, study = floor_plan.rooms
+    floor_plan = replace(
+        floor_plan,
+        rooms=(
+            replace(
+                kitchen,
+                boundary=(
+                    (0.139, 0.0),
+                    *kitchen.boundary[1:-1],
+                    (0.139, 1.5),
+                ),
+            ),
+            study,
+        ),
+    )
+    circles = [
+        {"x": 0.45, "y": 0.5, "radius": 0.1},
+        {"x": 0.5, "y": 0.5, "radius": 0.1},
+    ]
+    area = _scoped_area(floor_plan, circles)
+    jittered = replace(
+        floor_plan,
+        rooms=(
+            replace(
+                floor_plan.rooms[0],
+                boundary=(
+                    (0.141, 0.0),
+                    *floor_plan.rooms[0].boundary[1:-1],
+                    (0.141, 1.5),
+                ),
+            ),
+            study,
+        ),
+    )
+
+    assert area_binding_status(area, jittered) is AreaBindingStatus.CURRENT
+
+
 def test_scoped_binding_rejects_tampered_tolerance_evidence() -> None:
     floor_plan = _floor_plan()
     circles = [{"x": 0.1, "y": 0.5, "radius": 0.05}]

--- a/tests/test_area_binding.py
+++ b/tests/test_area_binding.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import custom_components.matic_robot.area_binding as area_binding_module
 from custom_components.matic_robot.area_binding import (
     AREA_SCHEMA_VERSION,
     HASH_ONLY_SCOPED_MAP_BINDING_VERSION,
@@ -539,6 +540,22 @@ def test_local_segment_matching_finds_non_greedy_pairing() -> None:
     current = ((0, 1, 100, 1), (1, -10, 101, -10))
 
     assert _local_segments_match(saved, current, ((50, 0, 0),))
+
+
+def test_local_segment_matching_restricts_spatial_candidates() -> None:
+    shape = tuple((index * 1000, 0, 0) for index in range(512))
+    segments = tuple(
+        (center_x - 100, 0, center_x + 100, 0) for center_x, _center_y, _radius in shape
+    )
+
+    with patch.object(
+        area_binding_module,
+        "_local_segment_contexts_match",
+        wraps=area_binding_module._local_segment_contexts_match,
+    ) as matches:
+        assert _local_segments_match(segments, segments, shape)
+
+    assert matches.call_count == len(segments)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_area_binding.py
+++ b/tests/test_area_binding.py
@@ -481,7 +481,14 @@ def test_scoped_binding_rejects_unexplained_probe_occupancy_change() -> None:
 
 
 def test_occupancy_explanation_rejects_malformed_evidence() -> None:
-    assert not _occupancy_changes_are_explained((), (0,), (), (), ((0, 0, 100),))
+    assert not _occupancy_changes_are_explained(
+        (),
+        (0,),
+        (),
+        (),
+        ((0, 0, 100),),
+        ({"x": 0.0, "y": 0.0, "radius": 0.1},),
+    )
 
 
 def test_occupancy_explanation_skips_unchanged_neighborhoods() -> None:
@@ -489,7 +496,15 @@ def test_occupancy_explanation_skips_unchanged_neighborhoods() -> None:
     segment = (650, -500, 650, 500)
 
     assert _occupancy_changes_are_explained(
-        (0, 0), (0, 2), (segment,), (segment,), shape
+        (0, 0),
+        (0, 2),
+        (segment,),
+        (segment,),
+        shape,
+        (
+            {"x": 0.0, "y": 0.0, "radius": 0.1},
+            {"x": 1.0, "y": 0.0, "radius": 0.1},
+        ),
     )
 
 
@@ -541,6 +556,46 @@ def test_scoped_binding_tolerates_probe_flip_with_unchanged_map_hash() -> None:
     assert (
         area["map_binding"]["local_segments_mm"] == current_binding["local_segments_mm"]
     )
+    assert area_binding_status(area, jittered) is AreaBindingStatus.CURRENT
+
+
+def test_scoped_binding_preserves_fractional_probe_tolerance() -> None:
+    circle = {"x": 0.963543, "y": 0.0, "radius": 1.533657}
+    saved_wall = 2.737451
+    current_wall = 2.747381
+    floor_plan = FloorPlan(
+        42,
+        "synthetic-partition",
+        b"synthetic-partition",
+        (
+            _room(
+                "fractional",
+                "Fractional",
+                ((-2.0, -3.0), (saved_wall, -3.0), (saved_wall, 3.0), (-2.0, 3.0)),
+            ),
+        ),
+    )
+    circles = [circle]
+    area = _scoped_area(floor_plan, circles)
+    jittered = replace(
+        floor_plan,
+        rooms=(
+            replace(
+                floor_plan.rooms[0],
+                boundary=(
+                    (-2.0, -3.0),
+                    (current_wall, -3.0),
+                    (current_wall, 3.0),
+                    (-2.0, 3.0),
+                ),
+            ),
+        ),
+    )
+
+    current_binding = binding_for_area(jittered, circles)
+    assert area["map_binding"]["local_segments_mm"] == [[2737, -3000, 2737, 3000]]
+    assert current_binding["local_segments_mm"] == [[2747, -3000, 2747, 3000]]
+    assert area["map_binding"]["local_occupancy"] != current_binding["local_occupancy"]
     assert area_binding_status(area, jittered) is AreaBindingStatus.CURRENT
 
 

--- a/tests/test_area_binding.py
+++ b/tests/test_area_binding.py
@@ -420,6 +420,31 @@ def test_scoped_binding_tolerates_local_subcentimeter_jitter() -> None:
     assert area_binding_status(area, jittered) is AreaBindingStatus.CURRENT
 
 
+def test_scoped_binding_tolerates_probe_occupancy_flip_at_jittered_wall() -> None:
+    floor_plan = _floor_plan()
+    circles = [{"x": 0.35, "y": 0.5, "radius": 0.1}]
+    area = _scoped_area(floor_plan, circles)
+    kitchen, study = floor_plan.rooms
+    jittered = replace(
+        floor_plan,
+        rooms=(
+            replace(
+                kitchen,
+                boundary=(
+                    (0.002, 0.0),
+                    *kitchen.boundary[1:-1],
+                    (0.002, 1.5),
+                ),
+            ),
+            study,
+        ),
+    )
+
+    current_binding = binding_for_area(jittered, circles)
+    assert area["map_binding"]["local_occupancy"] != current_binding["local_occupancy"]
+    assert area_binding_status(area, jittered) is AreaBindingStatus.CURRENT
+
+
 def test_scoped_binding_rejects_tampered_tolerance_evidence() -> None:
     floor_plan = _floor_plan()
     circles = [{"x": 0.1, "y": 0.5, "radius": 0.05}]

--- a/tests/test_area_binding.py
+++ b/tests/test_area_binding.py
@@ -17,6 +17,8 @@ from custom_components.matic_robot.area_binding import (
     _hash_only_area_geometry_fingerprint,
     _local_segment_geometries_match,
     _local_segments_match,
+    _occupancy_changes_are_explained,
+    _point_near_segment,
     area_binding_allows_review,
     area_binding_status,
     area_geometry_fingerprint,
@@ -446,6 +448,53 @@ def test_scoped_binding_tolerates_probe_occupancy_flip_at_jittered_wall() -> Non
     current_binding = binding_for_area(jittered, circles)
     assert area["map_binding"]["local_occupancy"] != current_binding["local_occupancy"]
     assert area_binding_status(area, jittered) is AreaBindingStatus.CURRENT
+
+
+def test_scoped_binding_rejects_unexplained_probe_occupancy_change() -> None:
+    narrow = _room(
+        "narrow",
+        "Narrow",
+        ((-0.05, -0.05), (0.05, -0.05), (0.05, 0.05), (-0.05, 0.05)),
+    )
+    enclosing = _room(
+        "enclosing",
+        "Enclosing",
+        ((-1.0, -1.0), (1.0, -1.0), (1.0, 1.0), (-1.0, 1.0)),
+    )
+    floor_plan = FloorPlan(
+        42,
+        "synthetic-partition",
+        b"synthetic-partition",
+        (narrow, enclosing),
+    )
+    circles = [{"x": 0.0, "y": 0.0, "radius": 0.1}]
+    area = _scoped_area(floor_plan, circles)
+    changed = replace(floor_plan, rooms=(narrow,))
+
+    current_binding = binding_for_area(changed, circles)
+    assert (
+        area["map_binding"]["local_segments_mm"] == current_binding["local_segments_mm"]
+    )
+    assert area["map_binding"]["local_occupancy"] != current_binding["local_occupancy"]
+    assert area_binding_status(area, changed) is AreaBindingStatus.GEOMETRY_CHANGED
+    assert area_binding_allows_review(area, changed)
+
+
+def test_occupancy_explanation_rejects_malformed_evidence() -> None:
+    assert not _occupancy_changes_are_explained((), (0,), (), (), ((0, 0, 100),))
+
+
+def test_occupancy_explanation_skips_unchanged_neighborhoods() -> None:
+    shape = ((0, 0, 100), (1000, 0, 100))
+    segment = (650, -500, 650, 500)
+
+    assert _occupancy_changes_are_explained(
+        (0, 0), (0, 2), (segment,), (segment,), shape
+    )
+
+
+def test_point_near_degenerate_segment() -> None:
+    assert _point_near_segment((1.0, 1.0), (0, 0, 0, 0))
 
 
 def test_scoped_binding_tolerates_probe_flip_with_unchanged_map_hash() -> None:

--- a/tests/test_area_binding.py
+++ b/tests/test_area_binding.py
@@ -14,6 +14,7 @@ from custom_components.matic_robot.area_binding import (
     SCOPED_MAP_BINDING_VERSION,
     AreaBindingStatus,
     _hash_only_area_geometry_fingerprint,
+    _local_segments_match,
     area_binding_allows_review,
     area_binding_status,
     area_geometry_fingerprint,
@@ -492,7 +493,7 @@ def test_scoped_binding_tolerates_probe_flip_with_unchanged_map_hash() -> None:
     assert area_binding_status(area, jittered) is AreaBindingStatus.CURRENT
 
 
-def test_scoped_binding_guard_band_tolerates_segment_entering_margin() -> None:
+def test_scoped_binding_ignores_jitter_at_guard_band_cutoff() -> None:
     floor_plan = _floor_plan()
     kitchen, study = floor_plan.rooms
     floor_plan = replace(
@@ -501,9 +502,9 @@ def test_scoped_binding_guard_band_tolerates_segment_entering_margin() -> None:
             replace(
                 kitchen,
                 boundary=(
-                    (0.149, 0.0),
+                    (0.139, 0.0),
                     *kitchen.boundary[1:-1],
-                    (0.149, 1.5),
+                    (0.139, 1.5),
                 ),
             ),
             study,
@@ -517,9 +518,9 @@ def test_scoped_binding_guard_band_tolerates_segment_entering_margin() -> None:
             replace(
                 floor_plan.rooms[0],
                 boundary=(
-                    (0.151, 0.0),
+                    (0.141, 0.0),
                     *floor_plan.rooms[0].boundary[1:-1],
-                    (0.151, 1.5),
+                    (0.141, 1.5),
                 ),
             ),
             study,
@@ -527,13 +528,16 @@ def test_scoped_binding_guard_band_tolerates_segment_entering_margin() -> None:
     )
 
     current_binding = binding_for_area(jittered, circles)
-    assert len(area["map_binding"]["local_segments_mm"]) == len(
-        current_binding["local_segments_mm"]
-    )
-    assert (
-        area["map_binding"]["local_segments_mm"] != current_binding["local_segments_mm"]
-    )
+    assert area["map_binding"]["local_segments_mm"] == []
+    assert current_binding["local_segments_mm"]
     assert area_binding_status(area, jittered) is AreaBindingStatus.CURRENT
+
+
+def test_local_segment_matching_finds_non_greedy_pairing() -> None:
+    saved = ((0, 0, 100, 0), (0, 10, 100, 10))
+    current = ((0, 1, 100, 1), (1, -10, 101, -10))
+
+    assert _local_segments_match(saved, current, ((50, 0, 0),))
 
 
 def test_scoped_binding_rejects_tampered_tolerance_evidence() -> None:

--- a/tests/test_area_binding.py
+++ b/tests/test_area_binding.py
@@ -498,7 +498,6 @@ def test_occupancy_explanation_rejects_malformed_evidence() -> None:
         (),
         ((0, 0, 100),),
         ({"x": 0.0, "y": 0.0, "radius": 0.1},),
-        False,
     )
 
 
@@ -516,7 +515,6 @@ def test_occupancy_explanation_skips_unchanged_neighborhoods() -> None:
             {"x": 0.0, "y": 0.0, "radius": 0.1},
             {"x": 1.0, "y": 0.0, "radius": 0.1},
         ),
-        True,
     )
 
 
@@ -537,7 +535,6 @@ def test_wall_pair_probe_explanation_rejects_incompatible_and_degenerate() -> No
         _segment_context(vertical, shape),
         (0.0, 0.0),
         shape,
-        False,
     )
     assert not _wall_pair_explains_probe(
         degenerate,
@@ -546,11 +543,25 @@ def test_wall_pair_probe_explanation_rejects_incompatible_and_degenerate() -> No
         _segment_context((1, 1, 1, 1), shape),
         (0.0, 0.0),
         shape,
-        False,
     )
 
 
-def test_scoped_binding_tolerates_probe_flip_with_unchanged_map_hash() -> None:
+def test_wall_pair_probe_explanation_aligns_reversed_wall_directions() -> None:
+    shape = ((0, 0, 100),)
+    saved = (339, -1000, 341, 1000)
+    current = (339, 1000, 341, -1000)
+
+    assert not _wall_pair_explains_probe(
+        saved,
+        _segment_context(saved, shape),
+        current,
+        _segment_context(current, shape),
+        (350.0, 0.0),
+        shape,
+    )
+
+
+def test_scoped_binding_tolerates_quantized_probe_flip_with_distant_change() -> None:
     floor_plan = _floor_plan()
     kitchen, study = floor_plan.rooms
     floor_plan = replace(
@@ -582,12 +593,15 @@ def test_scoped_binding_tolerates_probe_flip_with_unchanged_map_hash() -> None:
                     (0.0004, 1.5),
                 ),
             ),
-            study,
+            replace(
+                study,
+                boundary=((2.0, 0.0), (3.1, 0.0), (3.1, 1.0), (2.0, 1.0)),
+            ),
         ),
     )
 
     current_binding = binding_for_area(jittered, circles)
-    assert floor_plan_geometry_fingerprint(jittered) == (
+    assert floor_plan_geometry_fingerprint(jittered) != (
         floor_plan_geometry_fingerprint(floor_plan)
     )
     assert area["map_binding"]["local_occupancy"] != current_binding["local_occupancy"]
@@ -734,7 +748,6 @@ def test_occupancy_explanation_indexes_overlapping_neighborhoods() -> None:
             current,
             shape,
             circles,
-            False,
         )
 
     assert explains.call_count < len(saved) * len(current) // 8

--- a/tests/test_area_binding.py
+++ b/tests/test_area_binding.py
@@ -445,6 +445,53 @@ def test_scoped_binding_tolerates_probe_occupancy_flip_at_jittered_wall() -> Non
     assert area_binding_status(area, jittered) is AreaBindingStatus.CURRENT
 
 
+def test_scoped_binding_tolerates_probe_flip_with_unchanged_map_hash() -> None:
+    floor_plan = _floor_plan()
+    kitchen, study = floor_plan.rooms
+    floor_plan = replace(
+        floor_plan,
+        rooms=(
+            replace(
+                kitchen,
+                boundary=(
+                    (0.0001, 0.0),
+                    *kitchen.boundary[1:-1],
+                    (0.0001, 1.5),
+                ),
+            ),
+            study,
+        ),
+    )
+    # The lower-left diagonal probe lands at x=0.00025, between both wall
+    # positions, while the wall remains inside the local segment neighborhood.
+    circles = [{"x": 0.2477373734152916, "y": 0.5, "radius": 0.1}]
+    area = _scoped_area(floor_plan, circles)
+    jittered = replace(
+        floor_plan,
+        rooms=(
+            replace(
+                floor_plan.rooms[0],
+                boundary=(
+                    (0.0004, 0.0),
+                    *floor_plan.rooms[0].boundary[1:-1],
+                    (0.0004, 1.5),
+                ),
+            ),
+            study,
+        ),
+    )
+
+    current_binding = binding_for_area(jittered, circles)
+    assert floor_plan_geometry_fingerprint(jittered) == (
+        floor_plan_geometry_fingerprint(floor_plan)
+    )
+    assert area["map_binding"]["local_occupancy"] != current_binding["local_occupancy"]
+    assert (
+        area["map_binding"]["local_segments_mm"] == current_binding["local_segments_mm"]
+    )
+    assert area_binding_status(area, jittered) is AreaBindingStatus.CURRENT
+
+
 def test_scoped_binding_rejects_tampered_tolerance_evidence() -> None:
     floor_plan = _floor_plan()
     circles = [{"x": 0.1, "y": 0.5, "radius": 0.05}]

--- a/tests/test_area_binding.py
+++ b/tests/test_area_binding.py
@@ -680,6 +680,45 @@ def test_scoped_binding_preserves_fractional_probe_tolerance() -> None:
     assert area_binding_status(area, jittered) is AreaBindingStatus.CURRENT
 
 
+def test_scoped_binding_uses_expanded_guard_during_wall_comparison() -> None:
+    saved_wall = 0.8509
+    current_wall = 0.8608
+    floor_plan = FloorPlan(
+        42,
+        "synthetic-partition",
+        b"synthetic-partition",
+        (
+            _room(
+                "fractional-guard",
+                "Fractional Guard",
+                ((0.0, -1.0), (saved_wall, -1.0), (saved_wall, 1.0), (0.0, 1.0)),
+            ),
+        ),
+    )
+    circles = [{"x": 0.50049, "y": 0.0, "radius": 0.10049}]
+    area = _scoped_area(floor_plan, circles)
+    jittered = replace(
+        floor_plan,
+        rooms=(
+            replace(
+                floor_plan.rooms[0],
+                boundary=(
+                    (0.0, -1.0),
+                    (current_wall, -1.0),
+                    (current_wall, 1.0),
+                    (0.0, 1.0),
+                ),
+            ),
+        ),
+    )
+
+    current_binding = binding_for_area(jittered, circles)
+    assert [851, -1000, 851, 1000] in area["map_binding"]["local_segments_mm"]
+    assert [861, -1000, 861, 1000] in current_binding["local_segments_mm"]
+    assert area["map_binding"]["local_occupancy"] != current_binding["local_occupancy"]
+    assert area_binding_status(area, jittered) is AreaBindingStatus.CURRENT
+
+
 def test_scoped_binding_ignores_jitter_at_guard_band_cutoff() -> None:
     floor_plan = _floor_plan()
     kitchen, study = floor_plan.rooms

--- a/tests/test_area_binding.py
+++ b/tests/test_area_binding.py
@@ -492,6 +492,50 @@ def test_scoped_binding_tolerates_probe_flip_with_unchanged_map_hash() -> None:
     assert area_binding_status(area, jittered) is AreaBindingStatus.CURRENT
 
 
+def test_scoped_binding_guard_band_tolerates_segment_entering_margin() -> None:
+    floor_plan = _floor_plan()
+    kitchen, study = floor_plan.rooms
+    floor_plan = replace(
+        floor_plan,
+        rooms=(
+            replace(
+                kitchen,
+                boundary=(
+                    (0.149, 0.0),
+                    *kitchen.boundary[1:-1],
+                    (0.149, 1.5),
+                ),
+            ),
+            study,
+        ),
+    )
+    circles = [{"x": 0.5, "y": 0.5, "radius": 0.1}]
+    area = _scoped_area(floor_plan, circles)
+    jittered = replace(
+        floor_plan,
+        rooms=(
+            replace(
+                floor_plan.rooms[0],
+                boundary=(
+                    (0.151, 0.0),
+                    *floor_plan.rooms[0].boundary[1:-1],
+                    (0.151, 1.5),
+                ),
+            ),
+            study,
+        ),
+    )
+
+    current_binding = binding_for_area(jittered, circles)
+    assert len(area["map_binding"]["local_segments_mm"]) == len(
+        current_binding["local_segments_mm"]
+    )
+    assert (
+        area["map_binding"]["local_segments_mm"] != current_binding["local_segments_mm"]
+    )
+    assert area_binding_status(area, jittered) is AreaBindingStatus.CURRENT
+
+
 def test_scoped_binding_rejects_tampered_tolerance_evidence() -> None:
     floor_plan = _floor_plan()
     circles = [{"x": 0.1, "y": 0.5, "radius": 0.05}]

--- a/tests/test_area_binding.py
+++ b/tests/test_area_binding.py
@@ -9,9 +9,11 @@ import pytest
 
 from custom_components.matic_robot.area_binding import (
     AREA_SCHEMA_VERSION,
+    HASH_ONLY_SCOPED_MAP_BINDING_VERSION,
     MAP_BINDING_VERSION,
     SCOPED_MAP_BINDING_VERSION,
     AreaBindingStatus,
+    _hash_only_area_geometry_fingerprint,
     area_binding_allows_review,
     area_binding_status,
     area_geometry_fingerprint,
@@ -71,6 +73,25 @@ def _scoped_area(
         "schema_version": AREA_SCHEMA_VERSION,
         "circles": saved_circles,
         "map_binding": binding_for_area(plan, saved_circles),
+    }
+
+
+def _hash_only_scoped_area(
+    floor_plan: FloorPlan | None = None,
+    circles: list[dict[str, float]] | None = None,
+) -> dict[str, object]:
+    plan = floor_plan or _floor_plan()
+    saved_circles = circles or [{"x": 0.5, "y": 0.5, "radius": 0.1}]
+    return {
+        "schema_version": AREA_SCHEMA_VERSION,
+        "circles": saved_circles,
+        "map_binding": {
+            **binding_for_floor_plan(plan),
+            "version": HASH_ONLY_SCOPED_MAP_BINDING_VERSION,
+            "local_geometry_sha256": _hash_only_area_geometry_fingerprint(
+                plan, saved_circles
+            ),
+        },
     }
 
 
@@ -282,6 +303,89 @@ def test_scoped_binding_automatically_accepts_unrelated_geometry_changes() -> No
         floor_plan_geometry_fingerprint(floor_plan)
     )
     assert area_binding_status(area, changed_elsewhere) is AreaBindingStatus.CURRENT
+
+
+def test_scoped_binding_uses_union_of_separated_mark_neighborhoods() -> None:
+    floor_plan = FloorPlan(
+        42,
+        "synthetic-partition",
+        b"synthetic-partition",
+        (
+            _room(
+                "outer",
+                "Outer",
+                ((0.0, 0.0), (10.0, 0.0), (10.0, 2.0), (0.0, 2.0)),
+            ),
+            _room(
+                "middle",
+                "Middle",
+                ((4.5, 0.5), (5.5, 0.5), (5.5, 1.5), (4.5, 1.5)),
+            ),
+        ),
+    )
+    circles = [
+        {"x": 1.0, "y": 1.0, "radius": 0.1},
+        {"x": 9.0, "y": 1.0, "radius": 0.1},
+    ]
+    area = _scoped_area(floor_plan, circles)
+    changed_between_marks = replace(
+        floor_plan,
+        rooms=(
+            floor_plan.rooms[0],
+            replace(
+                floor_plan.rooms[1],
+                boundary=((4.4, 0.5), (5.6, 0.5), (5.6, 1.5), (4.4, 1.5)),
+            ),
+        ),
+    )
+
+    assert floor_plan_geometry_fingerprint(changed_between_marks) != (
+        floor_plan_geometry_fingerprint(floor_plan)
+    )
+    assert area_binding_status(area, changed_between_marks) is AreaBindingStatus.CURRENT
+
+
+def test_hash_only_v2_binding_remains_valid_for_safe_migration() -> None:
+    floor_plan = _floor_plan()
+    circles = [{"x": 0.1, "y": 0.5, "radius": 0.05}]
+    area = _hash_only_scoped_area(floor_plan, circles)
+    kitchen, study = floor_plan.rooms
+    changed_elsewhere = replace(
+        floor_plan,
+        rooms=(
+            kitchen,
+            replace(
+                study,
+                boundary=((2.1, 0.0), (3.1, 0.0), (3.1, 1.0), (2.1, 1.0)),
+            ),
+        ),
+    )
+
+    assert area_binding_status(area, floor_plan) is AreaBindingStatus.CURRENT
+    assert area_binding_status(area, changed_elsewhere) is AreaBindingStatus.CURRENT
+    invalid = {
+        **area,
+        "map_binding": {
+            **area["map_binding"],
+            "local_geometry_sha256": "0" * 64,
+        },
+    }
+    assert area_binding_status(invalid, floor_plan) is AreaBindingStatus.INVALID
+    missing_circles = {key: value for key, value in area.items() if key != "circles"}
+    assert area_binding_status(missing_circles, floor_plan) is AreaBindingStatus.INVALID
+    changed_nearby = replace(
+        floor_plan,
+        rooms=(
+            replace(
+                kitchen,
+                boundary=((0.05, 0.0), *kitchen.boundary[1:]),
+            ),
+            study,
+        ),
+    )
+    assert (
+        area_binding_status(area, changed_nearby) is AreaBindingStatus.GEOMETRY_CHANGED
+    )
 
 
 def test_scoped_binding_tolerates_local_subcentimeter_jitter() -> None:

--- a/tests/test_area_binding.py
+++ b/tests/test_area_binding.py
@@ -14,6 +14,7 @@ from custom_components.matic_robot.area_binding import (
     SCOPED_MAP_BINDING_VERSION,
     AreaBindingStatus,
     _hash_only_area_geometry_fingerprint,
+    _local_segment_geometries_match,
     _local_segments_match,
     area_binding_allows_review,
     area_binding_status,
@@ -538,6 +539,58 @@ def test_local_segment_matching_finds_non_greedy_pairing() -> None:
     current = ((0, 1, 100, 1), (1, -10, 101, -10))
 
     assert _local_segments_match(saved, current, ((50, 0, 0),))
+
+
+@pytest.mark.parametrize(
+    ("saved", "current", "shape", "expected"),
+    [
+        (
+            (0, 0, 100, 0),
+            (0, 1, 100, 1),
+            ((1000, 1000, 0), (50, 0, 0)),
+            True,
+        ),
+        ((0, 0, 100, 0), (1000, 0, 1100, 0), ((50, 0, 0),), False),
+        ((0, 0, 100, 0), (0, 1, 100, 1), ((1000, 1000, 0),), False),
+        ((0, 0, 0, 0), (1, 1, 1, 1), ((0, 0, 0),), True),
+    ],
+)
+def test_local_segment_geometry_matching_edge_cases(
+    saved: tuple[int, int, int, int],
+    current: tuple[int, int, int, int],
+    shape: tuple[tuple[int, int, int], ...],
+    expected: bool,
+) -> None:
+    assert _local_segment_geometries_match(saved, current, shape) is expected
+
+
+def test_scoped_binding_tolerates_diagonal_clipping_amplification() -> None:
+    floor_plan = FloorPlan(
+        42,
+        "synthetic-partition",
+        b"synthetic-partition",
+        (
+            _room(
+                "sloped",
+                "Sloped",
+                ((0.0, 0.136), (1.0, 0.156), (1.0, 1.5), (0.0, 1.5)),
+            ),
+        ),
+    )
+    circles = [{"x": 0.5, "y": 0.5, "radius": 0.1}]
+    area = _scoped_area(floor_plan, circles)
+    jittered = replace(
+        floor_plan,
+        rooms=(
+            replace(
+                floor_plan.rooms[0],
+                boundary=((0.0, 0.138), (1.0, 0.158), (1.0, 1.5), (0.0, 1.5)),
+            ),
+        ),
+    )
+
+    assert area["map_binding"]["local_segments_mm"] == [[0, 136, 1000, 156]]
+    assert area_binding_status(area, jittered) is AreaBindingStatus.CURRENT
 
 
 def test_scoped_binding_rejects_tampered_tolerance_evidence() -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -228,10 +228,27 @@ async def test_setup_refreshes_before_forwarding_platforms(
     with patch(
         "custom_components.matic_robot.async_sync_custom_area_issue"
     ) as listener_sync:
+        scheduled = []
+        entry.async_create_background_task.side_effect = lambda _hass, target, _name: (
+            scheduled.append(target)
+        )
+        live_floor_plan = object()
+        coordinator.data.floor_plan = live_floor_plan
         sync_callback()
+        await scheduled[0]
         plans.async_add_listener.call_args.args[1]()
 
     assert listener_sync.call_count == 2
+    assert entry.async_create_background_task.call_count == 3
+    assert plans.async_upgrade_area_bindings.await_count == 2
+    assert plans.async_upgrade_area_bindings.call_args.args == (
+        "synthetic-serial",
+        live_floor_plan,
+    )
+    assert (
+        entry.async_create_background_task.call_args.args[2]
+        == "matic_robot custom area binding upgrade"
+    )
 
 
 async def test_setup_closes_client_when_first_refresh_fails() -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -17,6 +17,7 @@ from custom_components.matic_robot import (
     async_unload_entry,
 )
 from custom_components.matic_robot.client.exceptions import CannotConnectError
+from custom_components.matic_robot.client.models import FloorPlan, Room
 from custom_components.matic_robot.const import (
     CONF_CERTIFICATE_FINGERPRINT,
     CONF_HERMES_CREDENTIAL,
@@ -154,7 +155,16 @@ async def test_setup_refreshes_before_forwarding_platforms(
     coordinator = SimpleNamespace(
         async_config_entry_first_refresh=AsyncMock(),
         async_add_listener=MagicMock(return_value=coordinator_unsubscribe),
-        data=SimpleNamespace(floor_plan=None),
+        data=SimpleNamespace(
+            floor_plan=FloorPlan(
+                42,
+                "synthetic-partition",
+                b"synthetic-partition",
+                (),
+            )
+            if native_history_error
+            else None
+        ),
     )
     slam_map = SimpleNamespace(
         async_load=AsyncMock(),
@@ -194,7 +204,10 @@ async def test_setup_refreshes_before_forwarding_platforms(
 
     decode.assert_called_once_with("test-credential")
     coordinator.async_config_entry_first_refresh.assert_awaited_once()
-    plans.async_upgrade_area_bindings.assert_awaited_once_with("synthetic-serial", None)
+    initial_floor_plan = coordinator.data.floor_plan
+    plans.async_upgrade_area_bindings.assert_awaited_once_with(
+        "synthetic-serial", initial_floor_plan
+    )
     if native_history_error:
         plans.async_import_native_history.assert_not_awaited()
     else:
@@ -223,7 +236,7 @@ async def test_setup_refreshes_before_forwarding_platforms(
         ((coordinator_unsubscribe,), {}),
         ((plan_unsubscribe,), {}),
     ]
-    sync_area_issue.assert_called_once_with(hass, "entry", {}, None)
+    sync_area_issue.assert_called_once_with(hass, "entry", {}, initial_floor_plan)
 
     with patch(
         "custom_components.matic_robot.async_sync_custom_area_issue"
@@ -232,7 +245,20 @@ async def test_setup_refreshes_before_forwarding_platforms(
         entry.async_create_background_task.side_effect = lambda _hass, target, _name: (
             scheduled.append(target)
         )
-        live_floor_plan = object()
+        live_floor_plan = FloorPlan(
+            42,
+            "synthetic-partition",
+            b"synthetic-partition",
+            (
+                Room(
+                    "room",
+                    "Room",
+                    "room",
+                    b"room",
+                    ((0.0, 0.0), (1.0, 0.0), (0.0, 1.0)),
+                ),
+            ),
+        )
         coordinator.data.floor_plan = live_floor_plan
         sync_callback()
         await scheduled[0]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -11,6 +11,7 @@ from homeassistant.components import frontend
 from homeassistant.exceptions import ConfigEntryAuthFailed
 
 from custom_components.matic_robot import (
+    _floor_plan_supports_area_binding,
     async_remove_entry,
     async_setup,
     async_setup_entry,
@@ -28,6 +29,7 @@ from custom_components.matic_robot.const import (
     DOMAIN,
     PLATFORMS,
 )
+from custom_components.matic_robot.plans import AreaBindingUpgradeResult
 
 
 def _entry() -> SimpleNamespace:
@@ -48,6 +50,29 @@ def _entry() -> SimpleNamespace:
         entry_id="entry",
         async_create_background_task=MagicMock(side_effect=close_background_coroutine),
         async_on_unload=MagicMock(),
+    )
+
+
+def test_floor_plan_area_binding_support_requires_usable_geometry() -> None:
+    assert not _floor_plan_supports_area_binding(None)
+    assert not _floor_plan_supports_area_binding(
+        FloorPlan(42, "synthetic-partition", b"synthetic-partition", ())
+    )
+    assert _floor_plan_supports_area_binding(
+        FloorPlan(
+            42,
+            "synthetic-partition",
+            b"synthetic-partition",
+            (
+                Room(
+                    "room",
+                    "Room",
+                    "room",
+                    b"room",
+                    ((0.0, 0.0), (1.0, 0.0), (0.0, 1.0)),
+                ),
+            ),
+        )
     )
 
 
@@ -132,7 +157,13 @@ async def test_setup_refreshes_before_forwarding_platforms(
     plans = MagicMock()
     plans.areas.return_value = {}
     plans.async_add_listener.return_value = plan_unsubscribe
-    plans.async_upgrade_area_bindings = AsyncMock(return_value=0)
+    plans.async_upgrade_area_bindings = AsyncMock(
+        side_effect=(
+            AreaBindingUpgradeResult(0, True),
+            AreaBindingUpgradeResult(0, True),
+            AreaBindingUpgradeResult(1, False),
+        )
+    )
     plans.async_import_native_history = AsyncMock(return_value=False)
     hass = SimpleNamespace(
         config=SimpleNamespace(time_zone="America/Los_Angeles"),
@@ -245,7 +276,7 @@ async def test_setup_refreshes_before_forwarding_platforms(
         entry.async_create_background_task.side_effect = lambda _hass, target, _name: (
             scheduled.append(target)
         )
-        live_floor_plan = FloorPlan(
+        partial_floor_plan = FloorPlan(
             42,
             "synthetic-partition",
             b"synthetic-partition",
@@ -259,17 +290,35 @@ async def test_setup_refreshes_before_forwarding_platforms(
                 ),
             ),
         )
-        coordinator.data.floor_plan = live_floor_plan
+        complete_floor_plan = FloorPlan(
+            42,
+            "synthetic-partition",
+            b"synthetic-partition",
+            (
+                *partial_floor_plan.rooms,
+                Room(
+                    "later-room",
+                    "Later Room",
+                    "later-room",
+                    b"later-room",
+                    ((2.0, 0.0), (3.0, 0.0), (2.0, 1.0)),
+                ),
+            ),
+        )
+        coordinator.data.floor_plan = partial_floor_plan
         sync_callback()
         await scheduled[0]
+        coordinator.data.floor_plan = complete_floor_plan
+        sync_callback()
+        await scheduled[1]
         plans.async_add_listener.call_args.args[1]()
 
-    assert listener_sync.call_count == 2
-    assert entry.async_create_background_task.call_count == 3
-    assert plans.async_upgrade_area_bindings.await_count == 2
+    assert listener_sync.call_count == 3
+    assert entry.async_create_background_task.call_count == 4
+    assert plans.async_upgrade_area_bindings.await_count == 3
     assert plans.async_upgrade_area_bindings.call_args.args == (
         "synthetic-serial",
-        live_floor_plan,
+        complete_floor_plan,
     )
     assert (
         entry.async_create_background_task.call_args.args[2]
@@ -348,7 +397,9 @@ async def test_revoked_credential_enters_reauthentication_before_setup() -> None
 
 async def test_setup_closes_client_when_platform_forwarding_fails() -> None:
     plans = MagicMock()
-    plans.async_upgrade_area_bindings = AsyncMock(return_value=0)
+    plans.async_upgrade_area_bindings = AsyncMock(
+        return_value=AreaBindingUpgradeResult(0, False)
+    )
     plans.async_import_native_history = AsyncMock(return_value=False)
     hass = SimpleNamespace(
         config=SimpleNamespace(time_zone="UTC"),

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -161,6 +161,7 @@ async def test_setup_refreshes_before_forwarding_platforms(
         side_effect=(
             AreaBindingUpgradeResult(0, True),
             AreaBindingUpgradeResult(0, True),
+            AreaBindingUpgradeResult(0, True),
             AreaBindingUpgradeResult(1, False),
         )
     )
@@ -305,6 +306,21 @@ async def test_setup_refreshes_before_forwarding_platforms(
                 ),
             ),
         )
+        updated_floor_plan = FloorPlan(
+            42,
+            "synthetic-partition",
+            b"synthetic-partition",
+            (
+                *complete_floor_plan.rooms,
+                Room(
+                    "final-room",
+                    "Final Room",
+                    "final-room",
+                    b"final-room",
+                    ((4.0, 0.0), (5.0, 0.0), (4.0, 1.0)),
+                ),
+            ),
+        )
         coordinator.data.floor_plan = partial_floor_plan
         sync_callback()
         coordinator.data.floor_plan = complete_floor_plan
@@ -313,14 +329,20 @@ async def test_setup_refreshes_before_forwarding_platforms(
         await scheduled[0]
         assert len(scheduled) == 2
         await scheduled[1]
+        sync_callback()
+        assert len(scheduled) == 2
+        coordinator.data.floor_plan = updated_floor_plan
+        sync_callback()
+        assert len(scheduled) == 3
+        await scheduled[2]
         plans.async_add_listener.call_args.args[1]()
 
-    assert listener_sync.call_count == 3
-    assert entry.async_create_background_task.call_count == 4
-    assert plans.async_upgrade_area_bindings.await_count == 3
+    assert listener_sync.call_count == 5
+    assert entry.async_create_background_task.call_count == 5
+    assert plans.async_upgrade_area_bindings.await_count == 4
     assert plans.async_upgrade_area_bindings.call_args.args == (
         "synthetic-serial",
-        complete_floor_plan,
+        updated_floor_plan,
     )
     assert (
         entry.async_create_background_task.call_args.args[2]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -307,9 +307,11 @@ async def test_setup_refreshes_before_forwarding_platforms(
         )
         coordinator.data.floor_plan = partial_floor_plan
         sync_callback()
-        await scheduled[0]
         coordinator.data.floor_plan = complete_floor_plan
         sync_callback()
+        assert len(scheduled) == 1
+        await scheduled[0]
+        assert len(scheduled) == 2
         await scheduled[1]
         plans.async_add_listener.call_args.args[1]()
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -162,6 +162,7 @@ async def test_setup_refreshes_before_forwarding_platforms(
             AreaBindingUpgradeResult(0, True),
             AreaBindingUpgradeResult(0, True),
             AreaBindingUpgradeResult(0, True),
+            AreaBindingUpgradeResult(0, True),
             AreaBindingUpgradeResult(1, False),
         )
     )
@@ -198,6 +199,36 @@ async def test_setup_refreshes_before_forwarding_platforms(
             else None
         ),
     )
+    initial_floor_plan = coordinator.data.floor_plan
+    setup_floor_plan = FloorPlan(
+        42,
+        "synthetic-partition",
+        b"synthetic-partition",
+        (
+            Room(
+                "setup-room",
+                "Setup Room",
+                "setup-room",
+                b"setup-room",
+                ((-2.0, 0.0), (-1.0, 0.0), (-2.0, 1.0)),
+            ),
+        ),
+    )
+
+    def deliver_setup_floor_plan(_serial_number, _listener):
+        coordinator.data.floor_plan = setup_floor_plan
+        return plan_unsubscribe
+
+    plans.async_add_listener.side_effect = deliver_setup_floor_plan
+    setup_scheduled = []
+
+    def capture_setup_tasks(_hass, target, name):
+        if name == "matic_robot custom area binding upgrade":
+            setup_scheduled.append(target)
+        else:
+            target.close()
+
+    entry.async_create_background_task.side_effect = capture_setup_tasks
     slam_map = SimpleNamespace(
         async_load=AsyncMock(),
         async_collect=MagicMock(),
@@ -233,12 +264,19 @@ async def test_setup_refreshes_before_forwarding_platforms(
         ),
     ):
         assert await async_setup_entry(hass, entry) is True
+    assert len(setup_scheduled) == 1
+    await setup_scheduled[0]
 
     decode.assert_called_once_with("test-credential")
     coordinator.async_config_entry_first_refresh.assert_awaited_once()
-    initial_floor_plan = coordinator.data.floor_plan
-    plans.async_upgrade_area_bindings.assert_awaited_once_with(
-        "synthetic-serial", initial_floor_plan
+    assert plans.async_upgrade_area_bindings.await_count == 2
+    assert plans.async_upgrade_area_bindings.await_args_list[0].args == (
+        "synthetic-serial",
+        initial_floor_plan,
+    )
+    assert plans.async_upgrade_area_bindings.await_args_list[1].args == (
+        "synthetic-serial",
+        setup_floor_plan,
     )
     if native_history_error:
         plans.async_import_native_history.assert_not_awaited()
@@ -256,7 +294,7 @@ async def test_setup_refreshes_before_forwarding_platforms(
     slam_history.async_load.assert_awaited_once()
     slam_map.async_collect.assert_called_once_with(client)
     collect_history.assert_called_once()
-    assert entry.async_create_background_task.call_count == 2
+    assert entry.async_create_background_task.call_count == 3
     assert (
         entry.runtime_data.firmware_tracker
         is (hass.data[DOMAIN][DATA_FIRMWARE_TRACKER])
@@ -268,7 +306,7 @@ async def test_setup_refreshes_before_forwarding_platforms(
         ((coordinator_unsubscribe,), {}),
         ((plan_unsubscribe,), {}),
     ]
-    sync_area_issue.assert_called_once_with(hass, "entry", {}, initial_floor_plan)
+    sync_area_issue.assert_called_once_with(hass, "entry", {}, setup_floor_plan)
 
     with patch(
         "custom_components.matic_robot.async_sync_custom_area_issue"
@@ -338,8 +376,8 @@ async def test_setup_refreshes_before_forwarding_platforms(
         plans.async_add_listener.call_args.args[1]()
 
     assert listener_sync.call_count == 5
-    assert entry.async_create_background_task.call_count == 5
-    assert plans.async_upgrade_area_bindings.await_count == 4
+    assert entry.async_create_background_task.call_count == 6
+    assert plans.async_upgrade_area_bindings.await_count == 5
     assert plans.async_upgrade_area_bindings.call_args.args == (
         "synthetic-serial",
         updated_floor_plan,

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -382,6 +382,17 @@ async def test_area_binding_upgrade_stays_pending_for_partial_map(hass) -> None:
     manager._store.async_save.assert_awaited_once()
 
 
+async def test_area_binding_upgrade_ignores_malformed_area_record(hass) -> None:
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    manager._robot = MagicMock(return_value={"areas": {"corrupt": "not-an-area"}})
+
+    assert await manager.async_upgrade_area_bindings(
+        "serial", None
+    ) == AreaBindingUpgradeResult(0, False)
+    manager._store.async_save.assert_not_awaited()
+
+
 async def test_native_history_import_recovers_only_explicit_room_completions(
     hass,
 ) -> None:

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -12,7 +12,9 @@ from homeassistant.util import dt as dt_util
 
 from custom_components.matic_robot.area_binding import (
     AREA_SCHEMA_VERSION,
+    HASH_ONLY_SCOPED_MAP_BINDING_VERSION,
     SCOPED_MAP_BINDING_VERSION,
+    _hash_only_area_geometry_fingerprint,
     binding_for_area,
     binding_for_floor_plan,
 )
@@ -262,6 +264,17 @@ async def test_current_v1_area_bindings_upgrade_automatically(hass) -> None:
             "circles": circles,
             "map_binding": binding_for_area(floor_plan, circles),
         },
+        "hash_only_scoped": {
+            "schema_version": AREA_SCHEMA_VERSION,
+            "circles": circles,
+            "map_binding": {
+                **binding_for_floor_plan(floor_plan),
+                "version": HASH_ONLY_SCOPED_MAP_BINDING_VERSION,
+                "local_geometry_sha256": _hash_only_area_geometry_fingerprint(
+                    floor_plan, circles
+                ),
+            },
+        },
         "different_mission": {
             "schema_version": AREA_SCHEMA_VERSION,
             "circles": circles,
@@ -282,8 +295,11 @@ async def test_current_v1_area_bindings_upgrade_automatically(hass) -> None:
         "corrupt": "not-an-area",
     }
 
-    assert await manager.async_upgrade_area_bindings("serial", floor_plan) == 1
+    assert await manager.async_upgrade_area_bindings("serial", floor_plan) == 2
     assert robot["areas"]["current"]["map_binding"]["version"] == (
+        SCOPED_MAP_BINDING_VERSION
+    )
+    assert robot["areas"]["hash_only_scoped"]["map_binding"]["version"] == (
         SCOPED_MAP_BINDING_VERSION
     )
     manager._store.async_save.assert_awaited_once()

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -292,6 +292,16 @@ async def test_current_v1_area_bindings_upgrade_automatically(hass) -> None:
             "map_binding": binding_for_floor_plan(floor_plan),
         },
         "unbound": {"schema_version": 0, "circles": circles},
+        "list_version": {
+            "schema_version": AREA_SCHEMA_VERSION,
+            "circles": circles,
+            "map_binding": {"version": []},
+        },
+        "object_version": {
+            "schema_version": AREA_SCHEMA_VERSION,
+            "circles": circles,
+            "map_binding": {"version": {}},
+        },
         "corrupt": "not-an-area",
     }
 
@@ -302,6 +312,8 @@ async def test_current_v1_area_bindings_upgrade_automatically(hass) -> None:
     assert robot["areas"]["hash_only_scoped"]["map_binding"]["version"] == (
         SCOPED_MAP_BINDING_VERSION
     )
+    assert robot["areas"]["list_version"]["map_binding"]["version"] == []
+    assert robot["areas"]["object_version"]["map_binding"]["version"] == {}
     manager._store.async_save.assert_awaited_once()
     listener.assert_called_once()
 

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -1,6 +1,7 @@
 """Durable intelligent cleaning behavior."""
 
 import asyncio
+from dataclasses import replace
 from datetime import UTC, timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -28,6 +29,7 @@ from custom_components.matic_robot.client.models import (
 )
 from custom_components.matic_robot.const import DOMAIN
 from custom_components.matic_robot.plans import (
+    AreaBindingUpgradeResult,
     CleaningPlanManager,
     CleaningRoom,
     ManagedMotionReplacedError,
@@ -291,6 +293,11 @@ async def test_current_v1_area_bindings_upgrade_automatically(hass) -> None:
             "schema_version": AREA_SCHEMA_VERSION,
             "map_binding": binding_for_floor_plan(floor_plan),
         },
+        "invalid_circles": {
+            "schema_version": AREA_SCHEMA_VERSION,
+            "circles": [{}],
+            "map_binding": binding_for_floor_plan(floor_plan),
+        },
         "unbound": {"schema_version": 0, "circles": circles},
         "list_version": {
             "schema_version": AREA_SCHEMA_VERSION,
@@ -305,7 +312,9 @@ async def test_current_v1_area_bindings_upgrade_automatically(hass) -> None:
         "corrupt": "not-an-area",
     }
 
-    assert await manager.async_upgrade_area_bindings("serial", floor_plan) == 2
+    assert await manager.async_upgrade_area_bindings(
+        "serial", floor_plan
+    ) == AreaBindingUpgradeResult(2, False)
     assert robot["areas"]["current"]["map_binding"]["version"] == (
         SCOPED_MAP_BINDING_VERSION
     )
@@ -319,10 +328,58 @@ async def test_current_v1_area_bindings_upgrade_automatically(hass) -> None:
 
     manager._store.async_save.reset_mock()
     listener.reset_mock()
-    assert await manager.async_upgrade_area_bindings("serial", floor_plan) == 0
-    assert await manager.async_upgrade_area_bindings("serial", None) == 0
+    assert await manager.async_upgrade_area_bindings(
+        "serial", floor_plan
+    ) == AreaBindingUpgradeResult(0, False)
+    assert await manager.async_upgrade_area_bindings(
+        "serial", None
+    ) == AreaBindingUpgradeResult(0, True)
     manager._store.async_save.assert_not_awaited()
     listener.assert_not_called()
+
+
+async def test_area_binding_upgrade_stays_pending_for_partial_map(hass) -> None:
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    first_room = Room(
+        "first",
+        "First",
+        "first",
+        b"first",
+        ((0, 0), (1, 0), (0, 1)),
+    )
+    second_room = Room(
+        "second",
+        "Second",
+        "second",
+        b"second",
+        ((2, 0), (3, 0), (2, 1)),
+    )
+    complete = FloorPlan(
+        42,
+        "synthetic-partition",
+        b"synthetic-partition",
+        (first_room, second_room),
+    )
+    partial = replace(complete, rooms=(first_room,))
+    circles = [{"x": 2.2, "y": 0.2, "radius": 0.1}]
+    manager._robot("serial")["areas"] = {
+        "partial": {
+            "schema_version": AREA_SCHEMA_VERSION,
+            "circles": circles,
+            "map_binding": binding_for_floor_plan(complete),
+        }
+    }
+
+    assert await manager.async_upgrade_area_bindings(
+        "serial", partial
+    ) == AreaBindingUpgradeResult(0, True)
+    manager._store.async_save.assert_not_awaited()
+
+    assert await manager.async_upgrade_area_bindings(
+        "serial", complete
+    ) == AreaBindingUpgradeResult(1, False)
+    manager._store.async_save.assert_awaited_once()
 
 
 async def test_native_history_import_recovers_only_explicit_room_completions(


### PR DESCRIPTION
## What changed

- Retry legacy custom-area binding migration when the coordinator first receives a floor plan after startup.
- Replace fixed centimeter rounding with private millimeter evidence and an explicit 10 mm coordinate tolerance.
- Keep immutable area-shape and exact local-geometry digests so malformed or tampered tolerant evidence remains invalid.
- Add regression coverage for cross-boundary 2 mm jitter, newly introduced local boundaries, evidence integrity, and delayed map availability.
- Update the 0.3.3 verification record.

## Why

PR #28 merged before its two Codex P2 review threads were observed. This follow-up addresses both findings before 0.3.3 is tagged or published.

The startup-only migration attempt could miss an area for the lifetime of an entry when the optional map was temporarily unavailable. Fixed-grid centimeter rounding also did not guarantee sub-centimeter tolerance near a rounding boundary.

## Impact

Exactly current v1 areas migrate either during setup or on the first later coordinator update with a map. A 2 mm boundary drift now remains current even when it crosses an old rounding boundary; materially changed nearby geometry still fails closed. No robot protocol commands changed and no release has been published.

## Validation

- 878 Python tests / 8,200 statements at 100% coverage.
- Ruff lint and formatting.
- Strict MyPy.
- Public-tree privacy gate.
- Release archive parity.
- Clean-wheel import.
- Existing 42 Chromium and 3 mobile WebKit tests remain unchanged and passed on PR #28.

## Review-loop requirement

Do not merge through the `auto-merge-now` override. This PR must receive a fresh Codex review of the current head, have every actionable thread addressed and resolved, and pass `review-gate` from that review.