### PR TITLE
Add Matic Cues and automatic OTA analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ plans, automation, privacy, and troubleshooting.
 Home Assistant 2026.7 is the tested baseline and the minimum version accepted by
 HACS. Compatibility with other Home Assistant releases has not been validated.
 
-The integration has been tested on a real robot and a stock Home Assistant
-Yellow. One robot creates 51 fixed entities — 21 sensors, 12 binary sensors,
-5 buttons, 4 switches, 4 selects, 1 number, 2 cameras, 1 update, and 1 vacuum —
-plus two opt-in room statistics sensors per mapped room.
+The integration has been tested on real robots and Home Assistant Yellow and
+Container installations. One robot creates 55 fixed entities — 23 sensors,
+13 binary sensors, 5 buttons, 4 switches, 4 selects, 1 number, 2 cameras,
+1 event, 1 update, and 1 vacuum — plus two opt-in room statistics sensors per
+mapped room.
 Setup, state, map, cleaning, and settings paths have been exercised on the robot,
 and the integration is covered by automated tests.
 
@@ -38,12 +39,13 @@ and the integration is covered by automated tests.
   photographic SLAM camera and admin-only 3D Map Studio.
 - Activity, battery, rooms, hardware/software/protocol, current area, update,
   Wi-Fi, schedule, local cleaning history, dock/sink, Matter-pairing,
-  robot SSH-tunnel permission, diagnostic-upload state, and persistent firmware
-  compatibility health.
-- Controls for child lock, pet-waste avoidance, Hey Matic, double-pass mopping,
+  robot SSH-tunnel permission, diagnostic-upload state, Cues voice/gesture
+  lifecycle and following state, and persistent firmware compatibility health.
+- Controls for child lock, pet-waste avoidance, Matic Cues, double-pass mopping,
   and water flow.
-- Payload-free endpoint inspection and persistent weekly firmware compatibility
-  snapshots for every known non-credential Hermes read surface.
+- Payload-free endpoint inspection and automatic firmware compatibility
+  snapshots for every known non-credential Hermes read surface, including
+  bounded value-free wire-shape candidates for newly added protocol fields.
 
 ## Home Assistant capabilities
 
@@ -72,8 +74,11 @@ The integration adds Home Assistant-native planning and automation:
 - **Plan operations as actions.** Preview, run, stop-and-dock, history
   reset, and plan management are Home Assistant actions, so schedules,
   presence, and scripts can drive them unattended.
-- **Hey Matic control.** Enable or disable the robot's voice activation
-  from a switch — and therefore from any automation, scene, or schedule.
+- **Matic Cues.** Enable or disable Cues from a switch, observe its live voice
+  and gesture lifecycle, react to classified cleaning/navigation/following
+  intents, and use following-person state in automations. The integration
+  exposes only classifications and lifecycle state: no transcript, audio,
+  image, video, person identity, or pointing coordinate enters Home Assistant.
 - **Room-level automation events.** `room_started`, `room_completed`,
   `room_failed`, `room_interrupted`, `room_cancelled`, and
   `room_ended_unverified` events per run, with Home Assistant Area-to-room
@@ -103,6 +108,14 @@ Camera and microphone recording, clip retrieval and caching, recording metadata,
 and vendor share or discard decisions are not included because these
 privacy-sensitive support operations can have external or irreversible effects.
 See [Recording-related protocol notes](docs/recording-protocol.md).
+
+The Cues switch changes a local robot setting, but enabling it opts the robot
+into Matic's documented Cues processing. Matic says wake-word, direction, and
+gesture processing happen on-device, while audio after the chime is sent to
+Google Gemini; video is not sent. Review Matic's
+[Cues overview](https://maticrobots.com/hey-matic) and
+[voice-data explanation](https://maticrobots.com/blog/how-your-voice-data-is-handled)
+before enabling it.
 
 ## Install
 
@@ -216,9 +229,12 @@ uses the LAN.
   unofficial local protocol integration. Check the
   [firmware compatibility ledger](docs/firmware-compatibility.md) for observed
   versions and validation status. A newly observed version emits the
-  `matic_robot_firmware_changed` event; run the **Firmware snapshot** action to
-  compare all known read endpoints with the prior snapshot. A Repair is created
-  only when that comparison finds compatibility drift.
+  `matic_robot_firmware_changed` event and automatically compares all known read
+  endpoints with the prior snapshot. `matic_robot_firmware_analyzed` carries a
+  silent, payload-free result for advanced automations; the **Firmware
+  snapshot** action remains available for a deliberate repeat. A Repair is
+  created only when the comparison finds endpoint availability or transport
+  drift, never merely because a new structural candidate appeared.
 - Rooms without an exact Area name or unique alias require one manual mapping.
 - Managed plans require unique mapped room names because the robot's completion
   ledger identifies rooms by name. Duplicate names are blocked before motion

--- a/custom_components/matic_robot/__init__.py
+++ b/custom_components/matic_robot/__init__.py
@@ -143,6 +143,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: MaticConfigEntry) -> boo
             slam_history,
         )
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+        entry.async_create_background_task(
+            hass,
+            coordinator.async_watch_cues(),
+            f"{DOMAIN} Cues state collector",
+        )
         _schedule_native_reconciliation_recovery(
             hass,
             entry,

--- a/custom_components/matic_robot/binary_sensor.py
+++ b/custom_components/matic_robot/binary_sensor.py
@@ -110,6 +110,12 @@ DESCRIPTIONS = (
         entity_registry_enabled_default=False,
         value_fn=lambda state: state.telemetry.uploader_opt_in,
     ),
+    MaticBinarySensorDescription(
+        key="following_person",
+        translation_key="following_person",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        value_fn=lambda state: state.operational.following_person,
+    ),
 )
 
 

--- a/custom_components/matic_robot/client/api.py
+++ b/custom_components/matic_robot/client/api.py
@@ -856,42 +856,50 @@ class MaticHermesClient(AbstractAsyncContextManager["MaticHermesClient"]):
         channel = self._channel
         if channel is None:
             raise CannotConnectError("Hermes channel did not open")
+        failed_channel = channel
         request = CollectionRequest(
             initial_request=InitialRequest(
                 collection_name=collection_name,
                 config=SubscriptionServiceConfig(),
             )
         )
-        async with self._map_stream_errors(f"{collection_name} subscription"):
-            async with HermesStub(channel).FetchCollection.open(
-                metadata=self._metadata
-            ) as stream:
-                # FetchCollection is a tracked bidirectional subscription.  The
-                # server sends one update, then waits for its sequence id to be
-                # acknowledged before advancing to the next cached or live item.
-                try:
-                    await stream.send_message(request, end=False)
-                    while (response := await stream.recv_message()) is not None:
-                        entry = None
-                        if response.HasField("value"):
-                            entry = HermesCollectionEntry(
-                                bytes(response.key_bytes),
-                                _response_value_bytes(response),
-                            )
-                        if response.HasField("sequence_id"):
-                            await stream.send_message(
-                                CollectionRequest(sequence_id=response.sequence_id),
-                                end=False,
-                            )
-                        if entry is not None:
-                            yield entry
-                finally:
-                    # Long-lived bidirectional streams otherwise attempt a
-                    # graceful close during config-entry teardown. A robot that
-                    # is still holding the subscription open can leave Home
-                    # Assistant waiting for that handshake until its task-leak
-                    # timeout. Explicit cancellation is local, bounded cleanup.
-                    await _async_cancel_stream(stream)
+        try:
+            async with self._map_stream_errors(f"{collection_name} subscription"):
+                async with HermesStub(channel).FetchCollection.open(
+                    metadata=self._metadata
+                ) as stream:
+                    # FetchCollection is a tracked bidirectional subscription.  The
+                    # server sends one update, then waits for its sequence id to be
+                    # acknowledged before advancing to the next cached or live item.
+                    try:
+                        await stream.send_message(request, end=False)
+                        while (response := await stream.recv_message()) is not None:
+                            entry = None
+                            if response.HasField("value"):
+                                entry = HermesCollectionEntry(
+                                    bytes(response.key_bytes),
+                                    _response_value_bytes(response),
+                                )
+                            if response.HasField("sequence_id"):
+                                await stream.send_message(
+                                    CollectionRequest(sequence_id=response.sequence_id),
+                                    end=False,
+                                )
+                            if entry is not None:
+                                yield entry
+                    finally:
+                        # Long-lived bidirectional streams otherwise attempt a
+                        # graceful close during config-entry teardown. A robot that
+                        # is still holding the subscription open can leave Home
+                        # Assistant waiting for that handshake until its task-leak
+                        # timeout. Explicit cancellation is local, bounded cleanup.
+                        await _async_cancel_stream(stream)
+        except CannotConnectError:
+            _LOGGER.debug(
+                "Replacing failed Hermes %s subscription channel", collection_name
+            )
+            await self._async_reconnect_after_read_failure(failed_channel)
+            raise
 
     async def async_get_tracked_collection_entries(
         self,

--- a/custom_components/matic_robot/client/api.py
+++ b/custom_components/matic_robot/client/api.py
@@ -55,6 +55,9 @@ from .models import (
     CleaningSchedule,
     CleaningSession,
     CleaningSessionRecord,
+    CuesGestureStatus,
+    CuesIntent,
+    CuesVoiceStatus,
     FloorPlan,
     HermesCollectionEntry,
     RobotInfo,
@@ -468,6 +471,16 @@ class MaticHermesClient(AbstractAsyncContextManager["MaticHermesClient"]):
             return _decode_operational_state(payload)
         except DecodeError as err:
             raise CannotConnectError("Hermes returned malformed robot state") from err
+
+    async def async_subscribe_state(self) -> AsyncIterator[RobotOperationalState]:
+        """Yield live snapshots from the local ``kabuki_state`` property."""
+        async for entry in self.async_subscribe_collection_entries("kabuki_state"):
+            try:
+                yield _decode_operational_state(entry.value)
+            except DecodeError as err:
+                raise CannotConnectError(
+                    "Hermes returned malformed subscribed robot state"
+                ) from err
 
     async def async_get_floor_plan(self) -> FloorPlan:
         """Read and decode the active local coverage plan."""
@@ -1088,6 +1101,9 @@ class MaticHermesClient(AbstractAsyncContextManager["MaticHermesClient"]):
 def _decode_operational_state(payload: bytes) -> RobotOperationalState:
     """Decode the verified subset of Matic's internal Kabuki output."""
     wire = KabukiOutputWire.FromString(payload)
+    voice_status, voice_intent, gesture_status, following_person = _decode_cues_state(
+        payload
+    )
     percentage = None
     if wire.HasField("battery_fraction") and math.isfinite(wire.battery_fraction):
         percentage = max(0, min(100, round(wire.battery_fraction * 100)))
@@ -1107,7 +1123,133 @@ def _decode_operational_state(payload: bytes) -> RobotOperationalState:
         current_area=_decode_text_field(payload, 16),
         previous_area=_decode_text_field(payload, 14),
         robot_profile=_decode_text_field(payload, 17),
+        cues_voice_status=voice_status,
+        cues_voice_intent=voice_intent,
+        cues_gesture_status=gesture_status,
+        following_person=following_person,
     )
+
+
+_CUES_INTENTS_BY_FIELD = {
+    1: CuesIntent.CLEAN,
+    2: CuesIntent.DOCK,
+    3: CuesIntent.PAUSE,
+    4: CuesIntent.RESUME,
+    5: CuesIntent.STOP,
+    6: CuesIntent.FOLLOW_PERSON,
+    7: CuesIntent.SINK_SUMMON,
+    8: CuesIntent.NAVIGATE,
+    # Fields 9, 10, and 17 are recording-only intents. Deliberately collapse
+    # those classifications to UNKNOWN: this client does not expose Matic's
+    # recording features or create an automation signal around them.
+    9: CuesIntent.UNKNOWN,
+    10: CuesIntent.UNKNOWN,
+    11: CuesIntent.REDO_LAST_CLEAN,
+    12: CuesIntent.CLEAN_ALL,
+    13: CuesIntent.POINT_TO_CLEAN,
+    14: CuesIntent.POINT_TO_CLEAN,
+    15: CuesIntent.GO_AWAY,
+    16: CuesIntent.UNKNOWN,
+    17: CuesIntent.UNKNOWN,
+    # Firmware retains both legacy and current CleaningIntent tags.
+    18: CuesIntent.CLEAN,
+}
+
+_CUES_GESTURES_BY_FIELD = {
+    1: CuesGestureStatus.AWAITING_POINTED_TARGET,
+    2: CuesGestureStatus.POINTED_TARGET_ACCEPTED,
+    3: CuesGestureStatus.NO_TARGET_FOUND,
+    4: CuesGestureStatus.FACING_USER,
+    5: CuesGestureStatus.PERSON_NOT_FOUND,
+    6: CuesGestureStatus.FOLLOWING,
+}
+
+
+def _decode_cues_state(
+    payload: bytes,
+) -> tuple[
+    CuesVoiceStatus | None,
+    CuesIntent | None,
+    CuesGestureStatus | None,
+    bool | None,
+]:
+    """Decode the non-media Cues subset of Kabuki's repeated payloads."""
+    voice_status: CuesVoiceStatus | None = None
+    voice_intent: CuesIntent | None = None
+    gesture_status: CuesGestureStatus | None = None
+    following_person: bool | None = None
+    for output_field in decode_fields(payload):
+        if (
+            output_field.number != 18
+            or output_field.wire_type != 2
+            or not isinstance(output_field.value, bytes)
+        ):
+            continue
+        for cues_field in decode_fields(output_field.value):
+            if cues_field.number == 17 and cues_field.wire_type == 2:
+                assert isinstance(cues_field.value, bytes)
+                voice_status, voice_intent = _decode_cues_voice_status(cues_field.value)
+                if following_person is None:
+                    following_person = False
+            elif cues_field.number == 20 and cues_field.wire_type == 2:
+                # Following is represented by presence of a unit payload.
+                following_person = True
+            elif cues_field.number == 21 and cues_field.wire_type == 2:
+                assert isinstance(cues_field.value, bytes)
+                gesture_status = _decode_cues_gesture_status(cues_field.value)
+                if following_person is None:
+                    following_person = False
+    return voice_status, voice_intent, gesture_status, following_person
+
+
+def _decode_cues_voice_status(
+    payload: bytes,
+) -> tuple[CuesVoiceStatus | None, CuesIntent | None]:
+    """Decode Matic's VoiceStatus oneof without retaining voice content."""
+    status: CuesVoiceStatus | None = None
+    intent: CuesIntent | None = None
+    for field in decode_fields(payload):
+        if field.wire_type != 2 or not isinstance(field.value, bytes):
+            continue
+        if field.number == 1:
+            status = CuesVoiceStatus.DISABLED
+            intent = None
+        elif field.number == 2:
+            status = CuesVoiceStatus.LISTENING_FOR_WAKE_WORD
+            intent = None
+        elif field.number == 3:
+            status = CuesVoiceStatus.CLASSIFIED
+            intent = _decode_cues_intent(field.value)
+        elif field.number == 4:
+            # Rejection details can contain user-derived context. Only expose
+            # the lifecycle result needed for an automation trigger.
+            status = CuesVoiceStatus.REJECTED
+            intent = None
+        elif field.number == 5:
+            status = CuesVoiceStatus.LISTENING_FOR_INTENT
+            intent = None
+        elif field.number == 6:
+            status = CuesVoiceStatus.THINKING_FOR_INTENT
+            intent = None
+    return status, intent
+
+
+def _decode_cues_intent(payload: bytes) -> CuesIntent:
+    """Decode the classified intent kind, excluding recording-only variants."""
+    intent = CuesIntent.UNKNOWN
+    for field in decode_fields(payload):
+        if field.wire_type == 2 and isinstance(field.value, bytes):
+            intent = _CUES_INTENTS_BY_FIELD.get(field.number, CuesIntent.UNKNOWN)
+    return intent
+
+
+def _decode_cues_gesture_status(payload: bytes) -> CuesGestureStatus | None:
+    """Decode Matic's gesture lifecycle oneof without coordinates or imagery."""
+    status = None
+    for field in decode_fields(payload):
+        if field.wire_type == 2 and isinstance(field.value, bytes):
+            status = _CUES_GESTURES_BY_FIELD.get(field.number, status)
+    return status
 
 
 def _decode_current_version(

--- a/custom_components/matic_robot/client/models.py
+++ b/custom_components/matic_robot/client/models.py
@@ -34,6 +34,46 @@ class RobotActivity(StrEnum):
     READY = "ready"
 
 
+class CuesVoiceStatus(StrEnum):
+    """Privacy-safe Matic Cues voice lifecycle reported by the robot."""
+
+    DISABLED = "disabled"
+    LISTENING_FOR_WAKE_WORD = "listening_for_wake_word"
+    LISTENING_FOR_INTENT = "listening_for_intent"
+    THINKING_FOR_INTENT = "thinking_for_intent"
+    CLASSIFIED = "classified"
+    REJECTED = "rejected"
+
+
+class CuesGestureStatus(StrEnum):
+    """Privacy-safe Matic Cues gesture lifecycle reported by the robot."""
+
+    AWAITING_POINTED_TARGET = "awaiting_pointed_target"
+    POINTED_TARGET_ACCEPTED = "pointed_target_accepted"
+    NO_TARGET_FOUND = "no_target_found"
+    FACING_USER = "facing_user"
+    PERSON_NOT_FOUND = "person_not_found"
+    FOLLOWING = "following"
+
+
+class CuesIntent(StrEnum):
+    """Automation-safe intent classifications exposed by Matic Cues."""
+
+    CLEAN = "clean"
+    CLEAN_ALL = "clean_all"
+    DOCK = "dock"
+    GO_AWAY = "go_away"
+    NAVIGATE = "navigate"
+    PAUSE = "pause"
+    REDO_LAST_CLEAN = "redo_last_clean"
+    RESUME = "resume"
+    SINK_SUMMON = "sink_summon"
+    STOP = "stop"
+    FOLLOW_PERSON = "follow_person"
+    POINT_TO_CLEAN = "point_to_clean"
+    UNKNOWN = "unknown"
+
+
 @dataclass(frozen=True, slots=True)
 class RobotOperationalState:
     """Verified fields from the local ``kabuki_state`` property."""
@@ -52,6 +92,10 @@ class RobotOperationalState:
     current_area: str | None = None
     previous_area: str | None = None
     robot_profile: str | None = None
+    cues_voice_status: CuesVoiceStatus | None = None
+    cues_voice_intent: CuesIntent | None = None
+    cues_gesture_status: CuesGestureStatus | None = None
+    following_person: bool | None = None
 
     @property
     def activity(self) -> RobotActivity:

--- a/custom_components/matic_robot/client/wire.py
+++ b/custom_components/matic_robot/client/wire.py
@@ -8,6 +8,12 @@ from uuid import UUID
 
 from google.protobuf.message import DecodeError
 
+MAX_WIRE_SHAPE_BYTES = 64 * 1024
+MAX_WIRE_SHAPE_FIELDS = 256
+MAX_WIRE_SHAPE_DEPTH = 4
+
+type WireShapePath = tuple[tuple[int, int], ...]
+
 
 @dataclass(frozen=True, slots=True)
 class WireField:
@@ -16,6 +22,10 @@ class WireField:
     number: int
     wire_type: int
     value: int | bytes
+
+
+class _WireShapeLimitError(Exception):
+    """Signal that a structural fingerprint exceeded its public bounds."""
 
 
 def decode_fields(payload: bytes) -> tuple[WireField, ...]:
@@ -42,6 +52,68 @@ def decode_fields(payload: bytes) -> tuple[WireField, ...]:
             raise DecodeError(f"unsupported protobuf wire type {wire_type}")
         fields.append(WireField(number, wire_type, value))
     return tuple(fields)
+
+
+def wire_shape(
+    payload: bytes,
+    *,
+    nested_message_paths: tuple[tuple[int, ...], ...] = (),
+) -> tuple[str, ...] | None:
+    """Return a bounded, value-free protobuf structural fingerprint.
+
+    Every observed field contributes only its number and protobuf wire type.
+    Repeated occurrences collapse into one path, so collection sizes and other
+    activity-dependent counts are not retained. Length-delimited values are
+    traversed only along explicitly approved message paths; strings, media,
+    coordinates, and other opaque bytes are never interpreted or persisted.
+
+    ``None`` means the value was too large, too complex, or not a protobuf
+    message. A valid empty protobuf message returns an empty tuple.
+    """
+    if len(payload) > MAX_WIRE_SHAPE_BYTES:
+        return None
+    approved_paths = {
+        path
+        for path in nested_message_paths
+        if path and len(path) <= MAX_WIRE_SHAPE_DEPTH
+    }
+    shapes: set[WireShapePath] = set()
+    field_count = 0
+
+    def visit(
+        message: bytes,
+        number_path: tuple[int, ...],
+        shape_path: WireShapePath,
+    ) -> None:
+        nonlocal field_count
+        fields = decode_fields(message)
+        field_count += len(fields)
+        if field_count > MAX_WIRE_SHAPE_FIELDS:
+            raise _WireShapeLimitError
+        for field in fields:
+            child_numbers = (*number_path, field.number)
+            child_shape = (*shape_path, (field.number, field.wire_type))
+            shapes.add(child_shape)
+            if (
+                field.wire_type == 2
+                and isinstance(field.value, bytes)
+                and child_numbers in approved_paths
+            ):
+                try:
+                    visit(field.value, child_numbers, child_shape)
+                except DecodeError:
+                    # The approved field was populated with an opaque or
+                    # malformed value. Retain its outer shape only.
+                    continue
+
+    try:
+        visit(payload, (), ())
+    except DecodeError, _WireShapeLimitError:
+        return None
+    return tuple(
+        "/".join(f"{number}:{wire_type}" for number, wire_type in path)
+        for path in sorted(shapes)
+    )
 
 
 def bytes_fields(payload: bytes, number: int) -> tuple[bytes, ...]:

--- a/custom_components/matic_robot/const.py
+++ b/custom_components/matic_robot/const.py
@@ -7,6 +7,7 @@ PLATFORMS: Final = [
     "binary_sensor",
     "button",
     "camera",
+    "event",
     "number",
     "select",
     "sensor",
@@ -33,4 +34,23 @@ DATA_FIRMWARE_TRACKER: Final = "firmware_tracker"
 DATA_SLAM_MAP_STORE: Final = "slam_map_store"
 
 EVENT_FIRMWARE_CHANGED: Final = f"{DOMAIN}_firmware_changed"
+EVENT_FIRMWARE_ANALYZED: Final = f"{DOMAIN}_firmware_analyzed"
 EVENT_CLEANING_FINISHED: Final = f"{DOMAIN}_cleaning_finished"
+EVENT_CUES: Final = f"{DOMAIN}_cues"
+
+CUES_EVENT_TYPES: Final = (
+    "disabled",
+    "ready",
+    "wake_word_detected",
+    "intent_processing",
+    "intent_classified",
+    "intent_rejected",
+    "gesture_awaiting_pointed_target",
+    "gesture_pointed_target_accepted",
+    "gesture_no_target_found",
+    "gesture_facing_user",
+    "gesture_person_not_found",
+    "gesture_following",
+    "following_started",
+    "following_stopped",
+)

--- a/custom_components/matic_robot/coordinator.py
+++ b/custom_components/matic_robot/coordinator.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from dataclasses import replace
+from collections.abc import Callable
+from dataclasses import dataclass, replace
 from datetime import datetime, timedelta
 from functools import partial
 from time import monotonic
@@ -28,6 +29,7 @@ from .client.exceptions import (
     MaticError,
 )
 from .client.models import (
+    CuesVoiceStatus,
     FloorPlan,
     RobotInfo,
     RobotOperationalState,
@@ -36,8 +38,10 @@ from .client.models import (
     RobotTelemetry,
 )
 from .const import (
+    CUES_EVENT_TYPES,
     DOMAIN,
     EVENT_CLEANING_FINISHED,
+    EVENT_CUES,
     MAP_UPDATE_INTERVAL_SECONDS,
     SLOW_UPDATE_INTERVAL_SECONDS,
     UPDATE_INTERVAL_SECONDS,
@@ -55,8 +59,16 @@ SNAPSHOT_MAX_ATTEMPTS = 3
 ERROR_CONFIRMATION_POLLS = 2
 
 
+@dataclass(frozen=True, slots=True)
+class MaticCuesEvent:
+    """One privacy-safe Cues lifecycle event."""
+
+    event_type: str
+    attributes: dict[str, str]
+
+
 class MaticCoordinator(DataUpdateCoordinator[RobotState]):
-    """Coordinate local robot metadata and, later, push subscriptions."""
+    """Coordinate local robot snapshots and Cues push updates."""
 
     config_entry: ConfigEntry
 
@@ -98,6 +110,69 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
         self._pending_error_codes: tuple[int, ...] = ()
         self._pending_error_polls = 0
         self._identity_issue_active = False
+        self._cues_listeners: set[Callable[[MaticCuesEvent], None]] = set()
+
+    async def async_watch_cues(self) -> None:
+        """Keep Cues lifecycle state current between coordinator polls."""
+        retry_delay = 1
+        while True:
+            try:
+                async for state in self.client.async_subscribe_state():
+                    retry_delay = 1
+                    self.async_process_cues_state(state)
+            except asyncio.CancelledError:
+                raise
+            except MaticError as err:
+                _LOGGER.debug("Matic Cues subscription interrupted: %s", err)
+            await asyncio.sleep(retry_delay)
+            retry_delay = min(retry_delay * 2, 60)
+
+    @callback
+    def async_process_cues_state(self, state: RobotOperationalState) -> None:
+        """Merge a live Cues snapshot and emit meaningful transitions."""
+        if self.data is None:
+            return
+        previous = self.data.operational
+        current = replace(
+            previous,
+            cues_voice_status=state.cues_voice_status,
+            cues_voice_intent=state.cues_voice_intent,
+            cues_gesture_status=state.cues_gesture_status,
+            following_person=state.following_person,
+        )
+        if current == previous:
+            return
+        self.async_set_updated_data(replace(self.data, operational=current))
+        for event in _cues_events(previous, current):
+            self._async_fire_cues_event(event)
+
+    @callback
+    def async_add_cues_listener(
+        self, listener: Callable[[MaticCuesEvent], None]
+    ) -> Callable[[], None]:
+        """Subscribe an entity to privacy-safe Cues events."""
+        self._cues_listeners.add(listener)
+
+        def _remove_listener() -> None:
+            self._cues_listeners.discard(listener)
+
+        return _remove_listener
+
+    @callback
+    def _async_fire_cues_event(self, event: MaticCuesEvent) -> None:
+        """Publish one Cues transition to HA and the Cues event entity."""
+        assert event.event_type in CUES_EVENT_TYPES
+        self.hass.bus.async_fire(
+            EVENT_CUES,
+            {
+                "entry_id": self.config_entry.entry_id,
+                "device_id": self._device_id(self.data.info.serial_number),
+                "event_type": event.event_type,
+                **event.attributes,
+            },
+        )
+        for listener in tuple(self._cues_listeners):
+            listener(event)
 
     async def _async_update_data(self) -> RobotState:
         try:
@@ -443,3 +518,59 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
             return
         registry.async_update_device(device.id, sw_version=version)
         self._device_software_version = version
+
+
+def _cues_events(
+    previous: RobotOperationalState, current: RobotOperationalState
+) -> tuple[MaticCuesEvent, ...]:
+    """Return safe automation events represented by one Cues transition."""
+    events: list[MaticCuesEvent] = []
+    if previous.cues_voice_status != current.cues_voice_status:
+        voice_event = None
+        if current.cues_voice_status is not None:
+            voice_event = {
+                CuesVoiceStatus.DISABLED: "disabled",
+                CuesVoiceStatus.LISTENING_FOR_WAKE_WORD: "ready",
+                CuesVoiceStatus.LISTENING_FOR_INTENT: "wake_word_detected",
+                CuesVoiceStatus.THINKING_FOR_INTENT: "intent_processing",
+                CuesVoiceStatus.CLASSIFIED: "intent_classified",
+                CuesVoiceStatus.REJECTED: "intent_rejected",
+            }.get(current.cues_voice_status)
+        if voice_event is not None:
+            attributes = {}
+            if (
+                current.cues_voice_status is CuesVoiceStatus.CLASSIFIED
+                and current.cues_voice_intent is not None
+            ):
+                attributes["intent"] = current.cues_voice_intent.value
+            events.append(MaticCuesEvent(voice_event, attributes))
+    elif (
+        current.cues_voice_status is CuesVoiceStatus.CLASSIFIED
+        and previous.cues_voice_intent != current.cues_voice_intent
+    ):
+        attributes = (
+            {"intent": current.cues_voice_intent.value}
+            if current.cues_voice_intent is not None
+            else {}
+        )
+        events.append(MaticCuesEvent("intent_classified", attributes))
+
+    if previous.cues_gesture_status != current.cues_gesture_status:
+        if current.cues_gesture_status is not None:
+            events.append(
+                MaticCuesEvent(
+                    f"gesture_{current.cues_gesture_status.value}",
+                    {},
+                )
+            )
+    if previous.following_person != current.following_person:
+        if current.following_person is True:
+            events.append(MaticCuesEvent("following_started", {}))
+        elif previous.following_person is True and current.following_person is False:
+            events.append(
+                MaticCuesEvent(
+                    "following_stopped",
+                    {},
+                )
+            )
+    return tuple(events)

--- a/custom_components/matic_robot/coordinator.py
+++ b/custom_components/matic_robot/coordinator.py
@@ -111,14 +111,19 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
         self._pending_error_polls = 0
         self._identity_issue_active = False
         self._cues_listeners: set[Callable[[MaticCuesEvent], None]] = set()
+        self._latest_cues_state: RobotOperationalState | None = None
+        self._cues_push_sequence = 0
 
     async def async_watch_cues(self) -> None:
         """Keep Cues lifecycle state current between coordinator polls."""
         retry_delay = 1
         while True:
             try:
+                states_received = 0
                 async for state in self.client.async_subscribe_state():
-                    retry_delay = 1
+                    states_received += 1
+                    if states_received > 1:
+                        retry_delay = 1
                     self.async_process_cues_state(state)
             except asyncio.CancelledError:
                 raise
@@ -130,6 +135,8 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
     @callback
     def async_process_cues_state(self, state: RobotOperationalState) -> None:
         """Merge a live Cues snapshot and emit meaningful transitions."""
+        self._latest_cues_state = state
+        self._cues_push_sequence += 1
         if self.data is None:
             return
         previous = self.data.operational
@@ -175,6 +182,7 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
             listener(event)
 
     async def _async_update_data(self) -> RobotState:
+        cues_push_sequence = self._cues_push_sequence
         try:
             info, operational, floor_plan, pose, telemetry = await asyncio.gather(
                 self._async_info(),
@@ -222,6 +230,19 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
                         ),
                         f"{DOMAIN} firmware snapshot",
                     )
+            if self._cues_push_sequence != cues_push_sequence:
+                latest_cues_state = self._latest_cues_state
+                assert latest_cues_state is not None
+                state = replace(
+                    state,
+                    operational=replace(
+                        state.operational,
+                        cues_voice_status=latest_cues_state.cues_voice_status,
+                        cues_voice_intent=latest_cues_state.cues_voice_intent,
+                        cues_gesture_status=latest_cues_state.cues_gesture_status,
+                        following_person=latest_cues_state.following_person,
+                    ),
+                )
             return state
         except AuthenticationRequiredError as err:
             raise ConfigEntryAuthFailed(

--- a/custom_components/matic_robot/event.py
+++ b/custom_components/matic_robot/event.py
@@ -1,0 +1,53 @@
+"""Privacy-safe Matic Cues events."""
+
+from __future__ import annotations
+
+from homeassistant.components.event import EventEntity, EventEntityDescription
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import MaticConfigEntry
+from .const import CUES_EVENT_TYPES
+from .coordinator import MaticCuesEvent
+from .entity import MaticEntity
+
+PARALLEL_UPDATES = 0
+
+CUES_DESCRIPTION = EventEntityDescription(
+    key="cues",
+    translation_key="cues",
+    event_types=list(CUES_EVENT_TYPES),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: MaticConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Matic Cues event entity."""
+    async_add_entities([MaticCuesEventEntity(entry)])
+
+
+class MaticCuesEventEntity(MaticEntity, EventEntity):
+    """Expose Cues voice and gesture lifecycle events to automations."""
+
+    entity_description = CUES_DESCRIPTION
+    _unrecorded_attributes = frozenset({"intent"})
+
+    def __init__(self, entry: MaticConfigEntry) -> None:
+        super().__init__(entry)
+        self._attr_unique_id = f"{self.coordinator.data.info.serial_number}_cues"
+
+    async def async_added_to_hass(self) -> None:
+        """Listen for live Cues transitions."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self.coordinator.async_add_cues_listener(self._async_cues_event)
+        )
+
+    @callback
+    def _async_cues_event(self, event: MaticCuesEvent) -> None:
+        """Record one Cues lifecycle event on this entity."""
+        self._trigger_event(event.event_type, event.attributes)
+        self.async_write_ha_state()

--- a/custom_components/matic_robot/firmware.py
+++ b/custom_components/matic_robot/firmware.py
@@ -17,11 +17,23 @@ from .client.api import MaticHermesClient
 from .client.endpoints import HERMES_ENDPOINTS, HermesEndpoint
 from .client.exceptions import MaticError
 from .client.models import HermesCollectionEntry, RobotState
-from .const import DOMAIN, EVENT_FIRMWARE_CHANGED
+from .client.wire import wire_shape
+from .const import DOMAIN, EVENT_FIRMWARE_ANALYZED, EVENT_FIRMWARE_CHANGED
 
 STORAGE_VERSION = 1
 STORAGE_KEY = f"{DOMAIN}.firmware"
 MAX_HISTORY = 52
+ANALYSIS_VERSION = 1
+
+# Length-delimited values are opaque unless their message nesting has direct
+# protocol evidence. Root fields are safe to fingerprint on every bounded
+# value; these are the only approved recursive paths. They cover Kabuki's
+# repeated state envelopes plus the privacy-safe Cues voice and gesture
+# lifecycle. It deliberately stops before classified intent, rejection detail,
+# target data, coordinates, media, and every other nested opaque value.
+WIRE_SHAPE_NESTED_PATHS: dict[str, tuple[tuple[int, ...], ...]] = {
+    "kabuki_state": ((18,), (18, 17), (18, 21)),
+}
 
 
 class FirmwareTracker:
@@ -131,6 +143,16 @@ class FirmwareTracker:
                 "content_changed_endpoints": len(
                     release_comparison["content_changed_endpoints"]
                 ),
+                "wire_shape_changed_endpoints": len(
+                    release_comparison["wire_shape_changed_endpoints"]
+                ),
+                "new_wire_shape_count": sum(
+                    len(shapes)
+                    for shapes in release_comparison["new_wire_shapes"].values()
+                ),
+                "wire_shape_candidate_endpoints": release_comparison[
+                    "wire_shape_changed_endpoints"
+                ],
             }
             history.append(current)
             del history[:-MAX_HISTORY]
@@ -169,6 +191,36 @@ class FirmwareTracker:
             )
         elif release_comparison["baseline"] or release_changed:
             ir.async_delete_issue(self.hass, DOMAIN, self.issue_id(robot_id))
+        snapshot_release_changed = bool(
+            comparison["firmware_changed"] or comparison["protocol_changed"]
+        )
+        if snapshot_release_changed:
+            self.hass.bus.async_fire(
+                EVENT_FIRMWARE_ANALYZED,
+                {
+                    "entry_id": robot_id,
+                    "firmware_version": current.get("firmware_version"),
+                    "protocol_version": current.get("protocol_version"),
+                    "compatibility_status": robot["compatibility_status"],
+                    "analysis_version": current.get("analysis_version"),
+                    "structural_endpoints": current.get("structural_endpoints"),
+                    "wire_shape_count": current.get("wire_shape_count"),
+                    "availability_changed_endpoints": len(
+                        release_comparison["changed_endpoints"]
+                    ),
+                    "content_changed_endpoints": len(
+                        release_comparison["content_changed_endpoints"]
+                    ),
+                    "wire_shape_changed_endpoints": release_comparison[
+                        "wire_shape_changed_endpoints"
+                    ],
+                    "new_wire_shape_count": sum(
+                        len(shapes)
+                        for shapes in release_comparison["new_wire_shapes"].values()
+                    ),
+                    "new_wire_shapes": release_comparison["new_wire_shapes"],
+                },
+            )
         return comparison
 
     def summary(self, robot_id: str) -> dict[str, Any]:
@@ -180,14 +232,24 @@ class FirmwareTracker:
             "observed_version": robot.get("observed_version"),
             "observed_protocol": robot.get("observed_protocol"),
             "compatibility_status": robot.get("compatibility_status", "pending"),
+            "analysis_version": snapshot.get("analysis_version"),
             "last_snapshot_at": snapshot.get("captured_at"),
             "snapshot_count": len(robot.get("history", [])),
             "endpoint_count": snapshot.get("endpoint_count"),
             "populated_endpoints": snapshot.get("populated_endpoints"),
             "empty_endpoints": snapshot.get("empty_endpoints"),
             "failed_endpoints": snapshot.get("failed_endpoints"),
+            "structural_endpoints": snapshot.get("structural_endpoints"),
+            "wire_shape_count": snapshot.get("wire_shape_count"),
             "changed_endpoints": comparison.get("changed_endpoints"),
             "content_changed_endpoints": comparison.get("content_changed_endpoints"),
+            "wire_shape_changed_endpoints": comparison.get(
+                "wire_shape_changed_endpoints"
+            ),
+            "new_wire_shape_count": comparison.get("new_wire_shape_count"),
+            "wire_shape_candidate_endpoints": comparison.get(
+                "wire_shape_candidate_endpoints", []
+            ),
         }
 
     def needs_snapshot(self, robot_id: str, version: str, protocol: int | None) -> bool:
@@ -196,6 +258,7 @@ class FirmwareTracker:
         return bool(
             snapshot.get("firmware_version") != version
             or snapshot.get("protocol_version") != protocol
+            or snapshot.get("analysis_version") != ANALYSIS_VERSION
         )
 
     @callback
@@ -241,6 +304,8 @@ def _compare_snapshots(
             "protocol_changed": False,
             "changed_endpoints": [],
             "content_changed_endpoints": [],
+            "wire_shape_changed_endpoints": [],
+            "new_wire_shapes": {},
         }
     previous_endpoints = {item["name"]: item for item in previous.get("endpoints", [])}
     current_endpoints = {item["name"]: item for item in current.get("endpoints", [])}
@@ -256,6 +321,17 @@ def _compare_snapshots(
         for name in names
         if previous_endpoints.get(name) != current_endpoints.get(name)
     )
+    new_wire_shapes: dict[str, list[str]] = {}
+    for name in sorted(previous_endpoints.keys() & current_endpoints.keys()):
+        previous_shapes = _endpoint_wire_shapes(previous_endpoints[name])
+        current_shapes = _endpoint_wire_shapes(current_endpoints[name])
+        # An old snapshot or an opaque/non-protobuf payload establishes no
+        # structural baseline. Never turn a checker upgrade into a candidate.
+        if previous_shapes is None or current_shapes is None:
+            continue
+        added = sorted(current_shapes - previous_shapes)
+        if added:
+            new_wire_shapes[name] = added
     return {
         "baseline": False,
         "firmware_changed": previous.get("firmware_version")
@@ -264,7 +340,28 @@ def _compare_snapshots(
         != current.get("protocol_version"),
         "changed_endpoints": availability_changed,
         "content_changed_endpoints": content_changed,
+        "wire_shape_changed_endpoints": sorted(new_wire_shapes),
+        "new_wire_shapes": new_wire_shapes,
     }
+
+
+def _endpoint_wire_shapes(endpoint: Mapping[str, Any]) -> frozenset[str] | None:
+    """Return one endpoint's value-free shapes, or no comparable baseline."""
+    shapes: set[str] = set()
+    observed = False
+    for entry in endpoint.get("entries", []):
+        if not isinstance(entry, Mapping) or "wire_shape" not in entry:
+            continue
+        wire_shape_value = entry.get("wire_shape")
+        if wire_shape_value is None:
+            continue
+        if not isinstance(wire_shape_value, list) or not all(
+            isinstance(item, str) for item in wire_shape_value
+        ):
+            continue
+        observed = True
+        shapes.update(wire_shape_value)
+    return frozenset(shapes) if observed else None
 
 
 def _compatibility_signature(endpoint: Mapping[str, Any] | None) -> tuple[Any, ...]:
@@ -304,13 +401,20 @@ def snapshot_timestamp() -> str:
     return dt_util.utcnow().isoformat()
 
 
-def fingerprint_entry(value: HermesCollectionEntry) -> dict[str, Any]:
+def fingerprint_entry(
+    value: HermesCollectionEntry, *, endpoint_name: str | None = None
+) -> dict[str, Any]:
     """Return irreversible metadata for one Hermes value."""
+    shape = wire_shape(
+        value.value,
+        nested_message_paths=WIRE_SHAPE_NESTED_PATHS.get(endpoint_name or "", ()),
+    )
     return {
         "key_size": len(value.key),
         "value_size": len(value.value),
         "key_sha256": hashlib.sha256(value.key).hexdigest(),
         "value_sha256": hashlib.sha256(value.value).hexdigest(),
+        "wire_shape": list(shape) if shape is not None else None,
     }
 
 
@@ -337,7 +441,9 @@ async def _async_snapshot_endpoint(
         "kind": endpoint.kind,
         "sensitivity": endpoint.sensitivity,
         "status": "populated" if values else "empty",
-        "entries": [fingerprint_entry(value) for value in values],
+        "entries": [
+            fingerprint_entry(value, endpoint_name=endpoint.name) for value in values
+        ],
     }
 
 
@@ -355,7 +461,18 @@ async def async_build_firmware_snapshot(
     firmware_version = (
         state.telemetry.software_version or state.operational.software_version
     )
+    structural_endpoints = sum(
+        any(entry.get("wire_shape") is not None for entry in endpoint["entries"])
+        for endpoint in endpoints
+    )
+    wire_shape_count = sum(
+        len(entry["wire_shape"])
+        for endpoint in endpoints
+        for entry in endpoint["entries"]
+        if entry.get("wire_shape") is not None
+    )
     return {
+        "analysis_version": ANALYSIS_VERSION,
         "captured_at": snapshot_timestamp(),
         "firmware_version": firmware_version,
         "protocol_version": state.telemetry.protocol_version,
@@ -367,5 +484,7 @@ async def async_build_firmware_snapshot(
         "failed_endpoints": sum(
             endpoint["status"] == "error" for endpoint in endpoints
         ),
+        "structural_endpoints": structural_endpoints,
+        "wire_shape_count": wire_shape_count,
         "endpoints": endpoints,
     }

--- a/custom_components/matic_robot/icons.json
+++ b/custom_components/matic_robot/icons.json
@@ -11,7 +11,8 @@
       "update_available": { "default": "mdi:update" },
       "matter_pairing_mode": { "default": "mdi:access-point" },
       "ssh_tunnel_permission": { "default": "mdi:console-network" },
-      "diagnostic_upload": { "default": "mdi:cloud-upload" }
+      "diagnostic_upload": { "default": "mdi:cloud-upload" },
+      "following_person": { "default": "mdi:account-arrow-right" }
     },
     "button": {
       "run_selected_plan": { "default": "mdi:play-circle-outline" },
@@ -62,7 +63,12 @@
       "local_cleaning_sessions": { "default": "mdi:history" },
       "dock_detections": { "default": "mdi:home-search" },
       "sink_summon_locations": { "default": "mdi:water-pump" },
-      "coverage_time": { "default": "mdi:timer-outline" }
+      "coverage_time": { "default": "mdi:timer-outline" },
+      "cues_voice_status": { "default": "mdi:microphone-message" },
+      "cues_gesture_status": { "default": "mdi:gesture-tap" }
+    },
+    "event": {
+      "cues": { "default": "mdi:account-voice" }
     },
     "switch": {
       "child_lock": { "default": "mdi:lock" },

--- a/custom_components/matic_robot/sensor.py
+++ b/custom_components/matic_robot/sensor.py
@@ -107,6 +107,16 @@ class MaticStateSensorDescription(SensorEntityDescription):
 
 STATE_DESCRIPTIONS = (
     MaticStateSensorDescription(
+        key="cues_voice_status",
+        translation_key="cues_voice_status",
+        value_fn=lambda state: state.operational.cues_voice_status,
+    ),
+    MaticStateSensorDescription(
+        key="cues_gesture_status",
+        translation_key="cues_gesture_status",
+        value_fn=lambda state: state.operational.cues_gesture_status,
+    ),
+    MaticStateSensorDescription(
         key="protocol_version",
         translation_key="protocol_version",
         entity_category=EntityCategory.DIAGNOSTIC,

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -741,7 +741,10 @@ async def async_register_services(hass: HomeAssistant) -> None:
             "sensitivity": endpoint.sensitivity,
             "entry_count": len(values),
             "limit": call.data["limit"],
-            "entries": [fingerprint_entry(value) for value in values],
+            "entries": [
+                fingerprint_entry(value, endpoint_name=endpoint_name)
+                for value in values
+            ],
         }
         if endpoint_name == "latest_pose":
             response["pose_vector_paths"] = [

--- a/custom_components/matic_robot/strings.json
+++ b/custom_components/matic_robot/strings.json
@@ -544,6 +544,9 @@
           "off": "Not allowed",
           "on": "Allowed"
         }
+      },
+      "following_person": {
+        "name": "Following a person"
       }
     },
     "button": {
@@ -624,6 +627,28 @@
       },
       "current_area": {
         "name": "Current area"
+      },
+      "cues_voice_status": {
+        "name": "Cues voice status",
+        "state": {
+          "disabled": "Disabled",
+          "listening_for_wake_word": "Ready for wake word",
+          "listening_for_intent": "Listening for intent",
+          "thinking_for_intent": "Processing intent",
+          "classified": "Intent classified",
+          "rejected": "Intent rejected"
+        }
+      },
+      "cues_gesture_status": {
+        "name": "Cues gesture status",
+        "state": {
+          "awaiting_pointed_target": "Waiting for pointed target",
+          "pointed_target_accepted": "Pointed target accepted",
+          "no_target_found": "No target found",
+          "facing_user": "Facing user",
+          "person_not_found": "Person not found",
+          "following": "Following"
+        }
       },
       "coverage_time": {
         "name": "Coverage time"
@@ -714,7 +739,50 @@
         "name": "Pet-waste avoidance"
       },
       "voice_assistant": {
-        "name": "Hey Matic"
+        "name": "Matic Cues"
+      }
+    },
+    "event": {
+      "cues": {
+        "name": "Cues",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "disabled": "Disabled",
+              "ready": "Ready",
+              "wake_word_detected": "Wake word detected",
+              "intent_processing": "Processing intent",
+              "intent_classified": "Intent classified",
+              "intent_rejected": "Intent rejected",
+              "gesture_awaiting_pointed_target": "Waiting for pointed target",
+              "gesture_pointed_target_accepted": "Pointed target accepted",
+              "gesture_no_target_found": "No target found",
+              "gesture_facing_user": "Facing user",
+              "gesture_person_not_found": "Person not found",
+              "gesture_following": "Following gesture",
+              "following_started": "Following started",
+              "following_stopped": "Following stopped"
+            }
+          },
+          "intent": {
+            "name": "Intent",
+            "state": {
+              "clean": "Clean",
+              "clean_all": "Clean all",
+              "dock": "Dock",
+              "go_away": "Go away",
+              "navigate": "Navigate",
+              "pause": "Pause",
+              "redo_last_clean": "Redo last clean",
+              "resume": "Resume",
+              "sink_summon": "Sink summon",
+              "stop": "Stop",
+              "follow_person": "Follow person",
+              "point_to_clean": "Point to clean",
+              "unknown": "Unknown"
+            }
+          }
+        }
       }
     },
     "update": {
@@ -1051,7 +1119,7 @@
     },
     "firmware_snapshot": {
       "name": "Firmware snapshot",
-      "description": "Checks every known non-credential Hermes endpoint, stores a payload-free weekly compatibility record, and reports changes from the prior snapshot."
+      "description": "Checks every known non-credential Hermes endpoint, stores a payload-free compatibility record, and reports availability, content, and value-free wire-shape changes from the prior snapshot."
     }
   }
 }

--- a/custom_components/matic_robot/translations/en.json
+++ b/custom_components/matic_robot/translations/en.json
@@ -544,6 +544,9 @@
           "off": "Not allowed",
           "on": "Allowed"
         }
+      },
+      "following_person": {
+        "name": "Following a person"
       }
     },
     "button": {
@@ -624,6 +627,28 @@
       },
       "current_area": {
         "name": "Current area"
+      },
+      "cues_voice_status": {
+        "name": "Cues voice status",
+        "state": {
+          "disabled": "Disabled",
+          "listening_for_wake_word": "Ready for wake word",
+          "listening_for_intent": "Listening for intent",
+          "thinking_for_intent": "Processing intent",
+          "classified": "Intent classified",
+          "rejected": "Intent rejected"
+        }
+      },
+      "cues_gesture_status": {
+        "name": "Cues gesture status",
+        "state": {
+          "awaiting_pointed_target": "Waiting for pointed target",
+          "pointed_target_accepted": "Pointed target accepted",
+          "no_target_found": "No target found",
+          "facing_user": "Facing user",
+          "person_not_found": "Person not found",
+          "following": "Following"
+        }
       },
       "coverage_time": {
         "name": "Coverage time"
@@ -714,7 +739,50 @@
         "name": "Pet-waste avoidance"
       },
       "voice_assistant": {
-        "name": "Hey Matic"
+        "name": "Matic Cues"
+      }
+    },
+    "event": {
+      "cues": {
+        "name": "Cues",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "disabled": "Disabled",
+              "ready": "Ready",
+              "wake_word_detected": "Wake word detected",
+              "intent_processing": "Processing intent",
+              "intent_classified": "Intent classified",
+              "intent_rejected": "Intent rejected",
+              "gesture_awaiting_pointed_target": "Waiting for pointed target",
+              "gesture_pointed_target_accepted": "Pointed target accepted",
+              "gesture_no_target_found": "No target found",
+              "gesture_facing_user": "Facing user",
+              "gesture_person_not_found": "Person not found",
+              "gesture_following": "Following gesture",
+              "following_started": "Following started",
+              "following_stopped": "Following stopped"
+            }
+          },
+          "intent": {
+            "name": "Intent",
+            "state": {
+              "clean": "Clean",
+              "clean_all": "Clean all",
+              "dock": "Dock",
+              "go_away": "Go away",
+              "navigate": "Navigate",
+              "pause": "Pause",
+              "redo_last_clean": "Redo last clean",
+              "resume": "Resume",
+              "sink_summon": "Sink summon",
+              "stop": "Stop",
+              "follow_person": "Follow person",
+              "point_to_clean": "Point to clean",
+              "unknown": "Unknown"
+            }
+          }
+        }
       }
     },
     "update": {
@@ -1051,7 +1119,7 @@
     },
     "firmware_snapshot": {
       "name": "Firmware snapshot",
-      "description": "Checks every known non-credential Hermes endpoint, stores a payload-free weekly compatibility record, and reports changes from the prior snapshot."
+      "description": "Checks every known non-credential Hermes endpoint, stores a payload-free compatibility record, and reports availability, content, and value-free wire-shape changes from the prior snapshot."
     }
   }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,8 @@ the integration so instructions and behavior stay aligned with each release.
 
 - [Entities, controls, and actions](automation.md#entity-contract) — Use the
   complete Home Assistant surface exposed by one robot.
+- [Matic Cues](automation.md#matic-cues) — Automate privacy-safe voice, intent,
+  gesture, and following lifecycle state and review the enablement boundary.
 - [Saved cleaning plans](automation.md#saved-plans) — Choose rooms, customize
   per-room cleaning, and save the top-to-bottom order.
 - [Intelligent rotation](automation.md#intelligent-rotation) — Rotate fairly

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -8,8 +8,8 @@ settings, cleaning, and saved plans.
 
 ## Entity contract
 
-One configured robot creates 51 fixed entities — 21 sensors, 12 binary
-sensors, 5 buttons, 4 switches, 4 selects, 1 number, 2 cameras, 1 update, and
+One configured robot creates 55 fixed entities — 23 sensors, 13 binary sensors,
+5 buttons, 4 switches, 4 selects, 1 number, 2 cameras, 1 event, 1 update, and
 1 vacuum — plus two opt-in statistics sensors per mapped room.
 
 - `vacuum`: primary robot state plus start/resume, pause, stop, dock, Area
@@ -25,16 +25,19 @@ sensors, 5 buttons, 4 switches, 4 selects, 1 number, 2 cameras, 1 update, and
 - `sensor`: activity, battery, rooms, cleaning history, active plan, next room,
   firmware/protocol/update/compatibility state, current area, Wi-Fi state and
   signal, schedules, local sessions, last run duration, dock/sink, coverage,
-  and two opt-in statistics sensors per mapped room (see
-  [Room statistics](#room-statistics-and-the-recorder)).
+  Cues voice status, Cues gesture status, and two opt-in statistics sensors per
+  mapped room (see [Room statistics](#room-statistics-and-the-recorder)).
 - `update`: a read-only firmware surface in Home Assistant's update UI. The
   robot manages its own OTA installs and never reports the target version, so
   a pending update shows with an unknown latest version.
 - `binary_sensor`: cleaning, paused, returning, charging, low charge, fully
   charged, problem, update available, Matter pairing mode, active cleaning
-  session, robot SSH tunnel permission, and robot diagnostic upload.
+  session, robot SSH tunnel permission, robot diagnostic upload, and whether
+  Cues is following a person.
 - `switch` and `number`: robot settings such as child lock,
-  pet-waste avoidance, Hey Matic, double-pass mopping, and water flow.
+  pet-waste avoidance, Matic Cues, double-pass mopping, and water flow.
+- `event`: live Cues voice, intent, gesture, and following transitions. Intent
+  attributes are available to automations but excluded from Recorder history.
 
 Camera and microphone recording, clip retrieval and caching, recording
 metadata, and vendor share or discard decisions are not included in the entity
@@ -51,6 +54,57 @@ continue to anchor every registry entity.
 charged` states and a battery-check icon. It intentionally does not use Home
 Assistant's battery binary-sensor device class, whose generic on/off labels
 would invert the meaning and display a fully charged robot as `Low`.
+
+## Matic Cues
+
+The **Matic Cues** switch controls the robot's verified local
+`voice_enabled_command` setting. Enabling it is also consent to the robot's
+separate Cues data handling: Matic documents wake-word, direction, and gesture
+processing as on-device, audio after the chime as sent to Google Gemini, and
+video as never sent. Read Matic's [Cues overview](https://maticrobots.com/hey-matic)
+and [voice-data explanation](https://maticrobots.com/blog/how-your-voice-data-is-handled)
+before automating the switch.
+
+The integration subscribes to `kabuki_state` over the authenticated LAN session
+and exposes only these bounded values:
+
+- `sensor.matic_cues_voice_status`: disabled, ready for the wake word,
+  listening, processing, classified, or rejected;
+- `sensor.matic_cues_gesture_status`: target selection, target acceptance,
+  no-target, facing-user, person-not-found, or following lifecycle;
+- `binary_sensor.matic_following_person`: whether the robot reports active
+  following;
+- `event.matic_cues`: the most recent lifecycle transition.
+
+The `matic_robot_cues` bus event carries `device_id`, `entry_id`, `event_type`,
+and, only for `intent_classified`, an `intent`. Event types are `disabled`,
+`ready`, `wake_word_detected`, `intent_processing`, `intent_classified`,
+`intent_rejected`, `gesture_awaiting_pointed_target`,
+`gesture_pointed_target_accepted`, `gesture_no_target_found`,
+`gesture_facing_user`, `gesture_person_not_found`, `gesture_following`,
+`following_started`, and `following_stopped`. Automation-safe intents are
+`clean`, `clean_all`, `dock`, `go_away`, `navigate`, `pause`,
+`redo_last_clean`, `resume`, `sink_summon`, `stop`, `follow_person`,
+`point_to_clean`, and `unknown`.
+
+For example, turn on a light while Matic is following someone:
+
+```yaml
+triggers:
+  - trigger: event
+    event_type: matic_robot_cues
+    event_data:
+      event_type: following_started
+actions:
+  - action: light.turn_on
+    target:
+      entity_id: light.hallway
+```
+
+Home Assistant never receives a transcript, audio, image, video, person
+identity, pointing coordinate, or rejection detail. Recording-only intent
+variants are withheld as `unknown`; recording and clip features remain outside
+the integration.
 
 ## Complete cleaning action
 
@@ -283,8 +337,12 @@ exactly one Matic robot. Fields:
   `map_semantics`).
 - `limit` (default `32`, range 1–256): maximum entries to return.
 
-The response contains endpoint kind/sensitivity plus key/value sizes and SHA-256
-hashes. Raw bytes are never returned through the public Home Assistant action.
+The response contains endpoint kind/sensitivity plus key/value sizes, SHA-256
+hashes, and an optional value-free protobuf wire shape. A wire shape contains
+only unique field-number/wire-type paths; repeated occurrences collapse, and
+raw bytes are never returned through the public Home Assistant action. Nested
+inspection is restricted to audited Kabuki lifecycle message paths and stops
+before classified intent, rejection details, targets, coordinates, and media.
 The typed registry routes single-value properties correctly instead of treating
 every name as a collection stream.
 
@@ -297,14 +355,26 @@ Home Assistant and returns:
 - firmware and protocol versions;
 - populated, empty, and failed endpoint counts;
 - endpoint kind, sensitivity, status, sizes, and hashes;
-- availability/transport changes separately from ordinary content changes.
+- availability/transport changes separately from ordinary content changes;
+- newly added, bounded protobuf wire shapes as capability candidates.
 
 When the coordinator observes a new firmware version, the integration fires
 `matic_robot_firmware_changed` with previous and current firmware/protocol
-values. A Home Assistant Repair is created only when the subsequent snapshot
-finds endpoint availability or transport drift; normal weekly OTAs remain
-silent. Snapshotting never promotes a firmware to control-verified; physical
-write validation remains deliberate.
+values and starts the snapshot in the background. After comparison it fires the
+silent `matic_robot_firmware_analyzed` event with compatibility counts, safe
+candidate endpoint names, and their new wire paths. The Firmware compatibility
+diagnostic sensor exposes the analysis version, structural totals, and candidate
+counts. A checker-format upgrade causes one silent re-baseline snapshot on the
+current firmware.
+
+Structural candidates do not change the sensor from `compatible`, create a
+Repair, send a persistent notification, or log a warning. A Home Assistant
+Repair is created only when the snapshot finds endpoint availability or
+transport drift, so ordinary weekly OTAs remain quiet. A structural candidate
+means only that a field shape is new; it still requires synthetic fixtures and
+human protocol evidence before becoming a decoded entity or command.
+Snapshotting never promotes firmware to control-verified; physical write
+validation remains deliberate.
 
 ## Room statistics and the recorder
 
@@ -358,6 +428,10 @@ durations, the firmware version that produced the run, and the
 or custom logging.
 `matic_robot_firmware_changed` likewise carries `device_id`/`entry_id` so
 multi-robot homes can tell which robot updated.
+`matic_robot_firmware_analyzed` is the silent post-snapshot result with safe
+compatibility counts plus structural-candidate endpoint names and wire paths.
+`matic_robot_cues` carries the same identifiers for safe voice/gesture lifecycle
+and classified-intent automations; see [Matic Cues](#matic-cues).
 
 Use ordinary state triggers and conditions on any telemetry, setting, Activity,
 or binary sensor. This keeps automations composable with schedules, presence,

--- a/docs/firmware-compatibility.md
+++ b/docs/firmware-compatibility.md
@@ -24,13 +24,14 @@ separates an observed update from verified compatibility.
 
 | Firmware | First observed | Integration | Status | Evidence | Changes or capabilities |
 | --- | --- | --- | --- | --- | --- |
+| [v172.9](firmware-versions/v172.md) | 2026-08-13 | development | Core read verified | Live authenticated `kabuki_state` and settings read; protocol 25; Cues setting read/write; all six voice and gesture stages; accepted/rejected intent paths; following true/false; analyzer sweep 31 populated / 9 empty / 0 failed with 26 structural endpoints and 77 value-free paths | Adds the privacy-safe Matic Cues read surface and upgrades automatic OTA analysis with bounded structural candidates. The complete Cues lifecycle and first structural analysis format were observed live; unexercised intent kinds remain app-schema-derived with synthetic fixtures. |
 | [v171.10](firmware-versions/v171.md) | 2026-08-09 | 0.3.4 candidate | Read verified | The 0.3.4 candidate was live-validated on HA 2026.7.2 Container with a local BlueZ adapter on an ARM64 Linux host; protocol 25; initial credential issuance completed; coordinator, state, telemetry, map, rooms, and pose decoded; payload-free sweep 32 populated / 8 empty / 0 failed | Release 0.3.3 discarded an unchanged local scanner entry as not fresh; 0.3.4 accepts that retained entry after the active sweep. Reauthorization, credential replacement, stale-bond recovery, and controls remain pending. |
 | [v169.9](firmware-versions/v169.md) | 2026-07-27 | 0.3.0 | Control verified | Live on HA 2026.7.4; protocol 25; snapshot 28 populated / 12 empty / 0 failed; no endpoint availability changes | Full local map, pose, rooms, telemetry, and update state remained available; quick and standard coverage, all three cleaning modes, complete saved-plan handoff, both intelligent-stop branches, and persisted custom-area cleaning passed live without false credit |
 | [v168.11](firmware-versions/v168.md) | 2026-07-20 | 0.2.0–0.2.3 | Core read verified | Live on HA 2026.7.2; protocol 25; automatic baseline snapshot 28 populated / 12 empty / 0 failed; selected stop/dock/room-plan paths later exercised | Uploader-state decoder fix released and live-confirmed; robot-side stream resets handled as transport noise; complete control matrix remains pending |
 
 No v170 build was observed, so the ledger makes no v170 compatibility claim.
-The v171.10 validation result is a direct live observation and does not infer
-behavior for the missing release.
+The v171.10 and v172.9 validation results are direct live observations and do
+not infer behavior for the missing release.
 
 An empty or pending entry is not a compatibility claim. Synthetic tests show
 that the integration handles the documented protocol shapes; only real-robot
@@ -68,13 +69,20 @@ check in this order:
 
 The integration automatically records the first firmware as a baseline. Each
 newly observed firmware or protocol pair fires `matic_robot_firmware_changed`
-and starts a background, payload-free snapshot of all known endpoints. A Home
-Assistant Repair is created only when availability or transport status changes;
-a normal weekly OTA does not create an issue.
+and starts a background, payload-free snapshot of all known endpoints. The
+snapshot also compares bounded value-free protobuf shapes so newly added field
+paths become capability candidates instead of disappearing inside opaque hash
+changes. `matic_robot_firmware_analyzed` reports the silent counts and paths for
+advanced automations. A Home Assistant Repair is created only when availability or
+transport status changes; a normal weekly OTA or structural candidate does not
+create an issue or notification.
 
-That automated snapshot runs only after authentication. It cannot validate
-initial pairing, reauthorization, credential replacement, or the physical
-Bluetooth adapter path; those remain deliberate manual checks.
+That automated snapshot runs only after authentication. Structural analysis
+records field numbers and wire types, never values, and nested traversal stops
+before classified intents, rejection detail, targets, coordinates, and media.
+It cannot infer meaning, discover an endpoint name absent from the allowlist,
+or validate initial pairing, reauthorization, credential replacement, physical
+controls, or the Bluetooth adapter path; those remain deliberate manual checks.
 
 The event can also drive a local notification:
 

--- a/docs/firmware-endpoint-map.md
+++ b/docs/firmware-endpoint-map.md
@@ -22,7 +22,7 @@ real robot actually returned after an OTA.
 
 | Collection/property | Decoded data | Current HA exposure |
 | --- | --- | --- |
-| `kabuki_state` | Battery, state/error codes, activity, firmware fallback, channel/profile, current/previous area | Vacuum; activity, battery and current-area sensors; seven operational binary sensors; attributes |
+| `kabuki_state` | Battery, state/error codes, activity, firmware fallback, channel/profile, current/previous area, Cues voice/gesture lifecycle and following presence | Vacuum; activity, battery, current-area and Cues lifecycle sensors; operational binary sensors; Cues event entity and bus event; attributes |
 | `coverage_plan` | Mission, partition, named room IDs and geometry | Rooms sensor, map camera, vacuum segments/Areas, cleaning target |
 | `latest_pose` | Robot position and heading across both verified wire layouts; payload-free vector paths in endpoint inspection | Map camera |
 | `approximate_trajectory` | Mission-correlated, finite 2D route updates and mission-scoped clear markers | Typed client stream; no HA entity or map overlay yet |
@@ -42,7 +42,7 @@ real robot actually returned after an OTA.
 | `coverage_time` | Accumulated coverage seconds | Coverage-time sensor |
 | `child_lock_enabled_state` | Child-lock state | Child-lock switch |
 | `petwaste_enabled_state` | Pet-waste avoidance state | Pet-waste-avoidance switch |
-| `voice_enabled_state` | Hey Matic state | Voice-assistant switch |
+| `voice_enabled_state` | Matic Cues state | Cues switch |
 | `matter_pairing_state` | Pairing-mode presence | Matter-pairing binary sensor |
 | `deep_mop_override_setting_state` | Double-pass mop state | Deep-mop switch |
 | `water_flow_override_state` | Water-flow multiplier | Water-flow number |
@@ -53,7 +53,9 @@ real robot actually returned after an OTA.
 ## Allowlisted exploratory reads
 
 These are bounded, payload-free reads through `inspect_hermes_endpoint` and the
-weekly `firmware_snapshot` action. Payloads are not decoded into entities unless listed above. “Candidate” is a
+automatic/manual `firmware_snapshot` workflow. The snapshot records hashes and
+bounded value-free wire shapes where the payload is a small protobuf message.
+Payloads are not decoded into entities unless listed above. “Candidate” is a
 research direction, not a promise that the field exists or is safe on every
 firmware.
 
@@ -84,7 +86,7 @@ credentials, arbitrary names, and raw payload output are deliberately excluded.
 | `user_command` | Full-floor/room coverage and official drawn-circle custom coverage; vacuum, mop or both; Quick/Optimal/Heavy Duty; ordered/unordered | Vacuum start/Area/segment cleaning; `matic_robot.clean`; `matic_robot.clean_area`; saved plans and areas |
 | `child_lock_enabled_command` | Boolean | Child-lock switch |
 | `petwaste_enabled_command` | Boolean | Pet-waste-avoidance switch |
-| `voice_enabled_command` | Boolean | Voice-assistant switch |
+| `voice_enabled_command` | Boolean | Cues switch |
 | `deep_mop_override_setting_command` | Enable/disable | Deep-mop switch |
 | `water_flow_override_command` | 0.5–2.0 in 0.1 steps | Water-flow number |
 
@@ -101,6 +103,8 @@ Home Assistant error handling.
 - [Snapshot template](firmware-versions/template.md) — copy after each OTA.
 
 The integration persists 52 safe snapshots, emits an event on a new version,
-raises a Home Assistant Repair only for compatibility drift, and separates
-endpoint availability changes from normal content changes. The Markdown ledger
+then emits a silent analysis event after the automatic comparison. It separates
+endpoint availability changes, normal content changes, and newly added wire
+shapes. Only availability/transport drift creates a Home Assistant Repair;
+structural candidates remain diagnostic until reviewed. The Markdown ledger
 remains the reviewed compatibility claim.

--- a/docs/firmware-versions/template.md
+++ b/docs/firmware-versions/template.md
@@ -24,7 +24,7 @@ protocol_version: N
 | 15 telemetry properties | Pending | |
 | Schedule and coverage-history collections | Pending | |
 | Dock and sink collection counts | Pending | |
-| Allowlisted exploratory reads | Pending | |
+| Allowlisted exploratory reads and wire-shape candidates | Pending | |
 | Stop, pause, resume and dock | Not tested | |
 | Coverage/room commands and cleaning settings | Not tested | |
 
@@ -44,7 +44,7 @@ protocol_version: N
 - [ ] When credential recovery is claimed, exercise explicit replacement and
   stale-bond removal.
 - [ ] Confirm coordinator refresh and decoded reads.
-- [ ] Run a hash-only exploratory availability sweep.
+- [ ] Run a payload-free availability and wire-shape sweep.
 - [ ] Review privacy-safe diagnostics for protocol drift.
 - [ ] Compare with the preceding firmware snapshot.
 - [ ] Exercise supported writes deliberately and record exact coverage.

--- a/docs/firmware-versions/v172.md
+++ b/docs/firmware-versions/v172.md
@@ -1,0 +1,82 @@
+# Matic firmware v172.9
+
+[Endpoint map](../firmware-endpoint-map.md) ·
+[Firmware ledger](../firmware-compatibility.md)
+
+status: core reads, Cues lifecycle, and value-free endpoint analysis verified;
+cleaning controls pending<br>
+first_observed_pacific: 2026-08-13<br>
+integration_version: development<br>
+protocol_version: 25
+
+## Endpoint snapshot
+
+| Surface | Status | Evidence / limit |
+| --- | --- | --- |
+| Authentication and core state | Verified | An authenticated local session reported firmware v172.9 and protocol 25. The robot was docked with no active Hermes errors. |
+| Matic Cues setting | Verified read/write | The local `voice_enabled_state` property reported Cues enabled. The existing verified Boolean command disabled Cues and restored the original enabled value on v172.9. |
+| Cues voice lifecycle | Verified live | All six bounded stages were observed: disabled, ready-for-wake-word, listening-for-intent, thinking, classified, and rejected. The original enabled setting was restored after the disabled-state check. |
+| Classified intent | Partially verified live | Accepted `pause` and `point_to_clean` classifications and a rejected request were observed. All other bounded intent tags remain schema-derived with synthetic fixtures. Recording-only variants reduce to `unknown`; transcripts and rejection details are not decoded. |
+| Gesture lifecycle and following | Verified live | All six app-exposed gesture states were observed: facing-user, awaiting-target, target-accepted, no-target, person-not-found, and following. Following presence changed true then false; the verified STOP command ended motion immediately. |
+| Automatic firmware analysis | Analyzer verified live | The new analysis format read all 40 allowlisted endpoints: 31 populated, 9 empty, 0 failed. Twenty-six bounded protobuf endpoints produced 77 unique value-free paths, including 15 audited Kabuki lifecycle paths. This is the first structural format baseline, so there is no earlier wire-shape snapshot to compare. |
+| Cues media and coordinates | Not exposed | Audio, images, video, transcripts, person identity, pointing coordinates, recording collections, and vendor decisions remain outside the integration. |
+| Cleaning controls | Not tested | No v172 control-compatibility claim. |
+
+## Cues implementation evidence
+
+The official app model exposes optional voice and gesture lifecycle state plus
+a following-person boolean. The v172 native schema confirms that these are
+contained in repeated Kabuki payloads: voice status, following presence, and
+gesture status are separate bounded fields. Classified intent kinds cover
+cleaning, navigation, docking, pause/resume/stop, sink summon, follow-person,
+and point-to-clean behavior.
+
+The Home Assistant integration uses that evidence only for reads. A live
+tracked subscription keeps the lifecycle current between ordinary coordinator
+polls. Synthetic protobuf fixtures cover every exposed lifecycle value and
+intent kind, malformed targeted messages, recording-only withholding, and
+subscription teardown/retry behavior. No raw robot payload, private identifier,
+media, or coordinate is committed.
+
+A bounded live exercise then observed accepted and rejected voice paths, every
+gesture lifecycle value, and following start/stop. Point-to-clean and following
+motion were stopped immediately with the existing verified STOP command. The
+robot finished ready, Cues enabled, and following false. Only decoded enums and
+booleans were inspected; no audio, transcript, media, coordinate, raw payload,
+or home-specific value was retained.
+
+The upgraded firmware checker now distinguishes endpoint reachability,
+ordinary opaque content changes, and newly added protobuf field shapes. Its
+live v172.9 exercise retained only counts, hashes, and unique field-number/wire-
+type paths; all 40 endpoints remained reachable. Structural candidates are
+silent diagnostics and cannot create a Repair. The first deployed refresh will
+persist one re-baseline because prior snapshots contain hashes but no shapes.
+
+Matic documents wake-word, direction, and gesture processing as on-device,
+audio after the chime as sent to Google Gemini, and video as never sent. The
+integration therefore labels the existing enable switch **Matic Cues** and
+documents that enabling the local setting opts into the robot's separate data
+handling. See Matic's [Cues overview](https://maticrobots.com/hey-matic) and
+[voice-data explanation](https://maticrobots.com/blog/how-your-voice-data-is-handled).
+
+## Promotion checklist
+
+- [x] Record firmware and protocol versions.
+- [x] Confirm authenticated core state and the Cues setting read.
+- [x] Exercise the local Cues enable command and restore the original setting.
+- [x] Observe the enabled and disabled Cues voice lifecycle values live.
+- [x] Cover all exposed Cues lifecycle and intent wire shapes with synthetic
+  fixtures.
+- [x] Keep recordings, media, transcripts, coordinates, rejection details, and
+  raw collections outside the public surface.
+- [x] Exercise the voice lifecycle from wake word through accepted and rejected
+  intent on a live robot.
+- [x] Exercise gesture and following transitions on a live robot.
+- [x] Run the payload-free endpoint and wire-shape sweep; all 40 endpoints
+  remained reachable compared with v171.10, with no prior structural baseline.
+- [ ] Exercise supported cleaning/settings controls before making a control
+  compatibility claim.
+
+Never commit downloaded diagnostics, raw robot payloads, credentials, network
+or device identifiers, maps, room names, Wi-Fi details, media, or other home
+data.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -19,8 +19,9 @@ pairing attempt; it is not stored in the config entry, logs, diagnostics, or
 rotation history.
 
 The entity state machine contains activity, battery, firmware metadata,
-current/previous Area context, preference state, summary counts, and diagnostic
-state. High-context diagnostic entities are disabled by default. Attributes
+current/previous Area context, preference state, summary counts, diagnostic
+state, and bounded Cues lifecycle classifications. High-context diagnostic
+entities are disabled by default. Attributes
 that carry home context — the connected Wi-Fi SSID, schedule definitions, room
 names and IDs, the latest session's visited/completed rooms and durations, and
 full plan/history records — stay live on the state machine for templates but
@@ -33,6 +34,18 @@ room's name and cleaning durations as long-term statistics; and the
 rooms, verified completed rooms, and per-room durations in its payload. Home
 Assistant's recorder retains enabled entity states according to the user's
 recorder settings.
+
+Cues contributes only voice/gesture lifecycle enums, a following-person
+boolean, and an automation-safe classified intent. The event entity excludes
+its `intent` attribute from Recorder history. No transcript, audio, image,
+video, person identity, pointing coordinate, rejection detail, or raw Cues
+collection is exposed or stored. Recording-only classifications are reduced to
+`unknown`. The integration's setting command is local, but enabling Cues opts
+the robot into Matic's separately documented processing: Matic says on-device
+processing handles the wake word, sound direction, and gestures, while audio
+after the chime is sent to Google Gemini and video is not sent. See Matic's
+[Cues overview](https://maticrobots.com/hey-matic) and
+[voice-data explanation](https://maticrobots.com/blog/how-your-voice-data-is-handled).
 
 The visible-by-default room-map camera renders geometry and pose and contains
 no photographic pixels. The separate photographic SLAM camera accumulates the
@@ -74,6 +87,17 @@ room-geometry bindings so a legacy area, remap, floor change, or geometry drift
 fails closed instead of applying old coordinates to a new map. The resulting
 Repair exposes only an affected-area count, never names, coordinates, or map
 identifiers.
+
+Firmware compatibility history uses another private local store capped at 52
+snapshots. It retains endpoint reachability, sizes, irreversible hashes, and—on
+bounded protobuf values—unique field-number/wire-type paths. Repeated fields
+collapse into one path, so counts are not retained. Nested Kabuki traversal is
+limited to audited voice/gesture lifecycle envelopes and stops before
+classified intent, rejection details, target data, coordinates, media, and all
+other opaque values. Structural candidates and their paths may appear in the
+private snapshot store, diagnostic sensor, explicit action response, and silent
+analysis event. They never create a Repair or notification, and require human
+evidence before the integration assigns meaning.
 
 The current photographic/structural map and its timeline use private integration
 storage, not Recorder. Timeline retention is limited to 12 time-spaced scenes

--- a/docs/recording-protocol.md
+++ b/docs/recording-protocol.md
@@ -15,6 +15,14 @@ photographic pixels. The default-disabled **Photorealistic map** and admin-only
 Map Studio use accumulated local SLAM color/structure pages; they do not expose
 recording collections, clips, microphones, or a live video stream.
 
+The privacy-safe [Matic Cues surface](automation.md#matic-cues) is also separate.
+It exposes only bounded lifecycle enums, classified intent kinds, and following
+presence from `kabuki_state`. It does not expose transcripts, media, person
+identity, pointing coordinates, rejection details, raw Cues collections, or
+recording-only intent variants. Enabling Cues still opts the robot into Matic's
+documented post-chime audio processing, so review the linked consent guidance
+before using the switch.
+
 ## Why recording controls are not included
 
 Camera and microphone content can reveal people, conversations, belongings,

--- a/tests/test_api_paths.py
+++ b/tests/test_api_paths.py
@@ -714,6 +714,35 @@ async def test_subscribe_collection_entries_cancels_blocked_stream_on_teardown(
     assert stream.cancelled.is_set()
 
 
+async def test_subscribe_collection_entries_reconnects_failed_channel(
+    monkeypatch,
+) -> None:
+    stream = _BidirectionalSequenceStream([])
+    stream.recv_message = AsyncMock(side_effect=StreamTerminatedError("dropped"))
+    method = _OpenMethod(stream)
+    failed_channel = SimpleNamespace(close=MagicMock())
+    fresh_channel = object()
+    monkeypatch.setattr(
+        "custom_components.matic_robot.client.api.HermesStub",
+        lambda channel: SimpleNamespace(FetchCollection=method),
+    )
+    client = MaticHermesClient("robot.invalid", 16320, credential=_credential())
+    client._channel = failed_channel
+
+    async def connect_fresh_channel() -> None:
+        client._channel = fresh_channel
+
+    client._async_connect_locked = AsyncMock(side_effect=connect_fresh_channel)
+
+    with pytest.raises(CannotConnectError, match="connection failed"):
+        await anext(client.async_subscribe_collection_entries("live_map"))
+
+    assert client._channel is fresh_channel
+    client._async_connect_locked.assert_awaited_once_with()
+    failed_channel.close.assert_called_once_with()
+    assert stream.cancelled is True
+
+
 async def test_subscribe_collection_entries_requires_a_connected_channel() -> None:
     client = MaticHermesClient("robot.invalid", 16320)
     client.async_connect = AsyncMock()

--- a/tests/test_api_paths.py
+++ b/tests/test_api_paths.py
@@ -461,6 +461,22 @@ async def test_state_read_reconnects_and_retries_stale_channel() -> None:
     failed_channel.close.assert_called_once_with()
 
 
+async def test_state_subscription_decodes_updates_and_rejects_malformed() -> None:
+    client = MaticHermesClient("robot.invalid", 16320)
+    valid = KabukiOutputWire(states=[106]).SerializeToString()
+
+    async def entries(_name):
+        yield HermesCollectionEntry(b"", valid)
+        yield HermesCollectionEntry(b"", b"\x0a\xff")
+
+    client.async_subscribe_collection_entries = entries
+    updates = client.async_subscribe_state()
+
+    assert (await anext(updates)).activity is RobotActivity.DOCKED
+    with pytest.raises(CannotConnectError, match="malformed subscribed"):
+        await anext(updates)
+
+
 async def test_stale_reader_reuses_channel_replaced_by_concurrent_reader() -> None:
     client = MaticHermesClient("robot.invalid", 16320)
     failed_channel = SimpleNamespace(close=MagicMock())

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -241,6 +241,33 @@ async def test_cues_watcher_retries_transport_failures(hass) -> None:
     assert [args.args for args in sleep.await_args_list] == [(1,), (2,)]
 
 
+async def test_cues_watcher_backs_off_after_initial_snapshots(hass) -> None:
+    client = _client()
+    attempts = 0
+
+    async def short_lived_subscription():
+        nonlocal attempts
+        attempts += 1
+        yield client.async_get_state.return_value
+        if attempts == 3:
+            yield client.async_get_state.return_value
+        raise MaticError("stream closed")
+
+    client.async_subscribe_state = short_lived_subscription
+    coordinator = _coordinator(hass, client)
+
+    with (
+        patch(
+            "custom_components.matic_robot.coordinator.asyncio.sleep",
+            AsyncMock(side_effect=[None, None, asyncio.CancelledError]),
+        ) as sleep,
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await coordinator.async_watch_cues()
+
+    assert [args.args for args in sleep.await_args_list] == [(1,), (2,), (1,)]
+
+
 async def test_cues_watcher_applies_updates_and_propagates_cancel(hass) -> None:
     client = _client()
     coordinator = _coordinator(hass, client)
@@ -264,6 +291,38 @@ async def test_cues_watcher_applies_updates_and_propagates_cancel(hass) -> None:
         coordinator.data.operational.cues_voice_status
         is CuesVoiceStatus.LISTENING_FOR_INTENT
     )
+
+
+async def test_live_cues_push_wins_over_an_overlapping_poll(hass) -> None:
+    client = _client()
+    coordinator = _coordinator(hass, client)
+    initial = await coordinator._async_update_data()
+    coordinator.async_set_updated_data(initial)
+    state_read_started = asyncio.Event()
+    release_state_read = asyncio.Event()
+
+    async def slow_state_read() -> RobotOperationalState:
+        state_read_started.set()
+        await release_state_read.wait()
+        return initial.operational
+
+    client.async_get_state.side_effect = slow_state_read
+    poll = hass.async_create_task(coordinator._async_update_data())
+    await state_read_started.wait()
+    pushed = replace(
+        initial.operational,
+        cues_voice_status=CuesVoiceStatus.CLASSIFIED,
+        cues_voice_intent=CuesIntent.CLEAN_ALL,
+        following_person=True,
+    )
+    coordinator.async_process_cues_state(pushed)
+    release_state_read.set()
+
+    state = await poll
+
+    assert state.operational.cues_voice_status is CuesVoiceStatus.CLASSIFIED
+    assert state.operational.cues_voice_intent is CuesIntent.CLEAN_ALL
+    assert state.operational.following_person is True
 
 
 async def test_optional_map_failures_do_not_hide_core_state(hass) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
@@ -18,13 +19,16 @@ from custom_components.matic_robot.client.exceptions import (
 )
 from custom_components.matic_robot.client.models import (
     CleaningSession,
+    CuesGestureStatus,
+    CuesIntent,
+    CuesVoiceStatus,
     FloorPlan,
     RobotInfo,
     RobotOperationalState,
     RobotTelemetry,
     Room,
 )
-from custom_components.matic_robot.coordinator import MaticCoordinator
+from custom_components.matic_robot.coordinator import MaticCoordinator, MaticCuesEvent
 
 
 def _client() -> AsyncMock:
@@ -102,6 +106,164 @@ async def test_update_combines_required_and_optional_local_state(hass) -> None:
     assert state.floor_plan is None
     assert state.pose is None
     assert state.telemetry.protocol_version == 25
+
+
+async def test_live_cues_state_emits_safe_entity_and_bus_events(hass) -> None:
+    from pytest_homeassistant_custom_component.common import async_capture_events
+
+    from custom_components.matic_robot.const import EVENT_CUES
+
+    client = _client()
+    coordinator = _coordinator(hass, client)
+    initial = await coordinator._async_update_data()
+    coordinator.async_set_updated_data(initial)
+    entity_events: list[MaticCuesEvent] = []
+    remove_listener = coordinator.async_add_cues_listener(entity_events.append)
+    bus_events = async_capture_events(hass, EVENT_CUES)
+
+    ready = replace(
+        initial.operational,
+        cues_voice_status=CuesVoiceStatus.LISTENING_FOR_WAKE_WORD,
+    )
+    coordinator.async_process_cues_state(ready)
+    listening = replace(
+        ready,
+        cues_voice_status=CuesVoiceStatus.LISTENING_FOR_INTENT,
+    )
+    coordinator.async_process_cues_state(listening)
+    classified = replace(
+        listening,
+        cues_voice_status=CuesVoiceStatus.CLASSIFIED,
+        cues_voice_intent=CuesIntent.POINT_TO_CLEAN,
+        cues_gesture_status=CuesGestureStatus.POINTED_TARGET_ACCEPTED,
+        following_person=True,
+    )
+    coordinator.async_process_cues_state(classified)
+    coordinator.async_process_cues_state(classified)
+    await hass.async_block_till_done()
+
+    assert [event.event_type for event in entity_events] == [
+        "ready",
+        "wake_word_detected",
+        "intent_classified",
+        "gesture_pointed_target_accepted",
+        "following_started",
+    ]
+    assert entity_events[2].attributes == {"intent": "point_to_clean"}
+    assert [event.data["event_type"] for event in bus_events] == [
+        event.event_type for event in entity_events
+    ]
+    assert bus_events[2].data["intent"] == "point_to_clean"
+    assert bus_events[2].data["entry_id"] == "entry"
+    assert bus_events[2].data["device_id"] is None
+    assert coordinator.data.operational.following_person is True
+
+    remove_listener()
+    coordinator.async_process_cues_state(replace(classified, following_person=False))
+    assert entity_events[-1].event_type == "following_started"
+
+
+@pytest.mark.parametrize(
+    ("voice_status", "event_type"),
+    [
+        (CuesVoiceStatus.DISABLED, "disabled"),
+        (CuesVoiceStatus.THINKING_FOR_INTENT, "intent_processing"),
+        (CuesVoiceStatus.REJECTED, "intent_rejected"),
+    ],
+)
+async def test_live_cues_remaining_voice_transitions(
+    hass, voice_status: CuesVoiceStatus, event_type: str
+) -> None:
+    client = _client()
+    coordinator = _coordinator(hass, client)
+    initial = await coordinator._async_update_data()
+    coordinator.async_set_updated_data(initial)
+    events: list[MaticCuesEvent] = []
+    coordinator.async_add_cues_listener(events.append)
+
+    coordinator.async_process_cues_state(
+        replace(initial.operational, cues_voice_status=voice_status)
+    )
+
+    assert [event.event_type for event in events] == [event_type]
+
+
+async def test_live_cues_classified_intent_can_change_in_place(hass) -> None:
+    client = _client()
+    coordinator = _coordinator(hass, client)
+    initial = await coordinator._async_update_data()
+    classified = replace(
+        initial.operational,
+        cues_voice_status=CuesVoiceStatus.CLASSIFIED,
+        cues_voice_intent=CuesIntent.CLEAN,
+    )
+    coordinator.async_set_updated_data(replace(initial, operational=classified))
+    events: list[MaticCuesEvent] = []
+    coordinator.async_add_cues_listener(events.append)
+
+    coordinator.async_process_cues_state(
+        replace(classified, cues_voice_intent=CuesIntent.CLEAN_ALL)
+    )
+
+    assert events == [MaticCuesEvent("intent_classified", {"intent": "clean_all"})]
+
+
+async def test_live_cues_ignores_updates_before_initial_refresh(hass) -> None:
+    coordinator = _coordinator(hass, _client())
+
+    coordinator.async_process_cues_state(
+        RobotOperationalState(50, (), (), False, False, False, False, False, False)
+    )
+
+    assert coordinator.data is None
+
+
+async def test_cues_watcher_retries_transport_failures(hass) -> None:
+    client = _client()
+
+    async def failed_subscription():
+        if False:
+            yield client.async_get_state.return_value
+        raise MaticError("offline")
+
+    client.async_subscribe_state = failed_subscription
+    coordinator = _coordinator(hass, client)
+
+    with (
+        patch(
+            "custom_components.matic_robot.coordinator.asyncio.sleep",
+            AsyncMock(side_effect=[None, asyncio.CancelledError]),
+        ) as sleep,
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await coordinator.async_watch_cues()
+
+    assert [args.args for args in sleep.await_args_list] == [(1,), (2,)]
+
+
+async def test_cues_watcher_applies_updates_and_propagates_cancel(hass) -> None:
+    client = _client()
+    coordinator = _coordinator(hass, client)
+    initial = await coordinator._async_update_data()
+    coordinator.async_set_updated_data(initial)
+    updated = replace(
+        initial.operational,
+        cues_voice_status=CuesVoiceStatus.LISTENING_FOR_INTENT,
+    )
+
+    async def subscription():
+        yield updated
+        raise asyncio.CancelledError
+
+    client.async_subscribe_state = subscription
+
+    with pytest.raises(asyncio.CancelledError):
+        await coordinator.async_watch_cues()
+
+    assert (
+        coordinator.data.operational.cues_voice_status
+        is CuesVoiceStatus.LISTENING_FOR_INTENT
+    )
 
 
 async def test_optional_map_failures_do_not_hide_core_state(hass) -> None:

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -23,6 +23,7 @@ from custom_components.matic_robot import (
     update,
     vacuum,
 )
+from custom_components.matic_robot import event as event_platform
 from custom_components.matic_robot.client.commands import (
     CleaningMode,
     CoverageSetting,
@@ -42,6 +43,7 @@ from custom_components.matic_robot.client.models import (
     Room,
     WifiNetwork,
 )
+from custom_components.matic_robot.coordinator import MaticCuesEvent
 from custom_components.matic_robot.entity import MaticEntity
 from custom_components.matic_robot.plans import PlanStopDecision
 
@@ -167,6 +169,7 @@ def _entry(*, paused: bool = False, idle: bool = False, with_floor_plan: bool = 
         async_request_full_refresh=AsyncMock(),
         async_discard_current_room=MagicMock(),
         async_add_listener=MagicMock(return_value=MagicMock()),
+        async_add_cues_listener=MagicMock(return_value=MagicMock()),
         last_update_success=True,
     )
     history = SimpleNamespace(
@@ -273,25 +276,27 @@ async def test_platform_setups_create_the_full_entity_surface(hass) -> None:
     await add_platform("sensor", sensor.async_setup_entry)
     await add_platform("select", select.async_setup_entry)
     await add_platform("camera", camera.async_setup_entry)
+    await add_platform("event", event_platform.async_setup_entry)
     await add_platform("number", number.async_setup_entry)
     await add_platform("switch", switch.async_setup_entry)
     await add_platform("update", update.async_setup_entry)
     await add_platform("vacuum", vacuum.async_setup_entry)
 
-    # 51 fixed entities plus two opt-in statistics sensors per mapped room.
+    # 55 fixed entities plus two opt-in statistics sensors per mapped room.
     assert platform_counts == {
-        "binary_sensor": 12,
+        "binary_sensor": 13,
         "button": 5,
         "camera": 2,
+        "event": 1,
         "number": 1,
         "select": 4,
-        "sensor": 25,
+        "sensor": 27,
         "switch": 4,
         "update": 1,
         "vacuum": 1,
     }
-    assert len(entities) == 55
-    assert len({entity.unique_id for entity in entities}) == 55
+    assert len(entities) == 59
+    assert len({entity.unique_id for entity in entities}) == 59
     assert all(entity.device_info["manufacturer"] == "Matic" for entity in entities)
 
 
@@ -332,6 +337,23 @@ async def test_room_statistics_sensors_follow_floor_plan_growth(hass) -> None:
     )
     listener()
     assert len(added) == 2
+
+
+async def test_cues_event_entity_records_live_event(hass) -> None:
+    entry = _entry()
+    entity = event_platform.MaticCuesEventEntity(entry)
+    entity.hass = hass
+    entity.entity_id = "event.test_robot_cues"
+    entity.async_write_ha_state = MagicMock()
+
+    await entity.async_added_to_hass()
+    listener = entry.runtime_data.coordinator.async_add_cues_listener.call_args.args[0]
+    listener(MaticCuesEvent("intent_classified", {"intent": "clean_all"}))
+
+    assert entity.state_attributes["event_type"] == "intent_classified"
+    assert entity.state_attributes["intent"] == "clean_all"
+    assert entity._unrecorded_attributes == frozenset({"intent"})
+    entity.async_write_ha_state.assert_called_once_with()
 
 
 async def test_room_sensors_wait_for_a_floor_plan(hass) -> None:
@@ -752,6 +774,7 @@ def test_sensor_and_binary_sensor_values() -> None:
         True,
         None,
         None,
+        None,
     ]
     assert {
         description.key
@@ -800,7 +823,22 @@ def test_sensor_and_binary_sensor_values() -> None:
     assert [
         sensor.MaticStateSensor(entry, description).native_value
         for description in sensor.STATE_DESCRIPTIONS
-    ] == [25, None, "stable", "idle", "connected", 3, 7, 4, 1, 600, 600, -45]
+    ] == [
+        None,
+        None,
+        25,
+        None,
+        "stable",
+        "idle",
+        "connected",
+        3,
+        7,
+        4,
+        1,
+        600,
+        600,
+        -45,
+    ]
 
     state_sensors = {
         description.key: sensor.MaticStateSensor(entry, description)

--- a/tests/test_firmware.py
+++ b/tests/test_firmware.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from custom_components.matic_robot.client.models import HermesCollectionEntry
 from custom_components.matic_robot.firmware import (
+    ANALYSIS_VERSION,
     MAX_HISTORY,
     FirmwareTracker,
     _compare_snapshots,
     _compatibility_status,
+    fingerprint_entry,
     snapshot_timestamp,
 )
 
@@ -19,8 +22,10 @@ def _snapshot(
     *,
     status: str = "populated",
     value_hash: str = "one",
+    wire_shapes: list[str] | None = None,
 ) -> dict[str, object]:
     return {
+        "analysis_version": ANALYSIS_VERSION,
         "captured_at": "2026-07-20T00:00:00+00:00",
         "firmware_version": version,
         "protocol_version": 25,
@@ -28,12 +33,21 @@ def _snapshot(
         "populated_endpoints": int(status == "populated"),
         "empty_endpoints": int(status == "empty"),
         "failed_endpoints": int(status == "error"),
+        "structural_endpoints": 1,
+        "wire_shape_count": len(wire_shapes) if wire_shapes is not None else 1,
         "endpoints": [
             {
                 "name": "current_version",
                 "kind": "property",
                 "status": status,
-                "entries": [{"value_sha256": value_hash}],
+                "entries": [
+                    {
+                        "value_sha256": value_hash,
+                        "wire_shape": wire_shapes
+                        if wire_shapes is not None
+                        else ["1:2"],
+                    }
+                ],
             }
         ],
     }
@@ -91,26 +105,39 @@ async def test_tracker_persists_snapshots_caps_history_and_summarizes(hass) -> N
         "observed_version": None,
         "observed_protocol": None,
         "compatibility_status": "baseline",
+        "analysis_version": ANALYSIS_VERSION,
         "last_snapshot_at": "2026-07-20T00:00:00+00:00",
         "snapshot_count": MAX_HISTORY,
         "endpoint_count": 1,
         "populated_endpoints": 1,
         "empty_endpoints": 0,
         "failed_endpoints": 0,
+        "structural_endpoints": 1,
+        "wire_shape_count": 1,
         "changed_endpoints": 0,
         "content_changed_endpoints": 0,
+        "wire_shape_changed_endpoints": 0,
+        "new_wire_shape_count": 0,
+        "wire_shape_candidate_endpoints": [],
     }
     assert tracker.summary("missing")["snapshot_count"] == 0
     assert tracker.needs_snapshot("entry", "v169.0", 25) is False
     assert tracker.needs_snapshot("entry", "v169.0", None) is True
     assert tracker.needs_snapshot("entry", "v170", 25) is True
+    legacy_snapshot = _snapshot("v169.0")
+    legacy_snapshot.pop("analysis_version")
+    tracker._data["robots"]["legacy"] = {"snapshot": legacy_snapshot}
+    assert tracker.needs_snapshot("legacy", "v169.0", 25) is True
     assert FirmwareTracker.issue_id("entry") == "firmware_changed_923fe53966c6"
     delete_issue.assert_called_once()
 
+    analysis_events = []
+    hass.bus.async_listen("matic_robot_firmware_analyzed", analysis_events.append)
     with patch(
         "custom_components.matic_robot.firmware.ir.async_create_issue"
     ) as create_issue:
         await tracker.async_record_snapshot("entry", _snapshot("v170", status="error"))
+    await hass.async_block_till_done()
     assert create_issue.call_args.kwargs["translation_key"] == "firmware_regression"
     assert create_issue.call_args.kwargs["translation_placeholders"] == {
         "previous": "v169.0",
@@ -120,6 +147,20 @@ async def test_tracker_persists_snapshots_caps_history_and_summarizes(hass) -> N
         "count": "1",
     }
     assert "entry" not in create_issue.call_args.args[2]
+    assert analysis_events[0].data == {
+        "entry_id": "entry",
+        "firmware_version": "v170",
+        "protocol_version": 25,
+        "compatibility_status": "regression",
+        "analysis_version": ANALYSIS_VERSION,
+        "structural_endpoints": 1,
+        "wire_shape_count": 1,
+        "availability_changed_endpoints": 1,
+        "content_changed_endpoints": 1,
+        "wire_shape_changed_endpoints": [],
+        "new_wire_shape_count": 0,
+        "new_wire_shapes": {},
+    }
 
     with patch(
         "custom_components.matic_robot.firmware.ir.async_delete_issue"
@@ -147,6 +188,63 @@ async def test_removed_robots_forget_history_and_withdraw_repairs(hass) -> None:
     delete_issue.assert_called_once()
     assert tracker._data["robots"] == {}
     tracker._store.async_save.assert_awaited_once()
+
+
+async def test_wire_shape_candidates_stay_silent_and_compatible(hass) -> None:
+    previous = _snapshot("v168.11", wire_shapes=["1:2"])
+    stored = {
+        "robots": {
+            "entry": {
+                "observed_version": "v168.11",
+                "observed_protocol": 25,
+                "compatibility_status": "compatible",
+                "snapshot": previous,
+                "history": [previous],
+            }
+        }
+    }
+    tracker = FirmwareTracker(hass)
+    tracker._store = SimpleNamespace(
+        async_load=AsyncMock(return_value=stored), async_save=AsyncMock()
+    )
+    await tracker.async_load()
+    events = []
+    hass.bus.async_listen("matic_robot_firmware_analyzed", events.append)
+    current = _snapshot("v169.0", wire_shapes=["1:2", "18:2", "18:2/17:2"])
+
+    with (
+        patch(
+            "custom_components.matic_robot.firmware.ir.async_create_issue"
+        ) as create_issue,
+        patch(
+            "custom_components.matic_robot.firmware.ir.async_delete_issue"
+        ) as delete_issue,
+    ):
+        comparison = await tracker.async_record_snapshot("entry", current)
+    await hass.async_block_till_done()
+
+    create_issue.assert_not_called()
+    delete_issue.assert_called_once()
+    assert comparison["wire_shape_changed_endpoints"] == ["current_version"]
+    summary = tracker.summary("entry")
+    assert summary["compatibility_status"] == "compatible"
+    assert summary["wire_shape_changed_endpoints"] == 1
+    assert summary["new_wire_shape_count"] == 2
+    assert summary["wire_shape_candidate_endpoints"] == ["current_version"]
+    assert events[0].data == {
+        "entry_id": "entry",
+        "firmware_version": "v169.0",
+        "protocol_version": 25,
+        "compatibility_status": "compatible",
+        "analysis_version": ANALYSIS_VERSION,
+        "structural_endpoints": 1,
+        "wire_shape_count": 3,
+        "availability_changed_endpoints": 0,
+        "content_changed_endpoints": 1,
+        "wire_shape_changed_endpoints": ["current_version"],
+        "new_wire_shape_count": 2,
+        "new_wire_shapes": {"current_version": ["18:2", "18:2/17:2"]},
+    }
 
 
 def test_activity_dependent_population_is_not_availability_drift() -> None:
@@ -228,6 +326,8 @@ def test_snapshot_comparison_separates_availability_from_content() -> None:
         "protocol_changed": False,
         "changed_endpoints": ["current_version"],
         "content_changed_endpoints": ["current_version"],
+        "wire_shape_changed_endpoints": [],
+        "new_wire_shapes": {},
     }
 
     added = _snapshot()
@@ -236,6 +336,33 @@ def test_snapshot_comparison_separates_availability_from_content() -> None:
         {"name": "zones", "kind": "collection", "status": "empty", "entries": []},
     ]
     assert _compare_snapshots(previous, added)["changed_endpoints"] == ["zones"]
+
+    structural = _snapshot("v169", wire_shapes=["1:2", "18:2", "18:2/17:2"])
+    structural_comparison = _compare_snapshots(previous, structural)
+    assert structural_comparison["wire_shape_changed_endpoints"] == ["current_version"]
+    assert structural_comparison["new_wire_shapes"] == {
+        "current_version": ["18:2", "18:2/17:2"]
+    }
+    assert _compatibility_status("pending", structural_comparison) == "compatible"
+
+    removed_shape = _compare_snapshots(structural, previous)
+    assert removed_shape["wire_shape_changed_endpoints"] == []
+    assert removed_shape["new_wire_shapes"] == {}
+
+    legacy = _snapshot()
+    legacy_entry = legacy["endpoints"][0]
+    assert isinstance(legacy_entry, dict)
+    legacy_entry["entries"][0].pop("wire_shape")
+    assert _compare_snapshots(legacy, structural)["new_wire_shapes"] == {}
+
+    malformed = _snapshot("v169")
+    malformed_entry = malformed["endpoints"][0]
+    assert isinstance(malformed_entry, dict)
+    malformed_entry["entries"] = [
+        {"wire_shape": None},
+        {"wire_shape": [1]},
+    ]
+    assert _compare_snapshots(previous, malformed)["new_wire_shapes"] == {}
 
     assert _compatibility_status(None, {"baseline": True}) == "baseline"
     assert (
@@ -277,3 +404,19 @@ def test_snapshot_timestamp_uses_home_assistant_utc_clock() -> None:
         return_value=SimpleNamespace(isoformat=MagicMock(return_value="timestamp")),
     ):
         assert snapshot_timestamp() == "timestamp"
+
+
+def test_fingerprint_entry_keeps_only_hashes_sizes_and_wire_shape() -> None:
+    payload = b"\x92\x01\x05\x8a\x01\x02\x12\x00"
+    fingerprint = fingerprint_entry(
+        HermesCollectionEntry(b"private-key", payload), endpoint_name="kabuki_state"
+    )
+
+    assert fingerprint["wire_shape"] == [
+        "18:2",
+        "18:2/17:2",
+        "18:2/17:2/2:2",
+    ]
+    rendered = repr(fingerprint)
+    assert "private-key" not in rendered
+    assert repr(payload) not in rendered

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -9,7 +9,13 @@ from google.protobuf.descriptor import FieldDescriptor
 from google.protobuf.message import DecodeError
 
 from custom_components.matic_robot.client.api import _decode_operational_state
-from custom_components.matic_robot.client.models import CleaningSchedule, RobotActivity
+from custom_components.matic_robot.client.models import (
+    CleaningSchedule,
+    CuesGestureStatus,
+    CuesIntent,
+    CuesVoiceStatus,
+    RobotActivity,
+)
 from custom_components.matic_robot.client.proto.hermes_pb2 import (
     CollectionRequest,
     InitialRequest,
@@ -71,6 +77,7 @@ def test_decode_absent_or_non_finite_battery_as_unknown() -> None:
 
     assert absent.battery_percentage is None
     assert absent.activity is RobotActivity.CHARGING
+    assert absent.following_person is None
     assert non_finite.battery_percentage is None
 
 
@@ -130,6 +137,129 @@ def test_live_and_future_error_codes_remain_truthful_and_automation_safe() -> No
         "error_code_304",
         "error_code_999",
     )
+
+
+def _varint(value: int) -> bytes:
+    encoded = bytearray()
+    while value > 0x7F:
+        encoded.append((value & 0x7F) | 0x80)
+        value >>= 7
+    encoded.append(value)
+    return bytes(encoded)
+
+
+def _message_field(number: int, value: bytes = b"") -> bytes:
+    return _varint(number << 3 | 2) + _varint(len(value)) + value
+
+
+def _varint_field(number: int, value: int) -> bytes:
+    return _varint(number << 3) + _varint(value)
+
+
+def _cues_output(*payloads: bytes) -> bytes:
+    return b"".join(_message_field(18, payload) for payload in payloads)
+
+
+@pytest.mark.parametrize(
+    ("field", "expected"),
+    [
+        (1, CuesVoiceStatus.DISABLED),
+        (2, CuesVoiceStatus.LISTENING_FOR_WAKE_WORD),
+        (4, CuesVoiceStatus.REJECTED),
+        (5, CuesVoiceStatus.LISTENING_FOR_INTENT),
+        (6, CuesVoiceStatus.THINKING_FOR_INTENT),
+    ],
+)
+def test_decode_cues_voice_lifecycle(field: int, expected: CuesVoiceStatus) -> None:
+    payload = _cues_output(_message_field(17, _message_field(field)))
+
+    state = _decode_operational_state(payload)
+
+    assert state.cues_voice_status is expected
+    assert state.cues_voice_intent is None
+    assert state.following_person is False
+
+
+@pytest.mark.parametrize(
+    ("field", "expected"),
+    [
+        (1, CuesIntent.CLEAN),
+        (18, CuesIntent.CLEAN),
+        (2, CuesIntent.DOCK),
+        (3, CuesIntent.PAUSE),
+        (4, CuesIntent.RESUME),
+        (5, CuesIntent.STOP),
+        (6, CuesIntent.FOLLOW_PERSON),
+        (7, CuesIntent.SINK_SUMMON),
+        (8, CuesIntent.NAVIGATE),
+        (11, CuesIntent.REDO_LAST_CLEAN),
+        (12, CuesIntent.CLEAN_ALL),
+        (13, CuesIntent.POINT_TO_CLEAN),
+        (14, CuesIntent.POINT_TO_CLEAN),
+        (15, CuesIntent.GO_AWAY),
+        (16, CuesIntent.UNKNOWN),
+        (99, CuesIntent.UNKNOWN),
+    ],
+)
+def test_decode_cues_classified_intents(field: int, expected: CuesIntent) -> None:
+    voice_intent = _message_field(field)
+    voice_status = _message_field(3, voice_intent)
+    payload = _cues_output(_message_field(17, voice_status))
+
+    state = _decode_operational_state(payload)
+
+    assert state.cues_voice_status is CuesVoiceStatus.CLASSIFIED
+    assert state.cues_voice_intent is expected
+
+
+@pytest.mark.parametrize("field", [9, 10, 17])
+def test_decode_cues_withholds_recording_only_intents(field: int) -> None:
+    voice_status = _message_field(3, _message_field(field))
+
+    state = _decode_operational_state(_cues_output(_message_field(17, voice_status)))
+
+    assert state.cues_voice_intent is CuesIntent.UNKNOWN
+
+
+@pytest.mark.parametrize(
+    ("field", "expected"),
+    list(enumerate(CuesGestureStatus, start=1)),
+)
+def test_decode_cues_gesture_lifecycle(field: int, expected: CuesGestureStatus) -> None:
+    payload = _cues_output(_message_field(21, _message_field(field)))
+
+    state = _decode_operational_state(payload)
+
+    assert state.cues_gesture_status is expected
+
+
+def test_decode_cues_synthetic_ready_fixture_and_following_presence() -> None:
+    ready_voice = _message_field(17, _message_field(2))
+    unrelated_payload = _varint_field(15, 1)
+    following = _message_field(20)
+
+    state = _decode_operational_state(
+        _cues_output(ready_voice, unrelated_payload, following)
+    )
+
+    assert state.cues_voice_status is CuesVoiceStatus.LISTENING_FOR_WAKE_WORD
+    assert state.cues_gesture_status is None
+    assert state.following_person is True
+
+
+def test_decode_cues_voice_status_ignores_unrelated_wire_fields() -> None:
+    voice_status = b"\x08\x01" + _message_field(2)
+
+    state = _decode_operational_state(_cues_output(_message_field(17, voice_status)))
+
+    assert state.cues_voice_status is CuesVoiceStatus.LISTENING_FOR_WAKE_WORD
+
+
+def test_decode_cues_rejects_malformed_targeted_payload() -> None:
+    malformed_voice_status = _message_field(17, b"\x80")
+
+    with pytest.raises(DecodeError):
+        _decode_operational_state(_cues_output(malformed_voice_status))
 
 
 def test_schedule_without_minute_of_day_has_no_wall_clock_time() -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -396,6 +396,7 @@ async def test_setup_refreshes_before_forwarding_platforms(
     coordinator = SimpleNamespace(
         async_config_entry_first_refresh=AsyncMock(),
         async_add_listener=MagicMock(return_value=coordinator_unsubscribe),
+        async_watch_cues=AsyncMock(),
         data=SimpleNamespace(
             floor_plan=FloorPlan(
                 42,
@@ -503,7 +504,8 @@ async def test_setup_refreshes_before_forwarding_platforms(
     slam_history.async_load.assert_awaited_once()
     slam_map.async_collect.assert_called_once_with(client)
     collect_history.assert_called_once()
-    assert entry.async_create_background_task.call_count == 3
+    assert entry.async_create_background_task.call_count == 4
+    coordinator.async_watch_cues.assert_called_once_with()
     assert (
         entry.runtime_data.firmware_tracker
         is (hass.data[DOMAIN][DATA_FIRMWARE_TRACKER])
@@ -585,7 +587,7 @@ async def test_setup_refreshes_before_forwarding_platforms(
         plans.async_add_listener.call_args.args[1]()
 
     assert listener_sync.call_count == 5
-    assert entry.async_create_background_task.call_count == 6
+    assert entry.async_create_background_task.call_count == 7
     assert plans.async_upgrade_area_bindings.await_count == 5
     assert plans.async_upgrade_area_bindings.call_args.args == (
         "synthetic-serial",

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -412,10 +412,9 @@ def test_user_copy_matches_pairing_and_plan_behavior() -> None:
         inspection = services["inspect_hermes_endpoint"]
         assert "payload-free" in inspection["description"]
         assert set(inspection["fields"]) == {"endpoint", "limit"}
-        assert (
-            "weekly compatibility record"
-            in services["firmware_snapshot"]["description"]
-        )
+        firmware_snapshot = services["firmware_snapshot"]["description"]
+        assert "payload-free compatibility record" in firmware_snapshot
+        assert "value-free wire-shape changes" in firmware_snapshot
         assert (
             "Review the **Firmware snapshot** response"
             in translations["issues"]["firmware_regression"]["description"]
@@ -439,8 +438,9 @@ def test_documented_entity_surface_matches_release_contract() -> None:
     readme = " ".join((ROOT / "README.md").read_text().split())
     automation = " ".join((ROOT / "docs" / "automation.md").read_text().split())
     surface = (
-        "51 fixed entities — 21 sensors, 12 binary sensors, 5 buttons, "
-        "4 switches, 4 selects, 1 number, 2 cameras, 1 update, and 1 vacuum"
+        "55 fixed entities — 23 sensors, 13 binary sensors, 5 buttons, "
+        "4 switches, 4 selects, 1 number, 2 cameras, 1 event, 1 update, and "
+        "1 vacuum"
     )
 
     assert surface in readme

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1375,9 +1375,12 @@ async def test_firmware_snapshot_persists_safe_full_endpoint_sweep() -> None:
         response = await _registered_handler(services, "firmware_snapshot")(call)
 
     assert response["endpoint_count"] == len(HERMES_ENDPOINTS)
+    assert response["analysis_version"] == 1
     assert response["populated_endpoints"] == len(HERMES_ENDPOINTS) - 2
     assert response["empty_endpoints"] == 1
     assert response["failed_endpoints"] == 1
+    assert response["structural_endpoints"] == 0
+    assert response["wire_shape_count"] == 0
     failed = next(item for item in response["endpoints"] if item["status"] == "error")
     assert failed["error_type"] == "CannotConnectError"
     assert "synthetic failure" not in repr(response)

--- a/tests/test_wire.py
+++ b/tests/test_wire.py
@@ -8,12 +8,15 @@ import pytest
 from google.protobuf.message import DecodeError
 
 from custom_components.matic_robot.client.wire import (
+    MAX_WIRE_SHAPE_BYTES,
+    MAX_WIRE_SHAPE_FIELDS,
     decode_fields,
     first_bytes,
     first_varint,
     packed_floats,
     point,
     uuid_string,
+    wire_shape,
 )
 
 
@@ -57,3 +60,24 @@ def test_uuid_search_skips_non_message_and_invalid_nested_fields() -> None:
     )
 
     assert uuid_string(payload) == "01010101-0101-0101-0202-020202020202"
+
+
+def test_wire_shape_is_bounded_value_free_and_recurses_only_on_approved_paths() -> None:
+    nested = b"\x8a\x01\x02\x12\x00"
+    payload = b"\x08\x01\x08\x7f\x92\x01" + bytes((len(nested),)) + nested
+
+    assert wire_shape(payload) == ("1:0", "18:2")
+    assert wire_shape(payload, nested_message_paths=((18,), (18, 17))) == (
+        "1:0",
+        "18:2",
+        "18:2/17:2",
+        "18:2/17:2/2:2",
+    )
+
+
+def test_wire_shape_fails_closed_for_invalid_large_or_complex_values() -> None:
+    assert wire_shape(b"") == ()
+    assert wire_shape(b"\x00") is None
+    assert wire_shape(b"\x0a\x01\x80", nested_message_paths=((1,),)) == ("1:2",)
+    assert wire_shape(b"x" * (MAX_WIRE_SHAPE_BYTES + 1)) is None
+    assert wire_shape(b"\x08\x01" * (MAX_WIRE_SHAPE_FIELDS + 1)) is None


### PR DESCRIPTION
## What

- add local Matic Cues voice and gesture state decoding, Home Assistant entities, and automation events
- add continuous live-state watching with bounded retry/backoff behavior and fresh-channel recovery after transport rollover
- preserve pushed Cues state when coordinator polls overlap
- add value-free protobuf wire-shape analysis to firmware snapshots
- silently re-baseline legacy snapshots once and emit a diagnostic event only for actual new firmware/protocol snapshots
- document and test the verified v172.9 / protocol 25 behavior

## Why

The integration previously had no HA surface for Matic Cues and the firmware checker compared only known endpoint availability/content fingerprints. That meant structural protocol additions inside known endpoints could pass unnoticed and older snapshots could not opt into richer analysis.

## User impact

Cues can now drive local HA automations without retaining speech, imagery, coordinates, or raw protobuf data. OTA analysis remains quiet for regular users: structural candidates do not change compatibility, create repairs, create persistent notifications, or log warnings. Repairs remain limited to endpoint/transport regressions.

## Checks

- `pytest --cov=custom_components/matic_robot --cov-report=term-missing` — 1,005 passed, 100.00% coverage
- `ruff check .`
- `ruff format --check .`
- `mypy custom_components`
- `python scripts/check_public_tree.py`
- release/public-tree/packaging tests — 43 passed
- live v172.9 / protocol 25 Cues lifecycle and value-free OTA shape sweep verified