### PR TITLE
Credit Pieter Ouwerkerk in 0.3.4 release notes

### DIFF
--- a/docs/release-notes-0.3.4.md
+++ b/docs/release-notes-0.3.4.md
@@ -9,6 +9,12 @@ setup, reauthentication, or explicit credential replacement even when Home
 Assistant's directly attached adapter had already found Matic. Routine robot
 operation remains local-LAN only after authorization.
 
+Thanks to [Pieter Ouwerkerk (`@pouwerkerk`)](https://github.com/pouwerkerk) for
+diagnosing the retained-scanner failure, implementing the fix in
+[PR #30](https://github.com/ProspectOre/matic-home-assistant/pull/30), and
+live-validating initial pairing on the Home Assistant Container/local BlueZ
+path.
+
 ## Reliable local pairing discovery
 
 - Home Assistant may retain a valid Matic scanner entry without replacing its


### PR DESCRIPTION
## Summary

Add explicit contributor credit to the 0.3.4 release notes for Pieter Ouwerkerk (`@pouwerkerk`), linking both his profile and merged PR #30.

## Why

GitHub preserves Pieter's authorship on PR #30 and merge commit `6e862b7`, but the published release notes did not visibly acknowledge his diagnosis, implementation, and live initial-pairing validation. The tracked notes and GitHub release body should present the same attribution.

## Impact

Documentation only. The published `v0.3.4` tag remains immutable.

## Validation

- `git diff --check`
- public-tree privacy check
- 43 public-tree, release-metadata, and release-packaging tests