### PR TITLE
Fix BLE pairing from retained scanner entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,9 +259,12 @@ uses the LAN.
   exchange. Bluetooth proxies are not supported for setup. If a proxy can see
   Matic but the local adapter cannot, move the local adapter closer and remove
   obstructions. If pairing fails, temporarily disable Bluetooth proxies while
-  retrying so discovery and pairing stay on the local adapter. If that adapter
-  still misses fresh advertisements, reload its Home Assistant integration or
-  replug it before retrying. Routine use is LAN-only after authorization.
+  retrying so discovery and pairing stay on the local adapter. If Matic is not
+  retained in that adapter's Home Assistant scanner cache, compare with a
+  phone-side scan. Reload the Bluetooth integration or replug the adapter only
+  if the local scanner also cannot see nearby Bluetooth devices. Routine use is
+  LAN-only after authorization, but reauthentication and explicit credential
+  replacement need the same local Bluetooth path as initial setup.
 - For bugs, use the repository's bug-report form after reviewing and sanitizing
   diagnostics. Report vulnerabilities privately as described in
   [SECURITY.md](SECURITY.md). Never attach credentials, maps, captures, backups,

--- a/custom_components/matic_robot/bluetooth_pairing.py
+++ b/custom_components/matic_robot/bluetooth_pairing.py
@@ -7,7 +7,7 @@ import errno
 import logging
 import re
 import sys
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator, Callable, Iterable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -47,7 +47,7 @@ class BluetoothPasskeyCancelledError(MaticError):
 
 
 class BluetoothPairingIncompleteError(MaticError):
-    """The robot was advertising, but Bluetooth pairing did not complete."""
+    """A retained local candidate did not complete credential issuance."""
 
 
 class BluetoothPairingResetError(MaticError):
@@ -73,7 +73,7 @@ _ADAPTER_ERRNOS = {errno.EACCES, errno.ENODEV, errno.EPERM}
 
 @dataclass(frozen=True, slots=True)
 class _MaticDiscovery:
-    """One fresh Matic advertisement from a specific local adapter."""
+    """One Matic candidate retained by a specific local adapter."""
 
     device: Any
     name: str
@@ -179,19 +179,24 @@ def _is_matic_advertisement(info: Any) -> bool:
     when BlueZ has cached it, but it is commonly absent from live pairing
     advertisements.
     """
-    name = str(getattr(info, "name", "") or "").casefold()
-    service_uuids = {
-        str(uuid).casefold() for uuid in (getattr(info, "service_uuids", ()) or ())
-    }
+    return _is_matic_identity(
+        getattr(info, "name", ""), getattr(info, "service_uuids", ())
+    )
+
+
+def _is_matic_identity(name: object, service_uuids: Iterable[object] | None) -> bool:
+    """Return whether a name or service-UUID collection identifies Matic."""
+    normalized_name = str(name or "").casefold()
+    normalized_uuids = {str(uuid).casefold() for uuid in (service_uuids or ())}
     # Match "matic" only at a word boundary so genuine names ("Matic",
     # "Matic Robot", "matic-<serial>") pass while embedded matches
     # ("Automatic Blinds", "Prismatic") are rejected.
-    named_matic = re.search(rf"\b{MATIC_LOCAL_NAME}", name) is not None
-    return named_matic or MATIC_BLE_SERVICE_UUID in service_uuids
+    named_matic = re.search(rf"\b{MATIC_LOCAL_NAME}", normalized_name) is not None
+    return named_matic or MATIC_BLE_SERVICE_UUID in normalized_uuids
 
 
 async def _async_matic_discoveries(hass: HomeAssistant) -> list[Any]:
-    """Return fresh Matic advertisements seen by a local Bluetooth adapter."""
+    """Return Matic advertisements retained by a local Bluetooth adapter."""
     from homeassistant.components import bluetooth
 
     try:
@@ -207,17 +212,14 @@ async def _async_matic_discoveries(hass: HomeAssistant) -> list[Any]:
                 "Home Assistant has no directly attached connectable Bluetooth adapter"
             )
         before_scan = {
-            (scanner.source, address): (
-                advertisement,
-                scanner.discovered_device_timestamps.get(address),
-            )
-            for scanner in scanners
-            for address, (_device, advertisement) in (
-                scanner.discovered_devices_and_advertisement_data.items()
-            )
+            info.address: info.time
+            for info in bluetooth.async_discovered_service_info(hass, connectable=False)
         }
         await bluetooth.async_request_active_scan(
             hass, duration=BLUETOOTH_ACTIVE_SCAN_SECONDS
+        )
+        service_infos = tuple(
+            bluetooth.async_discovered_service_info(hass, connectable=False)
         )
     except RuntimeError as err:
         # Raised when Home Assistant's Bluetooth integration is not set up.
@@ -226,33 +228,37 @@ async def _async_matic_discoveries(hass: HomeAssistant) -> list[Any]:
         ) from err
 
     local_by_address: dict[str, _MaticDiscovery] = {}
-    fresh_remote_matic = False
-    scanners = list(bluetooth.async_current_scanners(hass))
-    for scanner in scanners:
-        timestamps = scanner.discovered_device_timestamps
-        for address, (
-            device,
-            advertisement,
-        ) in scanner.discovered_devices_and_advertisement_data.items():
-            previous = before_scan.get((scanner.source, address))
-            if previous is not None and (
-                advertisement is previous[0] and timestamps.get(address) == previous[1]
-            ):
-                continue
-            discovery = _MaticDiscovery(
-                device=device,
-                name=advertisement.local_name or device.name or address,
-                service_uuids=tuple(advertisement.service_uuids),
-                rssi=advertisement.rssi,
-                source=scanner.source,
-            )
-            if not _is_matic_advertisement(discovery):
+    remote_matic = False
+    for service_info in service_infos:
+        if not _is_matic_advertisement(service_info):
+            continue
+        previous_time = before_scan.get(service_info.address)
+        refreshed_source = previous_time is None or service_info.time > previous_time
+        scanner_devices = bluetooth.async_scanner_devices_by_address(
+            hass, service_info.address, connectable=False
+        )
+        for scanner_device in scanner_devices:
+            scanner = scanner_device.scanner
+            device = scanner_device.ble_device
+            advertisement = scanner_device.advertisement
+            address = device.address
+            name = advertisement.local_name or device.name or address
+            service_uuids = advertisement.service_uuids
+            if not _is_matic_identity(name, service_uuids):
                 continue
             if isinstance(scanner, bluetooth.BaseHaRemoteScanner):
-                fresh_remote_matic = True
+                if scanner.source == service_info.source and refreshed_source:
+                    remote_matic = True
                 continue
             if not scanner.connectable:
                 continue
+            discovery = _MaticDiscovery(
+                device=device,
+                name=name,
+                service_uuids=tuple(service_uuids),
+                rssi=advertisement.rssi,
+                source=scanner.source,
+            )
             current = local_by_address.get(address)
             if current is None or (discovery.rssi or -127) > (current.rssi or -127):
                 local_by_address[address] = discovery
@@ -267,13 +273,14 @@ async def _async_matic_discoveries(hass: HomeAssistant) -> list[Any]:
         reverse=True,
     )
     _LOGGER.debug(
-        "Found %s fresh local Matic advertisement(s); signal strength(s): %s dBm",
+        "Found %s local Matic advertisement cache entry(ies); "
+        "signal strength(s): %s dBm",
         len(local_discoveries),
         [discovery.rssi for discovery in local_discoveries],
     )
     if local_discoveries:
         return local_discoveries
-    if fresh_remote_matic:
+    if remote_matic:
         raise BluetoothProxyOnlyError(
             "Matic is visible only through a remote Bluetooth proxy"
         )
@@ -466,9 +473,9 @@ async def async_request_bluetooth_credential(
             "Home Assistant's Bluetooth adapter cannot open a connection "
             f"({_safe_bluetooth_error_summary(adapter_access_error)})"
         ) from adapter_access_error
-    # A fresh advertisement was found above, so Pairing mode was on; the
-    # failure happened after discovery and must not be reported as the
-    # pairing window being closed.
+    # A retained local candidate was found above. It may have gone silent before
+    # this attempt, so report the actual failing stage without claiming that a
+    # live pairing exchange started.
     raise BluetoothPairingIncompleteError(
         f"Matic Bluetooth credential request failed: {last_failure}"
     )

--- a/custom_components/matic_robot/strings.json
+++ b/custom_components/matic_robot/strings.json
@@ -210,10 +210,10 @@
       "invalid_passkey": "Enter all six digits shown on the robot's screen.",
       "pairing_code_expired": "That code expired. Turn Pairing mode off and back on in the Matic app, confirm below, then enter the new code immediately.",
       "pairing_code_rejected": "Matic did not accept that code. Turn Pairing mode off and back on in the Matic app, confirm below, then enter the new code immediately.",
-      "pairing_incomplete": "Pairing started but did not finish. Keep the robot near Home Assistant's Bluetooth adapter, turn Pairing mode off and on, then try again.",
+      "pairing_incomplete": "Home Assistant found a retained local Matic entry but could not complete the Bluetooth connection or credential request. Keep Matic near the local adapter, confirm Pairing mode is enabled, then retry. Check Settings → System → Logs for the failing stage.",
       "pairing_mode_confirmation_required": "Turn on Pairing mode first, then check the box to continue.",
-      "pairing_mode_off": "Home Assistant's local Bluetooth adapter did not receive a fresh pairing advertisement. Turn Pairing mode off and on, put the adapter within a few feet of Matic with minimal obstruction, temporarily disable Bluetooth proxies, then try again.",
-      "pairing_timeout": "Pairing did not finish within five minutes. Turn Pairing mode off and on, put Home Assistant's local Bluetooth adapter within a few feet of Matic, temporarily disable Bluetooth proxies, and try again. If it still misses the robot, reload or replug the adapter. Details are in Settings → System → Logs."
+      "pairing_mode_off": "Home Assistant could not find Matic through its local Bluetooth adapter, or Matic did not authorize credential issuance. Keep Matic within a few feet of the adapter, enable Pairing mode, and retry. Reload Bluetooth or replug the adapter only if the local scanner also cannot see nearby Bluetooth devices; otherwise compare with a phone scan.",
+      "pairing_timeout": "Pairing did not finish within five minutes. Review the last pairing stage in Settings → System → Logs, keep Matic near the local adapter, confirm Pairing mode is enabled, and retry. Reload Bluetooth or replug the adapter only if the local scanner also cannot see nearby devices."
     },
     "step": {
       "discovery_failed": {

--- a/custom_components/matic_robot/strings.json
+++ b/custom_components/matic_robot/strings.json
@@ -212,7 +212,7 @@
       "pairing_code_rejected": "Matic did not accept that code. Turn Pairing mode off and back on in the Matic app, confirm below, then enter the new code immediately.",
       "pairing_incomplete": "Home Assistant found a retained local Matic entry but could not complete the Bluetooth connection or credential request. Keep Matic near the local adapter, confirm Pairing mode is enabled, then retry. Check Settings → System → Logs for the failing stage.",
       "pairing_mode_confirmation_required": "Turn on Pairing mode first, then check the box to continue.",
-      "pairing_mode_off": "Home Assistant could not find Matic through its local Bluetooth adapter, or Matic did not authorize credential issuance. Keep Matic within a few feet of the adapter, enable Pairing mode, and retry. Reload Bluetooth or replug the adapter only if the local scanner also cannot see nearby Bluetooth devices; otherwise compare with a phone scan.",
+      "pairing_mode_off": "Home Assistant's local Bluetooth scanner could not find a Matic candidate. Keep Matic within a few feet of the adapter and retry. Pairing mode must remain enabled for the later authorization step. Reload Bluetooth or replug the adapter only if the local scanner also cannot see nearby Bluetooth devices; otherwise compare with a phone scan.",
       "pairing_timeout": "Pairing did not finish within five minutes. Review the last pairing stage in Settings → System → Logs, keep Matic near the local adapter, confirm Pairing mode is enabled, and retry. Reload Bluetooth or replug the adapter only if the local scanner also cannot see nearby devices."
     },
     "step": {

--- a/custom_components/matic_robot/translations/en.json
+++ b/custom_components/matic_robot/translations/en.json
@@ -210,10 +210,10 @@
       "invalid_passkey": "Enter all six digits shown on the robot's screen.",
       "pairing_code_expired": "That code expired. Turn Pairing mode off and back on in the Matic app, confirm below, then enter the new code immediately.",
       "pairing_code_rejected": "Matic did not accept that code. Turn Pairing mode off and back on in the Matic app, confirm below, then enter the new code immediately.",
-      "pairing_incomplete": "Pairing started but did not finish. Keep the robot near Home Assistant's Bluetooth adapter, turn Pairing mode off and on, then try again.",
+      "pairing_incomplete": "Home Assistant found a retained local Matic entry but could not complete the Bluetooth connection or credential request. Keep Matic near the local adapter, confirm Pairing mode is enabled, then retry. Check Settings → System → Logs for the failing stage.",
       "pairing_mode_confirmation_required": "Turn on Pairing mode first, then check the box to continue.",
-      "pairing_mode_off": "Home Assistant's local Bluetooth adapter did not receive a fresh pairing advertisement. Turn Pairing mode off and on, put the adapter within a few feet of Matic with minimal obstruction, temporarily disable Bluetooth proxies, then try again.",
-      "pairing_timeout": "Pairing did not finish within five minutes. Turn Pairing mode off and on, put Home Assistant's local Bluetooth adapter within a few feet of Matic, temporarily disable Bluetooth proxies, and try again. If it still misses the robot, reload or replug the adapter. Details are in Settings → System → Logs."
+      "pairing_mode_off": "Home Assistant could not find Matic through its local Bluetooth adapter, or Matic did not authorize credential issuance. Keep Matic within a few feet of the adapter, enable Pairing mode, and retry. Reload Bluetooth or replug the adapter only if the local scanner also cannot see nearby Bluetooth devices; otherwise compare with a phone scan.",
+      "pairing_timeout": "Pairing did not finish within five minutes. Review the last pairing stage in Settings → System → Logs, keep Matic near the local adapter, confirm Pairing mode is enabled, and retry. Reload Bluetooth or replug the adapter only if the local scanner also cannot see nearby devices."
     },
     "step": {
       "discovery_failed": {

--- a/custom_components/matic_robot/translations/en.json
+++ b/custom_components/matic_robot/translations/en.json
@@ -212,7 +212,7 @@
       "pairing_code_rejected": "Matic did not accept that code. Turn Pairing mode off and back on in the Matic app, confirm below, then enter the new code immediately.",
       "pairing_incomplete": "Home Assistant found a retained local Matic entry but could not complete the Bluetooth connection or credential request. Keep Matic near the local adapter, confirm Pairing mode is enabled, then retry. Check Settings → System → Logs for the failing stage.",
       "pairing_mode_confirmation_required": "Turn on Pairing mode first, then check the box to continue.",
-      "pairing_mode_off": "Home Assistant could not find Matic through its local Bluetooth adapter, or Matic did not authorize credential issuance. Keep Matic within a few feet of the adapter, enable Pairing mode, and retry. Reload Bluetooth or replug the adapter only if the local scanner also cannot see nearby Bluetooth devices; otherwise compare with a phone scan.",
+      "pairing_mode_off": "Home Assistant's local Bluetooth scanner could not find a Matic candidate. Keep Matic within a few feet of the adapter and retry. Pairing mode must remain enabled for the later authorization step. Reload Bluetooth or replug the adapter only if the local scanner also cannot see nearby Bluetooth devices; otherwise compare with a phone scan.",
       "pairing_timeout": "Pairing did not finish within five minutes. Review the last pairing stage in Settings → System → Logs, keep Matic near the local adapter, confirm Pairing mode is enabled, and retry. Reload Bluetooth or replug the adapter only if the local scanner also cannot see nearby devices."
     },
     "step": {

--- a/docs/firmware-compatibility.md
+++ b/docs/firmware-compatibility.md
@@ -8,6 +8,9 @@ separates an observed update from verified compatibility.
 
 - **Observed** — a firmware version was reported, but the integration has not
   been checked after the update.
+- **Pairing verified** — local BLE credential issuance was completed on the
+  recorded Home Assistant installation and physical adapter; authenticated
+  reads or controls may still be pending.
 - **Core read verified** — authenticated coordinator state, the floor plan, and
   the primary Home Assistant surfaces work; optional reads or a full endpoint
   sweep may still have documented gaps.
@@ -21,8 +24,13 @@ separates an observed update from verified compatibility.
 
 | Firmware | First observed | Integration | Status | Evidence | Changes or capabilities |
 | --- | --- | --- | --- | --- | --- |
+| [v171.10](firmware-versions/v171.md) | 2026-08-09 | 0.3.3 (affected) | Read verified | An unreleased candidate based on 0.3.3 was live-validated on HA 2026.7.2 Container with a local BlueZ adapter on an ARM64 Linux host; protocol 25; initial credential issuance completed; coordinator, state, telemetry, map, rooms, and pose decoded; payload-free sweep 32 populated / 8 empty / 0 failed | Release 0.3.3 discarded an unchanged local scanner entry as not fresh; the candidate accepts that retained entry after the active sweep. Reauthorization, credential replacement, stale-bond recovery, and controls remain pending. |
 | [v169.9](firmware-versions/v169.md) | 2026-07-27 | 0.3.0 | Control verified | Live on HA 2026.7.4; protocol 25; snapshot 28 populated / 12 empty / 0 failed; no endpoint availability changes | Full local map, pose, rooms, telemetry, and update state remained available; quick and standard coverage, all three cleaning modes, complete saved-plan handoff, both intelligent-stop branches, and persisted custom-area cleaning passed live without false credit |
 | [v168.11](firmware-versions/v168.md) | 2026-07-20 | 0.2.0–0.2.3 | Core read verified | Live on HA 2026.7.2; protocol 25; automatic baseline snapshot 28 populated / 12 empty / 0 failed; selected stop/dock/room-plan paths later exercised | Uploader-state decoder fix released and live-confirmed; robot-side stream resets handled as transport noise; complete control matrix remains pending |
+
+No v170 build was observed, so the ledger makes no v170 compatibility claim.
+The v171.10 validation result is a direct live observation and does not infer
+behavior for the missing release.
 
 An empty or pending entry is not a compatibility claim. Synthetic tests show
 that the integration handles the documented protocol shapes; only real-robot
@@ -39,14 +47,22 @@ notes.
 For each firmware, record the integration and Home Assistant versions, then
 check in this order:
 
-1. Confirm local discovery and authenticated coordinator refresh.
-2. Confirm software version, protocol version, operational state, battery,
-   update state, map, pose, and room data still decode.
-3. Review privacy-safe logs and downloaded diagnostics for new missing fields,
+1. Record the Home Assistant installation, local Bluetooth adapter, and source
+   of the firmware version.
+2. Confirm local discovery and `GetBotInfo`.
+3. When physical access is available, exercise the claimed initial issuance or
+   reauthorization path on each installation/adapter path. Record distance and
+   scanner controls.
+4. When credential recovery is claimed, exercise explicit replacement and
+   stale-bond removal.
+5. Confirm authenticated coordinator refresh, software version, protocol
+   version, operational state, battery, update state, map, pose, and room data
+   still decode.
+6. Review privacy-safe logs and downloaded diagnostics for new missing fields,
    unknown state/error codes, or collection failures.
-4. Exercise supported controls deliberately: start, pause, resume, stop, dock,
+7. Exercise supported controls deliberately: start, pause, resume, stop, dock,
    room cleaning, cleaning modes, coverage levels, and saved plans.
-5. Record changed behavior, regressions, and newly observed fields or
+8. Record changed behavior, regressions, and newly observed fields or
    capabilities. Link public fixtures, tests, issues, or pull requests when
    available.
 
@@ -55,6 +71,10 @@ newly observed firmware or protocol pair fires `matic_robot_firmware_changed`
 and starts a background, payload-free snapshot of all known endpoints. A Home
 Assistant Repair is created only when availability or transport status changes;
 a normal weekly OTA does not create an issue.
+
+That automated snapshot runs only after authentication. It cannot validate
+initial pairing, reauthorization, credential replacement, or the physical
+Bluetooth adapter path; those remain deliberate manual checks.
 
 The event can also drive a local notification:
 

--- a/docs/firmware-versions/template.md
+++ b/docs/firmware-versions/template.md
@@ -3,10 +3,13 @@
 [Endpoint map](../firmware-endpoint-map.md) ·
 [Firmware ledger](../firmware-compatibility.md)
 
-status: observed / live validation pending  
-first_observed_pacific: YYYY-MM-DD  
-integration_version: X.Y.Z  
-home_assistant_version: YYYY.M  
+status: observed / live validation pending<br>
+first_observed_pacific: YYYY-MM-DD<br>
+integration_version: X.Y.Z<br>
+home_assistant_version: YYYY.M<br>
+home_assistant_installation: HAOS / Container / other<br>
+bluetooth_adapter: model / not applicable<br>
+firmware_version_source: authenticated telemetry / robot screen / operator report<br>
 protocol_version: N
 
 ## Endpoint snapshot
@@ -14,6 +17,8 @@ protocol_version: N
 | Surface | Status | Evidence / delta from preceding firmware |
 | --- | --- | --- |
 | Discovery and `GetBotInfo` | Pending | |
+| Initial BLE credential issuance | Pending | |
+| Reauthorization, credential replacement and stale-bond recovery | Not tested | |
 | Authentication, handshake and session data | Pending | |
 | Core reads: `kabuki_state`, `coverage_plan`, `latest_pose` | Pending | |
 | 15 telemetry properties | Pending | |
@@ -34,6 +39,10 @@ protocol_version: N
 ## Promotion checklist
 
 - [ ] Record integration, Home Assistant and protocol versions.
+- [ ] Exercise the claimed initial issuance or reauthorization path on each
+  installation/adapter path.
+- [ ] When credential recovery is claimed, exercise explicit replacement and
+  stale-bond removal.
 - [ ] Confirm coordinator refresh and decoded reads.
 - [ ] Run a hash-only exploratory availability sweep.
 - [ ] Review privacy-safe diagnostics for protocol drift.
@@ -44,4 +53,3 @@ protocol_version: N
 
 Never commit downloaded diagnostics, raw robot payloads, credentials, network or
 device identifiers, maps, room names, Wi-Fi details, or other home data.
-

--- a/docs/firmware-versions/v171.md
+++ b/docs/firmware-versions/v171.md
@@ -93,9 +93,12 @@ protocol_version: 25
   and the v169.9 decoded-read snapshot was not repeated on this host.
 - [ ] Exercise supported writes deliberately and record exact coverage — not
   run for this firmware record.
-- [ ] Link sanitized fixtures, tests, issues and pull requests —
-  [issue #31](https://github.com/ProspectOre/matic-home-assistant/issues/31) is
-  filed; add the pull-request link after submission.
+- [x] Link sanitized fixtures, tests, issues and pull requests —
+  [issue #31](https://github.com/ProspectOre/matic-home-assistant/issues/31),
+  [pull request #30](https://github.com/ProspectOre/matic-home-assistant/pull/30),
+  and the [scanner-cache regression tests](../../tests/test_bluetooth_pairing.py)
+  record the public evidence and fix; no live captures or diagnostics are
+  committed.
 - [x] Update the public ledger and workspace firmware memory — both record the
   read-verified result and its remaining limits.
 

--- a/docs/firmware-versions/v171.md
+++ b/docs/firmware-versions/v171.md
@@ -1,0 +1,103 @@
+# Matic firmware v171.10
+
+[Endpoint map](../firmware-endpoint-map.md) ·
+[Firmware ledger](../firmware-compatibility.md)
+
+status: initial BLE credential issuance and authenticated reads verified with an unreleased candidate; controls pending<br>
+first_observed_pacific: 2026-08-09<br>
+integration_version: 0.3.3 (affected release)<br>
+home_assistant_version: 2026.7.2<br>
+home_assistant_installation: Container on an ARM64 Linux host<br>
+bluetooth_adapter: local adapter through host BlueZ<br>
+firmware_version_source: robot screen; unauthenticated `GetBotInfo` does not return the software version<br>
+protocol_version: 25
+
+## Endpoint snapshot
+
+| Surface | Status | Evidence / delta from preceding firmware |
+| --- | --- | --- |
+| Discovery and `GetBotInfo` | Verified | The config flow validated the LAN endpoint and reported `authentication required: True`. Home Assistant's local connectable scanner retained Matic's expected name and service UUID at −59 dBm. |
+| Initial BLE credential issuance | Verified | Initial issuance completed on HA Container: BlueZ requested the displayed passkey, completed the bond, and exposed the authenticated token characteristic. |
+| Reauthorization, credential replacement and stale-bond recovery | Not tested | These recovery paths use the corrected discovery path but were not exercised. |
+| Authentication, handshake and session data | Verified | The robot issued a GATT credential, Hermes accepted the authorization commands, and the first coordinator refresh succeeded. |
+| Core reads: `kabuki_state`, `coverage_plan`, `latest_pose` | Verified | Privacy-safe diagnostics showed a successful coordinator update with decoded operational state, map and rooms, and pose; all three endpoints were populated in the payload-free sweep. |
+| 15 telemetry properties | Verified | Firmware v171.10, protocol 25, update and Wi-Fi state, settings, and collection counts decoded. `coverage_time` retained its known 16-byte tombstone/default; Wi-Fi scan detail was absent while connectivity decoded as connected. |
+| Schedule and coverage-history collections | Verified | Decoded diagnostics reported one scheduled cleaning and 20 local cleaning sessions. Schedule events, coverage-session history, and thumbnails were populated in the payload-free sweep; schedule previews were reachable but empty. |
+| Dock and sink collection counts | Verified | Decoded diagnostics reported one dock detection and one sink summon location. Both endpoints were populated; sink summons were reachable but empty. |
+| Allowlisted exploratory reads | Verified | Payload-free sweep: 40 endpoints, 32 populated, 8 empty, 0 failed. A repeat v171.10 snapshot reported no availability or transport changes. |
+| Stop, pause, resume and dock | Not tested | No compatibility claim. |
+| Coverage/room commands and cleaning settings | Not tested | No compatibility claim. |
+
+## Changes and capability candidates
+
+- Matic advertised continuously with Pairing mode both off and on. A Mac beside
+  the Home Assistant host received the exact vendor service UUID while the
+  robot was at the same location used for Home Assistant pairing. Pairing mode
+  therefore gates authorization and bonding, not whether this advertisement
+  exists.
+- BlueZ and Home Assistant's local `HaScanner` both retained the same Matic
+  entry, including its name, exact service UUID, connectable status, and an RSSI
+  of −59 to −61 dBm. The adapter had no pre-existing Matic bond.
+- Integration 0.3.3 snapshotted each scanner before an active sweep and then
+  accepted only entries whose advertisement object or timestamp changed.
+  Neither value changed in the observed sweep windows; byte-identical packets
+  may be deduplicated below the integration. The integration therefore
+  discarded the valid retained entry and logged zero fresh results.
+- Restarting Home Assistant and restarting host BlueZ did not change that
+  false-negative result. It was not a wedged adapter or stale-bond failure.
+- The unreleased candidate requests the same active sweep and then accepts a
+  matching entry retained by Home Assistant's local scanner. With that one
+  discovery change, passkey entry, bonding, authenticated GATT credential
+  issuance, Hermes authorization, and the first coordinator refresh all
+  completed. Release 0.3.3 remains the affected published version.
+- An authenticated payload-free snapshot reported protocol 25 and covered all
+  40 known non-credential endpoints: 32 populated, 8 empty, and 0 failed. Its
+  comparison with an earlier v171.10 snapshot found no availability or
+  transport changes; seven ordinary content fingerprints changed.
+- Privacy-safe diagnostics confirmed a successful coordinator update, decoded
+  operational and telemetry state, an available map with rooms, an available
+  pose, 40 of 40 observed endpoints healthy, and no command failures, active
+  Hermes error codes, or Home Assistant issues. Charging state 107 decoded;
+  auxiliary raw states 209 and 212 are preserved without speculative labels.
+- The matcher accepts `\bmatic` anywhere in the live local name or BlueZ-cached
+  device name, or the exact service UUID
+  `5b14adcd-e995-9e80-c55a-b6c6fb6c612f`. The live cache entry satisfied both
+  name and UUID matching.
+- This result does not support a v171 firmware regression or a robot Bluetooth
+  hardware fault. It is the first recorded physical pairing validation for the
+  project's HA Container/local BlueZ adapter path.
+- No v170 firmware was observed. This record makes no v170 compatibility claim
+  and does not compare broader authenticated surfaces across that gap.
+
+## Promotion checklist
+
+- [x] Record integration, Home Assistant and protocol versions — the tested
+  integration change, Home Assistant 2026.7.2, and protocol 25 are recorded.
+- [x] Exercise the claimed initial issuance or reauthorization path on each
+  installation/adapter path — initial issuance passed on HA Container with the
+  host's local adapter; no claim is made for reauthorization or another path.
+- [ ] When credential recovery is claimed, exercise explicit replacement and
+  stale-bond removal — neither recovery path was exercised, and no stale bond
+  existed during initial issuance.
+- [x] Confirm coordinator refresh and decoded reads — privacy-safe diagnostics
+  showed a successful update with operational state, telemetry, map, rooms, and
+  pose decoded.
+- [x] Run a hash-only exploratory availability sweep — 40 endpoints: 32
+  populated, 8 empty, and 0 failed.
+- [x] Review privacy-safe diagnostics for protocol drift — protocol remained
+  25; all 40 observed endpoints were healthy, with no endpoint or command
+  failures, active Hermes errors, or Home Assistant issues. Known optional
+  absent/default values are recorded above.
+- [ ] Compare with the preceding firmware snapshot — the repeat v171.10
+  snapshot had no availability or transport changes, but v170 was not observed
+  and the v169.9 decoded-read snapshot was not repeated on this host.
+- [ ] Exercise supported writes deliberately and record exact coverage — not
+  run for this firmware record.
+- [ ] Link sanitized fixtures, tests, issues and pull requests —
+  [issue #31](https://github.com/ProspectOre/matic-home-assistant/issues/31) is
+  filed; add the pull-request link after submission.
+- [x] Update the public ledger and workspace firmware memory — both record the
+  read-verified result and its remaining limits.
+
+Never commit downloaded diagnostics, raw robot payloads, credentials, network or
+device identifiers, maps, room names, Wi-Fi details, or other home data.

--- a/docs/hermes-pairing.md
+++ b/docs/hermes-pairing.md
@@ -1,10 +1,15 @@
 # Local pairing
 
 [Documentation home](README.md) · [Project overview](../README.md) ·
-[Get support](README.md#support)
+[Firmware ledger](firmware-compatibility.md) · [Get support](README.md#support)
 
-Status: verified on a Matic robot with Home Assistant 2026.7 and the built-in
-Bluetooth adapter in Home Assistant Yellow.
+Status: initial pairing and reauthentication were physically verified with Home
+Assistant 2026.7 and the built-in Bluetooth adapter in Home Assistant Yellow.
+Initial pairing was also verified on Home Assistant Container with a local
+BlueZ adapter on an ARM64 Linux host and Matic firmware v171.10 while validating
+the unreleased scanner-cache correction tracked in
+[issue #31](https://github.com/ProspectOre/matic-home-assistant/issues/31). See
+the firmware ledger for version-specific observations.
 
 This independent community integration is not affiliated with, endorsed by, or
 supported by Matic Robots Inc.
@@ -52,13 +57,24 @@ permissions above are required.
 Enable debug logging (`custom_components.matic_robot: debug`) and match the
 repeated line during a failing attempt:
 
-- `Found 0 fresh local Matic advertisement(s)` — the robot is not
-  reaching the local adapter during that scan. Turn Pairing mode off and back
-  on, put the adapter within a few feet of Matic with minimal obstruction, and
-  submit again promptly. If the local adapter still misses fresh advertisements,
-  reload its Home Assistant integration or replug it. If a 10-second
-  `bluetoothctl scan on` on the host hears no devices at all, the host's
-  Bluetooth adapter is wedged — reboot the Home Assistant host.
+- `Found 0 local Matic advertisement cache entry(ies)` — Home Assistant's local
+  connectable scanner does not currently retain a name or service UUID that
+  identifies Matic. Put the adapter within a few feet of Matic with minimal
+  obstruction, enable Pairing mode, and submit again promptly. If the local
+  scanner also cannot hear nearby Bluetooth devices, reload the Bluetooth
+  integration or replug the adapter; if a 10-second `bluetoothctl scan on`
+  still hears nothing, reboot the Home Assistant host. If nearby transmitters
+  remain visible but Matic does not, compare with a phone-side scan and report
+  the installation, adapter, integration, Home Assistant, and firmware
+  versions.
+- Integration 0.3.3 logged `Found 0 fresh local Matic advertisement(s)` when
+  Home Assistant retained an otherwise valid Matic entry whose object and
+  timestamp did not change during one requested scan. Identical advertisements
+  may be deduplicated, so that was not proof that the robot was silent. Version
+  0.3.3 is affected; use issue #31 and its linked pull request to track the
+  correction until a released version is named. As a diagnostic, if BlueZ
+  shows the Matic name and service UUID while 0.3.3 continues to log zero, this
+  known false-negative path is a likely cause.
 - `visible only through a remote Bluetooth proxy` — only ESPHome proxies can
   see the robot. Temporarily disable all Bluetooth proxies while retrying, and
   move or extend the adapter built into or attached to the host closer to
@@ -77,6 +93,13 @@ out distance, obstruction, a stale pairing window, and an adapter that needs a
 reload, replug, or host reboot. Bluetooth proxies are the exception: disable
 them temporarily during a troubled pairing attempt so the local adapter is the
 only Bluetooth path presented to setup.
+
+Initial setup, explicit credential replacement, and reauthentication all need a
+Matic entry in the local scanner cache before the integration can try to connect
+or clear a stale bond. A retained local entry can outlive the live
+advertisement, so a connection-stage failure does not prove pairing started.
+Routine operation is LAN-only while the saved credential remains valid, but an
+owner who later needs credential recovery still depends on this Bluetooth path.
 
 ## Failure behavior
 

--- a/tests/test_bluetooth_pairing.py
+++ b/tests/test_bluetooth_pairing.py
@@ -43,35 +43,17 @@ class _LocalScanner:
 
     def __init__(
         self,
-        devices: list[tuple[SimpleNamespace, SimpleNamespace, float]] | None = None,
+        devices: list[tuple[SimpleNamespace, SimpleNamespace]] | None = None,
         *,
         connectable: bool = True,
         source: str = "local-adapter",
     ) -> None:
         self.connectable = connectable
         self.source = source
-        self.discovered_devices_and_advertisement_data = {
+        self.devices = {
             device.address: (device, advertisement)
-            for device, advertisement, _timestamp in devices or []
+            for device, advertisement in devices or []
         }
-        self.discovered_device_timestamps = {
-            device.address: timestamp
-            for device, _advertisement, timestamp in devices or []
-        }
-
-    def refresh(self, addresses: set[str]) -> None:
-        """Record a new advertisement object for selected addresses."""
-        for address in addresses:
-            device, advertisement = self.discovered_devices_and_advertisement_data[
-                address
-            ]
-            self.discovered_devices_and_advertisement_data[address] = (
-                device,
-                SimpleNamespace(**vars(advertisement)),
-            )
-            self.discovered_device_timestamps[address] = (
-                self.discovered_device_timestamps.get(address, 0.0) + 1.0
-            )
 
 
 class _RemoteScanner(_LocalScanner):
@@ -82,35 +64,70 @@ def _advertisement(
     *,
     address: str = TEST_ADDRESS,
     name: str | None = "Matic Robot",
+    device_name: str | None = None,
     service_uuids: list[str] | None = None,
     rssi: int = -60,
-    timestamp: float = 99.0,
-) -> tuple[SimpleNamespace, SimpleNamespace, float]:
-    device = SimpleNamespace(address=address, name=name, details={"path": "local"})
+) -> tuple[SimpleNamespace, SimpleNamespace]:
+    device = SimpleNamespace(
+        address=address,
+        name=name if device_name is None else device_name,
+        details={"path": "local"},
+    )
     advertisement = SimpleNamespace(
         local_name=name,
         service_uuids=service_uuids or [],
         rssi=rssi,
     )
-    return device, advertisement, timestamp
+    return device, advertisement
 
 
-def _install_bluetooth(monkeypatch, scanners, *, fresh_addresses=None):
-    if fresh_addresses is None:
-        fresh_addresses = {
-            scanner: set(scanner.discovered_devices_and_advertisement_data)
-            for scanner in scanners
-        }
+def _install_bluetooth(monkeypatch, scanners, *, refreshed_addresses=None):
+    paths_by_address = {}
+    for scanner in scanners:
+        for address, (device, advertisement) in scanner.devices.items():
+            paths_by_address.setdefault(address, []).append(
+                SimpleNamespace(
+                    scanner=scanner,
+                    ble_device=device,
+                    advertisement=advertisement,
+                )
+            )
+    service_infos = []
+    for address, paths in paths_by_address.items():
+        strongest = max(paths, key=lambda path: path.advertisement.rssi)
+        advertisement = strongest.advertisement
+        device = strongest.ble_device
+        service_infos.append(
+            SimpleNamespace(
+                address=address,
+                name=advertisement.local_name or device.name or address,
+                service_uuids=advertisement.service_uuids,
+                source=strongest.scanner.source,
+                time=10.0,
+            )
+        )
+    if refreshed_addresses is None:
+        refreshed_addresses = set(paths_by_address)
 
     async def active_scan(_hass, *, duration):
         del duration
-        for scanner, addresses in fresh_addresses.items():
-            scanner.refresh(addresses)
+        for info in service_infos:
+            if info.address in refreshed_addresses:
+                info.time += 1.0
 
     scan = AsyncMock(side_effect=active_scan)
+
+    def scanner_devices_by_address(_hass, address, *, connectable):
+        del connectable
+        return paths_by_address.get(address, [])
+
     bluetooth = SimpleNamespace(
         BaseHaRemoteScanner=_RemoteScanner,
         async_current_scanners=MagicMock(return_value=scanners),
+        async_discovered_service_info=MagicMock(return_value=service_infos),
+        async_scanner_devices_by_address=MagicMock(
+            side_effect=scanner_devices_by_address
+        ),
         async_request_active_scan=scan,
     )
     monkeypatch.setitem(sys.modules, "homeassistant.components.bluetooth", bluetooth)
@@ -616,7 +633,7 @@ async def test_generic_connection_failure_remains_retryable(
     assert TEST_ADDRESS not in str(exc_info.value)
 
 
-async def test_requires_an_active_matic_advertisement(monkeypatch) -> None:
+async def test_requires_a_local_matic_cache_entry(monkeypatch) -> None:
     monkeypatch.setattr(
         bluetooth_pairing,
         "_async_matic_discoveries",
@@ -629,16 +646,16 @@ async def test_requires_an_active_matic_advertisement(monkeypatch) -> None:
         )
 
 
-async def test_discovery_requires_a_fresh_local_result(monkeypatch) -> None:
+async def test_discovery_accepts_an_unchanged_local_cache_entry(monkeypatch) -> None:
     hass = object()
-    fresh = _advertisement(timestamp=99.0)
-    stale = _advertisement(address=OTHER_ADDRESS, timestamp=80.0)
-    scanner = _LocalScanner([fresh, stale])
-    scan = _install_bluetooth(
-        monkeypatch,
-        [scanner],
-        fresh_addresses={scanner: {TEST_ADDRESS}},
+    cached = _advertisement()
+    unrelated = _advertisement(
+        address=OTHER_ADDRESS,
+        name="Other Robot",
+        service_uuids=["0000180f-0000-1000-8000-00805f9b34fb"],
     )
+    scanner = _LocalScanner([cached, unrelated])
+    scan = _install_bluetooth(monkeypatch, [scanner], refreshed_addresses=set())
 
     result = await _async_matic_discoveries(hass)
 
@@ -646,6 +663,17 @@ async def test_discovery_requires_a_fresh_local_result(monkeypatch) -> None:
         hass, duration=bluetooth_pairing.BLUETOOTH_ACTIVE_SCAN_SECONDS
     )
     assert [discovery.device.address for discovery in result] == [TEST_ADDRESS]
+
+
+async def test_discovery_uses_bluez_cached_device_name(monkeypatch) -> None:
+    scanner = _LocalScanner(
+        [_advertisement(name=None, device_name="Robot Matic", service_uuids=[])]
+    )
+    _install_bluetooth(monkeypatch, [scanner], refreshed_addresses=set())
+
+    result = await _async_matic_discoveries(object())
+
+    assert [discovery.name for discovery in result] == ["Robot Matic"]
 
 
 async def test_discovery_identifies_service_uuid_without_a_local_name(
@@ -707,6 +735,26 @@ async def test_discovery_uses_local_path_when_proxy_signal_is_stronger(
     assert result[0].source == "local"
 
 
+async def test_discovery_does_not_share_identity_between_scanner_paths(
+    monkeypatch,
+) -> None:
+    local = _LocalScanner(
+        [
+            _advertisement(
+                name="Other Robot",
+                service_uuids=["0000180f-0000-1000-8000-00805f9b34fb"],
+                rssi=-80,
+            )
+        ],
+        source="local",
+    )
+    remote = _RemoteScanner([_advertisement(rssi=-30)], source="proxy")
+    _install_bluetooth(monkeypatch, [local, remote])
+
+    with pytest.raises(BluetoothProxyOnlyError):
+        await _async_matic_discoveries(object())
+
+
 async def test_discovery_reports_proxy_only_visibility(monkeypatch) -> None:
     local = _LocalScanner([])
     remote = _RemoteScanner([_advertisement()], source="proxy")
@@ -714,6 +762,14 @@ async def test_discovery_reports_proxy_only_visibility(monkeypatch) -> None:
 
     with pytest.raises(BluetoothProxyOnlyError):
         await _async_matic_discoveries(object())
+
+
+async def test_discovery_ignores_stale_proxy_cache_entry(monkeypatch) -> None:
+    local = _LocalScanner([])
+    remote = _RemoteScanner([_advertisement()], source="proxy")
+    _install_bluetooth(monkeypatch, [local, remote], refreshed_addresses=set())
+
+    assert await _async_matic_discoveries(object()) == []
 
 
 async def test_discovery_ignores_nonconnectable_local_scanners(monkeypatch) -> None:


### PR DESCRIPTION
## What changed

- Use Home Assistant's public Bluetooth discovery APIs after the requested active sweep.
- Accept matching entries retained by a directly attached, connectable local scanner without requiring their object or timestamp to change during that sweep.
- Require current-sweep evidence before reporting that Matic is visible only through a remote Bluetooth proxy.
- Preserve the scoped BlueZ agent, displayed-passkey flow, and local-adapter requirement.
- Add regression coverage for an unchanged local cache entry, the BlueZ-cached device-name fallback, stale proxy entries, and scanner-path identity isolation.
- Update pairing diagnostics and troubleshooting, and record the bounded v171.10 pairing and read validation.

## Why

Integration 0.3.3 snapshotted each scanner before requesting an active scan and discarded matching entries whose advertisement object and timestamp did not change during that request. In the observed failure, Home Assistant's local scanner retained a connectable Matic entry with the expected name, exact vendor UUID, and an RSSI near −60 dBm, but the integration still logged `Found 0 fresh`.

A retained local entry may outlive live advertising, so it is treated only as a connection candidate—not as proof that Matic is currently present. The subsequent connection, bonding, and authorization stages determine whether pairing can proceed. A stale local candidate fails safely during connection, while proxy-only reporting still requires a proxy observation refreshed during the current sweep.

## Impact

Initial credential issuance can now proceed when Home Assistant retains a matching local Matic entry without mutating it during the individual scan request. Reauthentication and explicit credential replacement use the same corrected discovery path, although those paths were not live-tested here.

The change does not broaden which scanners may pair, alter the robot protocol, bypass the displayed passkey, expose credentials, or weaken the scoped BlueZ agent. Pairing still requires a directly attached connectable adapter and successful robot authorization.

No release version is assigned by this PR. Integration 0.3.3 remains the affected published version.

## Live validation

Live validation used Matic firmware v171.10, Home Assistant 2026.7.2 Container, and the ARM64 Linux host's local BlueZ adapter. The corrected flow completed local discovery, displayed-passkey entry, bonding, authenticated GATT credential issuance, Hermes authorization, and an authenticated coordinator refresh.

A privacy-safe payload-free sweep covered all 40 known non-credential endpoints: 32 populated, 8 empty, and 0 failed. Reauthentication, explicit credential replacement, stale-bond recovery, and controls were not exercised and are not claimed.

## Validation

- 915 Python tests / 8,548 statements at 100% coverage.
- Ruff lint and formatting.
- Strict MyPy.
- Public-tree privacy gate.
- Successful live initial credential issuance and authenticated reads.
- Hassfest, HACS, Test, and Browser workflows await approval for this fork PR.

Closes #31