### PR TITLE
Harden manual review gate

### DIFF
--- a/.github/workflows/review-base-advance.yml
+++ b/.github/workflows/review-base-advance.yml
@@ -2,6 +2,7 @@ name: Invalidate Review Gates on Base Advance
 
 on:
   push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       base_branch:

--- a/.github/workflows/review-base-advance.yml
+++ b/.github/workflows/review-base-advance.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
-    inputs:
-      base_branch:
-        description: Base branch whose open pull requests should be invalidated
-        required: false
-        type: string
 
 permissions:
   actions: write
@@ -27,7 +22,7 @@ jobs:
       - id: prs
         name: Find pull requests targeting the advanced branch
         env:
-          BASE_BRANCH: ${{ inputs.base_branch || github.ref_name }}
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
           BASE_PUSHED_AT: ${{ github.event.repository.pushed_at }}
           EVENT_NAME: ${{ github.event_name }}
           GH_TOKEN: ${{ github.token }}
@@ -53,36 +48,20 @@ jobs:
           review_gate_prs_file="$(mktemp)"
           trap 'rm -f "$review_gate_prs_file"' EXIT
           gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate > "$review_gate_prs_file"
-          # Push-triggered invalidation is deliberately conservative: only a
-          # current PR head with durable review-gate status evidence created
-          # before this base push can be invalidated. Workflow-run head_sha is
-          # the workflow ref for pull_request_target/workflow_dispatch and is
-          # therefore not evidence of the evaluated PR head.
-          matrix='{"include":[]}'
-          while IFS=$'\t' read -r pr_number event_head_sha; do
-            include_head=false
-            if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-              include_head=true
-            elif gh api "repos/$REPO/commits/$event_head_sha/statuses?per_page=100" --paginate --slurp \
-              | jq -e --arg context "review-gate" --argjson pushed_at "$base_pushed_at" '
-                  any(.[][];
-                    (.context == $context)
-                    and ((.created_at | fromdateiso8601) <= $pushed_at))' >/dev/null; then
-              include_head=true
-            fi
-            if [[ "$include_head" == "true" ]]; then
-              matrix="$(
-                jq -c --argjson pr "$pr_number" --arg head "$event_head_sha" \
-                  '.include += [{pr_number: $pr, event_head_sha: $head}]' <<< "$matrix"
-              )"
-            fi
-          done < <(
-            jq -r --arg base "$BASE_BRANCH" '
-              .[]
-              | select(.base.ref == $base)
-              | [.number, .head.sha]
-              | @tsv' "$review_gate_prs_file"
-          )
+          # Conservatively invalidate every current head for a PR that already
+          # existed when the default base advanced. A head pushed while this
+          # job waited is safe to include because it already requires a fresh
+          # exact-head review; PRs opened after the base push are left alone.
+          matrix="$(
+            jq -sc --arg base "$BASE_BRANCH" --arg event "$EVENT_NAME" \
+              --argjson pushed_at "$base_pushed_at" '
+                {include: [.[][]
+                  | select(.base.ref == $base)
+                  | select($event == "workflow_dispatch"
+                      or ((.created_at | fromdateiso8601) <= $pushed_at))
+                  | {pr_number: .number, event_head_sha: .head.sha}]}'
+              "$review_gate_prs_file"
+          )"
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
           echo "count=$(jq '.include | length' <<< "$matrix")" >> "$GITHUB_OUTPUT"
 
@@ -103,7 +82,7 @@ jobs:
     steps:
       - name: Persist a base-change marker and revoke the required gate
         env:
-          BASE_BRANCH: ${{ inputs.base_branch || github.ref_name }}
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
           EVENT_HEAD_SHA: ${{ matrix.event_head_sha }}
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ matrix.pr_number }}

--- a/.github/workflows/review-base-advance.yml
+++ b/.github/workflows/review-base-advance.yml
@@ -48,40 +48,41 @@ jobs:
             exit 1
           fi
           base_pushed_at="${BASE_PUSHED_AT:-0}"
-          # Workflow histories can exceed the platform argument limit; retain
-          # paginated API JSON in scoped temporary files instead of argv.
+          # Pull-request histories can exceed the platform argument limit;
+          # retain paginated API JSON in a scoped temporary file.
           review_gate_prs_file="$(mktemp)"
-          review_gate_runs_file="$(mktemp)"
-          trap 'rm -f "$review_gate_prs_file" "$review_gate_runs_file"' EXIT
+          trap 'rm -f "$review_gate_prs_file"' EXIT
           gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate > "$review_gate_prs_file"
-          gh api "repos/$REPO/actions/workflows/review-gate.yml/runs?per_page=100" --paginate > "$review_gate_runs_file"
           # Push-triggered invalidation is deliberately conservative: only a
-          # PR/head recorded by a review-gate run created before this base push
-          # can be invalidated. A PR opened later or given a fresh head while
-          # this job waited is left to its newer event-driven evaluation.
-          matrix="$(
-            jq -cn --slurpfile prs "$review_gate_prs_file" --slurpfile runs "$review_gate_runs_file" \
-              --arg base "$BASE_BRANCH" --arg event "$EVENT_NAME" \
-              --argjson pushed_at "$base_pushed_at" '
-                def snapshot_before_base_push($number):
-                  [$runs[] | .workflow_runs[]?
-                   | select(any(.pull_requests[]?; .number == $number))
-                   | select((.created_at | fromdateiso8601) <= $pushed_at)
-                   | {created_at, head_sha}]
-                  | sort_by(.created_at)
-                  | last;
-                {include: [$prs[][]
-                  | select(.base.ref == $base)
-                  | . as $pr
-                  | if $event == "workflow_dispatch" then
-                      {pr_number: $pr.number, event_head_sha: $pr.head.sha}
-                    else
-                      (snapshot_before_base_push($pr.number)) as $snapshot
-                      | select($snapshot != null)
-                      | select($snapshot.head_sha == $pr.head.sha)
-                      | {pr_number: $pr.number, event_head_sha: $snapshot.head_sha}
-                    end]}'
-          )"
+          # current PR head with durable review-gate status evidence created
+          # before this base push can be invalidated. Workflow-run head_sha is
+          # the workflow ref for pull_request_target/workflow_dispatch and is
+          # therefore not evidence of the evaluated PR head.
+          matrix='{"include":[]}'
+          while IFS=$'\t' read -r pr_number event_head_sha; do
+            include_head=false
+            if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+              include_head=true
+            elif gh api "repos/$REPO/commits/$event_head_sha/statuses?per_page=100" --paginate --slurp \
+              | jq -e --arg context "review-gate" --argjson pushed_at "$base_pushed_at" '
+                  any(.[][];
+                    (.context == $context)
+                    and ((.created_at | fromdateiso8601) <= $pushed_at))' >/dev/null; then
+              include_head=true
+            fi
+            if [[ "$include_head" == "true" ]]; then
+              matrix="$(
+                jq -c --argjson pr "$pr_number" --arg head "$event_head_sha" \
+                  '.include += [{pr_number: $pr, event_head_sha: $head}]' <<< "$matrix"
+              )"
+            fi
+          done < <(
+            jq -r --arg base "$BASE_BRANCH" '
+              .[]
+              | select(.base.ref == $base)
+              | [.number, .head.sha]
+              | @tsv' "$review_gate_prs_file"
+          )
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
           echo "count=$(jq '.include | length' <<< "$matrix")" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/review-base-advance.yml
+++ b/.github/workflows/review-base-advance.yml
@@ -2,7 +2,6 @@ name: Invalidate Review Gates on Base Advance
 
 on:
   push:
-    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -14,6 +13,7 @@ permissions:
 jobs:
   discover:
     name: discover-targeting-prs
+    if: github.event_name != 'push' || github.ref_name == github.event.repository.default_branch
     runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
     outputs:
       matrix: ${{ steps.prs.outputs.matrix }}
@@ -43,8 +43,8 @@ jobs:
           gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate > "$review_gate_prs_file"
           # GitHub does not expose the time a particular SHA became a PR head.
           # Over-invalidate rather than trusting contributor-controlled commit
-          # timestamps. The gate permits a clean review posted after this base
-          # push on the same head, so a delayed workflow never requires a push.
+          # timestamps. A durable marker requires the contributor to push a
+          # new head before a regular review can qualify after this base push.
           matrix='{"include":[]}'
           while IFS=$'\t' read -r pr_number event_head_sha; do
             matrix="$(
@@ -73,7 +73,7 @@ jobs:
     # follow-up evaluation observes the durable marker under the gate lock.
     concurrency:
       group: review-gate-base-advance-${{ matrix.pr_number }}
-      cancel-in-progress: true
+      cancel-in-progress: false
     runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
     steps:
       - name: Persist a base-change marker and revoke the required gate
@@ -81,6 +81,7 @@ jobs:
           BASE_BRANCH: ${{ github.event.repository.default_branch }}
           BASE_PUSHED_AT: ${{ github.event_name == 'push' && github.event.repository.pushed_at || '' }}
           EVENT_HEAD_SHA: ${{ matrix.event_head_sha }}
+          EVENT_BASE_SHA: ${{ github.sha }}
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ matrix.pr_number }}
           REPO: ${{ github.repository }}
@@ -94,8 +95,8 @@ jobs:
             echo "GitHub CLI (gh) is required."
             exit 1
           }
-          if [[ ! "$EVENT_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "Could not resolve the PR head at the base-advance event." >&2
+          if [[ ! "$EVENT_HEAD_SHA" =~ ^[0-9a-f]{40}$ || ! "$EVENT_BASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Could not resolve the base-advance event state." >&2
             exit 1
           fi
           pr_state="$(
@@ -105,6 +106,10 @@ jobs:
           IFS=$'\t' read -r pr_node_id current_base base_sha head_sha auto_merge_enabled <<< "$pr_state"
           if [[ "$current_base" != "$BASE_BRANCH" ]]; then
             echo "PR #$PR_NUMBER no longer targets $BASE_BRANCH; skipping it."
+            exit 0
+          fi
+          if [[ "$base_sha" != "$EVENT_BASE_SHA" ]]; then
+            echo "A newer base push superseded this invalidation; skipping the older event."
             exit 0
           fi
           # Discovery can race a synchronize. Mark the current head instead of
@@ -128,8 +133,8 @@ jobs:
           else
             base_advanced_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           fi
-          gate_description="Base changed; request a fresh @codex review"
-          marker_description="Base changed for PR #$PR_NUMBER at base $base_sha at $base_advanced_at; request a fresh @codex review"
+          gate_description="Base changed; push a new head before @codex review"
+          marker_description="Base changed for PR #$PR_NUMBER at base $base_sha at $base_advanced_at; push a new head before @codex review"
 
           active_gate_runs() {
             gh api "repos/$REPO/actions/workflows/review-gate.yml/runs?per_page=100" --paginate --slurp \

--- a/.github/workflows/review-base-advance.yml
+++ b/.github/workflows/review-base-advance.yml
@@ -59,7 +59,7 @@ jobs:
           # this job waited is left to its newer event-driven evaluation.
           matrix="$(
             jq -cn --slurpfile prs "$review_gate_prs_file" --slurpfile runs "$review_gate_runs_file" \
-              --arg base "$BASE_BRANCH" --arg event "$EVENT_NAME" --arg repo "$REPO" \
+              --arg base "$BASE_BRANCH" --arg event "$EVENT_NAME" \
               --argjson pushed_at "$base_pushed_at" '
                 def snapshot_before_base_push($number):
                   [$runs[] | .workflow_runs[]?
@@ -70,7 +70,6 @@ jobs:
                   | last;
                 {include: [$prs[][]
                   | select(.base.ref == $base)
-                  | select(.head.repo.full_name == $repo)
                   | . as $pr
                   | if $event == "workflow_dispatch" then
                       {pr_number: $pr.number, event_head_sha: $pr.head.sha}
@@ -121,19 +120,15 @@ jobs:
           fi
           pr_state="$(
             gh api "repos/$REPO/pulls/$PR_NUMBER" \
-              | jq -er '[.node_id, .base.ref, .base.sha, .head.sha, .head.ref, .head.repo.full_name, ((.auto_merge != null) | tostring)] | @tsv'
+              | jq -er '[.node_id, .base.ref, .base.sha, .head.sha, ((.auto_merge != null) | tostring)] | @tsv'
           )"
-          IFS=$'\t' read -r pr_node_id current_base base_sha head_sha head_ref head_repository auto_merge_enabled <<< "$pr_state"
+          IFS=$'\t' read -r pr_node_id current_base base_sha head_sha auto_merge_enabled <<< "$pr_state"
           if [[ "$current_base" != "$BASE_BRANCH" ]]; then
             echo "PR #$PR_NUMBER no longer targets $BASE_BRANCH; skipping it."
             exit 0
           fi
           if [[ "$head_sha" != "$EVENT_HEAD_SHA" ]]; then
             echo "PR #$PR_NUMBER gained a new head after the base advance; leaving it reviewable."
-            exit 0
-          fi
-          if [[ "$head_repository" != "$REPO" || -z "$head_ref" ]]; then
-            echo "PR #$PR_NUMBER is not a same-repository branch; leaving its gate pending."
             exit 0
           fi
           if [[ ! "$pr_node_id" =~ ^PR_ || ! "$base_sha" =~ ^[0-9a-f]{40}$ || ! "$head_sha" =~ ^[0-9a-f]{40}$ || ! "$auto_merge_enabled" =~ ^(true|false)$ ]]; then
@@ -186,6 +181,12 @@ jobs:
           stamp_pending "$REVIEW_BASE_CONTEXT" "$marker_description"
           cancel_active_gate_runs
           stamp_pending "$REVIEW_GATE_CONTEXT" "$gate_description"
-          gh workflow run review-gate.yml --repo "$REPO" --ref "$head_ref" \
+          if ! gh api \
+            "repos/$REPO/contents/.github/workflows/review-gate.yml?ref=$current_base" \
+            --silent >/dev/null 2>&1; then
+            echo "Trusted review-gate evaluator is not installed on $current_base; leaving the required gate pending."
+            exit 0
+          fi
+          gh workflow run review-gate.yml --repo "$REPO" --ref "$current_base" \
             -f pull_request="$PR_NUMBER"
           echo "Base branch advancement invalidated regular review for PR #$PR_NUMBER."

--- a/.github/workflows/review-base-advance.yml
+++ b/.github/workflows/review-base-advance.yml
@@ -48,20 +48,37 @@ jobs:
           review_gate_prs_file="$(mktemp)"
           trap 'rm -f "$review_gate_prs_file"' EXIT
           gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate > "$review_gate_prs_file"
-          # Conservatively invalidate every current head for a PR that already
-          # existed when the default base advanced. A head pushed while this
-          # job waited is safe to include because it already requires a fresh
-          # exact-head review; PRs opened after the base push are left alone.
-          matrix="$(
-            jq -sc --arg base "$BASE_BRANCH" --arg event "$EVENT_NAME" \
+          # Invalidate PR heads that existed when the default base advanced.
+          # A current head with a commit timestamp after that push is a newer
+          # synchronize and already requires its own exact-head review, so do
+          # not place an obsolete base-change marker on it.
+          matrix='{"include":[]}'
+          while IFS=$'\t' read -r pr_number event_head_sha; do
+            head_committed_at="$(
+              gh api "repos/$REPO/commits/$event_head_sha" \
+                | jq -er '.commit.committer.date | fromdateiso8601'
+            )" || {
+              echo "Could not determine when PR #$pr_number head was committed; skipping it."
+              continue
+            }
+            if [[ "$EVENT_NAME" == "push" && "$head_committed_at" -gt "$base_pushed_at" ]]; then
+              echo "PR #$pr_number gained a new head after the base advance; leaving it reviewable."
+              continue
+            fi
+            matrix="$(
+              jq -c --argjson pr "$pr_number" --arg head "$event_head_sha" \
+                '.include += [{pr_number: $pr, event_head_sha: $head}]' <<< "$matrix"
+            )"
+          done < <(
+            jq -r --arg base "$BASE_BRANCH" --arg event "$EVENT_NAME" \
               --argjson pushed_at "$base_pushed_at" '
-                {include: [.[][]
-                  | select(.base.ref == $base)
-                  | select($event == "workflow_dispatch"
-                      or ((.created_at | fromdateiso8601) <= $pushed_at))
-                  | {pr_number: .number, event_head_sha: .head.sha}]}'
-              "$review_gate_prs_file"
-          )"
+                .[][]
+                | select(.base.ref == $base)
+                | select($event == "workflow_dispatch"
+                    or ((.created_at | fromdateiso8601) <= $pushed_at))
+                | [.number, .head.sha]
+                | @tsv' "$review_gate_prs_file"
+          )
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
           echo "count=$(jq '.include | length' <<< "$matrix")" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/review-base-advance.yml
+++ b/.github/workflows/review-base-advance.yml
@@ -79,27 +79,53 @@ jobs:
           }
           pr_state="$(
             gh api "repos/$REPO/pulls/$PR_NUMBER" \
-              | jq -er '[.node_id, .base.ref, .head.sha, ((.auto_merge != null) | tostring)] | @tsv'
+              | jq -er '[.node_id, .base.ref, .base.sha, .head.sha, ((.auto_merge != null) | tostring)] | @tsv'
           )"
-          IFS=$'\t' read -r pr_node_id current_base head_sha auto_merge_enabled <<< "$pr_state"
+          IFS=$'\t' read -r pr_node_id current_base base_sha head_sha auto_merge_enabled <<< "$pr_state"
           if [[ "$current_base" != "$BASE_BRANCH" ]]; then
             echo "PR #$PR_NUMBER no longer targets $BASE_BRANCH; skipping it."
             exit 0
           fi
-          if [[ ! "$pr_node_id" =~ ^PR_ || ! "$head_sha" =~ ^[0-9a-f]{40}$ || ! "$auto_merge_enabled" =~ ^(true|false)$ ]]; then
+          if [[ ! "$pr_node_id" =~ ^PR_ || ! "$base_sha" =~ ^[0-9a-f]{40}$ || ! "$head_sha" =~ ^[0-9a-f]{40}$ || ! "$auto_merge_enabled" =~ ^(true|false)$ ]]; then
             echo "Could not resolve the current PR state for #$PR_NUMBER." >&2
             exit 1
           fi
 
           stamp_pending() {
             local context="$1"
+            local description="$2"
             gh api "repos/$REPO/statuses/$head_sha" --silent \
               -f state=pending \
               -f context="$context" \
-              -f description="Base changed; push a new head before @codex review" \
+              -f description="$description" \
               -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
           }
-          stamp_pending "$REVIEW_GATE_CONTEXT"
+          gate_description="Base changed; push a new head before @codex review"
+          marker_description="Base changed for PR #$PR_NUMBER at base $base_sha; push a new head before @codex review"
+
+          active_gate_runs() {
+            gh api "repos/$REPO/actions/workflows/review-gate.yml/runs?per_page=100" --paginate --slurp \
+              | jq -r --argjson pr "$PR_NUMBER" --arg run_name "review-gate #$PR_NUMBER" '.[] | .workflow_runs[]?
+                  | select(.status != "completed")
+                  | select(any(.pull_requests[]?; .number == $pr) or .display_title == $run_name)
+                  | .id'
+          }
+
+          cancel_active_gate_runs() {
+            for run_id in $(active_gate_runs); do
+              gh run cancel "$run_id" --repo "$REPO" || true
+            done
+            for _attempt in $(seq 1 15); do
+              if [[ -z "$(active_gate_runs)" ]]; then
+                return 0
+              fi
+              sleep 2
+            done
+            echo "Review-gate runs for PR #$PR_NUMBER did not stop in time." >&2
+            exit 1
+          }
+
+          stamp_pending "$REVIEW_GATE_CONTEXT" "$gate_description"
           if [[ "$auto_merge_enabled" == "true" ]]; then
             # shellcheck disable=SC2016 # GraphQL expands this variable, not the shell.
             gh api graphql \
@@ -107,8 +133,9 @@ jobs:
               -F pullRequestId="$pr_node_id" >/dev/null
             echo "Disabled automatic merge for PR #$PR_NUMBER."
           fi
-          stamp_pending "$REVIEW_BASE_CONTEXT"
-          stamp_pending "$REVIEW_GATE_CONTEXT"
+          stamp_pending "$REVIEW_BASE_CONTEXT" "$marker_description"
+          cancel_active_gate_runs
+          stamp_pending "$REVIEW_GATE_CONTEXT" "$gate_description"
           gh workflow run review-gate.yml --repo "$REPO" \
             -f pull_request="$PR_NUMBER"
           echo "Base branch advancement invalidated regular review for PR #$PR_NUMBER."

--- a/.github/workflows/review-base-advance.yml
+++ b/.github/workflows/review-base-advance.yml
@@ -23,8 +23,6 @@ jobs:
         name: Find pull requests targeting the advanced branch
         env:
           BASE_BRANCH: ${{ github.event.repository.default_branch }}
-          BASE_PUSHED_AT: ${{ github.event.repository.pushed_at }}
-          EVENT_NAME: ${{ github.event_name }}
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
@@ -38,44 +36,25 @@ jobs:
             echo "Could not resolve the advanced base branch." >&2
             exit 1
           fi
-          if [[ "$EVENT_NAME" == "push" && ! "$BASE_PUSHED_AT" =~ ^[0-9]+$ ]]; then
-            echo "Could not determine when the base branch was advanced." >&2
-            exit 1
-          fi
-          base_pushed_at="${BASE_PUSHED_AT:-0}"
           # Pull-request histories can exceed the platform argument limit;
           # retain paginated API JSON in a scoped temporary file.
           review_gate_prs_file="$(mktemp)"
           trap 'rm -f "$review_gate_prs_file"' EXIT
           gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate > "$review_gate_prs_file"
-          # Invalidate PR heads that existed when the default base advanced.
-          # A current head with a commit timestamp after that push is a newer
-          # synchronize and already requires its own exact-head review, so do
-          # not place an obsolete base-change marker on it.
+          # GitHub does not expose the time a particular SHA became a PR head.
+          # Over-invalidate rather than trusting contributor-controlled commit
+          # timestamps. The gate permits a clean review posted after this base
+          # push on the same head, so a delayed workflow never requires a push.
           matrix='{"include":[]}'
           while IFS=$'\t' read -r pr_number event_head_sha; do
-            head_committed_at="$(
-              gh api "repos/$REPO/commits/$event_head_sha" \
-                | jq -er '.commit.committer.date | fromdateiso8601'
-            )" || {
-              echo "Could not determine when PR #$pr_number head was committed; skipping it."
-              continue
-            }
-            if [[ "$EVENT_NAME" == "push" && "$head_committed_at" -gt "$base_pushed_at" ]]; then
-              echo "PR #$pr_number gained a new head after the base advance; leaving it reviewable."
-              continue
-            fi
             matrix="$(
               jq -c --argjson pr "$pr_number" --arg head "$event_head_sha" \
                 '.include += [{pr_number: $pr, event_head_sha: $head}]' <<< "$matrix"
             )"
           done < <(
-            jq -r --arg base "$BASE_BRANCH" --arg event "$EVENT_NAME" \
-              --argjson pushed_at "$base_pushed_at" '
-                .[][]
+            jq -r --arg base "$BASE_BRANCH" '
+                .[]
                 | select(.base.ref == $base)
-                | select($event == "workflow_dispatch"
-                    or ((.created_at | fromdateiso8601) <= $pushed_at))
                 | [.number, .head.sha]
                 | @tsv' "$review_gate_prs_file"
           )
@@ -100,6 +79,7 @@ jobs:
       - name: Persist a base-change marker and revoke the required gate
         env:
           BASE_BRANCH: ${{ github.event.repository.default_branch }}
+          BASE_PUSHED_AT: ${{ github.event_name == 'push' && github.event.repository.pushed_at || '' }}
           EVENT_HEAD_SHA: ${{ matrix.event_head_sha }}
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ matrix.pr_number }}
@@ -127,10 +107,8 @@ jobs:
             echo "PR #$PR_NUMBER no longer targets $BASE_BRANCH; skipping it."
             exit 0
           fi
-          if [[ "$head_sha" != "$EVENT_HEAD_SHA" ]]; then
-            echo "PR #$PR_NUMBER gained a new head after the base advance; leaving it reviewable."
-            exit 0
-          fi
+          # Discovery can race a synchronize. Mark the current head instead of
+          # trusting commit metadata or silently leaving a stale green gate.
           if [[ ! "$pr_node_id" =~ ^PR_ || ! "$base_sha" =~ ^[0-9a-f]{40}$ || ! "$head_sha" =~ ^[0-9a-f]{40}$ || ! "$auto_merge_enabled" =~ ^(true|false)$ ]]; then
             echo "Could not resolve the current PR state for #$PR_NUMBER." >&2
             exit 1
@@ -145,8 +123,13 @@ jobs:
               -f description="$description" \
               -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
           }
-          gate_description="Base changed; push a new head before @codex review"
-          marker_description="Base changed for PR #$PR_NUMBER at base $base_sha; push a new head before @codex review"
+          if [[ "$BASE_PUSHED_AT" =~ ^[0-9]+$ ]]; then
+            base_advanced_at="$(jq -nr --argjson epoch "$BASE_PUSHED_AT" '$epoch | todateiso8601')"
+          else
+            base_advanced_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          fi
+          gate_description="Base changed; request a fresh @codex review"
+          marker_description="Base changed for PR #$PR_NUMBER at base $base_sha at $base_advanced_at; request a fresh @codex review"
 
           active_gate_runs() {
             gh api "repos/$REPO/actions/workflows/review-gate.yml/runs?per_page=100" --paginate --slurp \

--- a/.github/workflows/review-base-advance.yml
+++ b/.github/workflows/review-base-advance.yml
@@ -42,7 +42,9 @@ jobs:
           matrix="$(
             gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate --slurp \
               | jq -c --arg base "$BASE_BRANCH" \
-                  '{include: [.[][] | select(.base.ref == $base) | {pr_number: .number}]}'
+                  '{include: [.[][]
+                    | select(.base.ref == $base)
+                    | {pr_number: .number, event_head_sha: .head.sha}]}'
           )"
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
           echo "count=$(jq '.include | length' <<< "$matrix")" >> "$GITHUB_OUTPUT"
@@ -65,6 +67,7 @@ jobs:
       - name: Persist a base-change marker and revoke the required gate
         env:
           BASE_BRANCH: ${{ inputs.base_branch || github.ref_name }}
+          EVENT_HEAD_SHA: ${{ matrix.event_head_sha }}
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ matrix.pr_number }}
           REPO: ${{ github.repository }}
@@ -77,6 +80,10 @@ jobs:
             echo "GitHub CLI (gh) is required."
             exit 1
           }
+          if [[ ! "$EVENT_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Could not resolve the PR head at the base-advance event." >&2
+            exit 1
+          fi
           pr_state="$(
             gh api "repos/$REPO/pulls/$PR_NUMBER" \
               | jq -er '[.node_id, .base.ref, .base.sha, .head.sha, ((.auto_merge != null) | tostring)] | @tsv'
@@ -84,6 +91,10 @@ jobs:
           IFS=$'\t' read -r pr_node_id current_base base_sha head_sha auto_merge_enabled <<< "$pr_state"
           if [[ "$current_base" != "$BASE_BRANCH" ]]; then
             echo "PR #$PR_NUMBER no longer targets $BASE_BRANCH; skipping it."
+            exit 0
+          fi
+          if [[ "$head_sha" != "$EVENT_HEAD_SHA" ]]; then
+            echo "PR #$PR_NUMBER gained a new head after the base advance; leaving it reviewable."
             exit 0
           fi
           if [[ ! "$pr_node_id" =~ ^PR_ || ! "$base_sha" =~ ^[0-9a-f]{40}$ || ! "$head_sha" =~ ^[0-9a-f]{40}$ || ! "$auto_merge_enabled" =~ ^(true|false)$ ]]; then

--- a/.github/workflows/review-base-advance.yml
+++ b/.github/workflows/review-base-advance.yml
@@ -59,7 +59,7 @@ jobs:
           # this job waited is left to its newer event-driven evaluation.
           matrix="$(
             jq -cn --slurpfile prs "$review_gate_prs_file" --slurpfile runs "$review_gate_runs_file" \
-              --arg base "$BASE_BRANCH" --arg event "$EVENT_NAME" \
+              --arg base "$BASE_BRANCH" --arg event "$EVENT_NAME" --arg repo "$REPO" \
               --argjson pushed_at "$base_pushed_at" '
                 def snapshot_before_base_push($number):
                   [$runs[] | .workflow_runs[]?
@@ -70,6 +70,7 @@ jobs:
                   | last;
                 {include: [$prs[][]
                   | select(.base.ref == $base)
+                  | select(.head.repo.full_name == $repo)
                   | . as $pr
                   | if $event == "workflow_dispatch" then
                       {pr_number: $pr.number, event_head_sha: $pr.head.sha}
@@ -120,15 +121,19 @@ jobs:
           fi
           pr_state="$(
             gh api "repos/$REPO/pulls/$PR_NUMBER" \
-              | jq -er '[.node_id, .base.ref, .base.sha, .head.sha, ((.auto_merge != null) | tostring)] | @tsv'
+              | jq -er '[.node_id, .base.ref, .base.sha, .head.sha, .head.ref, .head.repo.full_name, ((.auto_merge != null) | tostring)] | @tsv'
           )"
-          IFS=$'\t' read -r pr_node_id current_base base_sha head_sha auto_merge_enabled <<< "$pr_state"
+          IFS=$'\t' read -r pr_node_id current_base base_sha head_sha head_ref head_repository auto_merge_enabled <<< "$pr_state"
           if [[ "$current_base" != "$BASE_BRANCH" ]]; then
             echo "PR #$PR_NUMBER no longer targets $BASE_BRANCH; skipping it."
             exit 0
           fi
           if [[ "$head_sha" != "$EVENT_HEAD_SHA" ]]; then
             echo "PR #$PR_NUMBER gained a new head after the base advance; leaving it reviewable."
+            exit 0
+          fi
+          if [[ "$head_repository" != "$REPO" || -z "$head_ref" ]]; then
+            echo "PR #$PR_NUMBER is not a same-repository branch; leaving its gate pending."
             exit 0
           fi
           if [[ ! "$pr_node_id" =~ ^PR_ || ! "$base_sha" =~ ^[0-9a-f]{40}$ || ! "$head_sha" =~ ^[0-9a-f]{40}$ || ! "$auto_merge_enabled" =~ ^(true|false)$ ]]; then
@@ -181,6 +186,6 @@ jobs:
           stamp_pending "$REVIEW_BASE_CONTEXT" "$marker_description"
           cancel_active_gate_runs
           stamp_pending "$REVIEW_GATE_CONTEXT" "$gate_description"
-          gh workflow run review-gate.yml --repo "$REPO" --ref "$current_base" \
+          gh workflow run review-gate.yml --repo "$REPO" --ref "$head_ref" \
             -f pull_request="$PR_NUMBER"
           echo "Base branch advancement invalidated regular review for PR #$PR_NUMBER."

--- a/.github/workflows/review-base-advance.yml
+++ b/.github/workflows/review-base-advance.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   actions: write
+  contents: read
   pull-requests: write
   statuses: write
 
@@ -107,6 +108,7 @@ jobs:
           REPO: ${{ github.repository }}
           REVIEW_BASE_CONTEXT: review-gate-base-change
           REVIEW_GATE_CONTEXT: review-gate
+          WORKFLOW_REF: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
           export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
@@ -182,11 +184,11 @@ jobs:
           cancel_active_gate_runs
           stamp_pending "$REVIEW_GATE_CONTEXT" "$gate_description"
           if ! gh api \
-            "repos/$REPO/contents/.github/workflows/review-gate.yml?ref=$current_base" \
+            "repos/$REPO/contents/.github/workflows/review-gate.yml?ref=$WORKFLOW_REF" \
             --silent >/dev/null 2>&1; then
-            echo "Trusted review-gate evaluator is not installed on $current_base; leaving the required gate pending."
+            echo "Trusted review-gate evaluator is not installed on $WORKFLOW_REF; leaving the required gate pending."
             exit 0
           fi
-          gh workflow run review-gate.yml --repo "$REPO" --ref "$current_base" \
+          gh workflow run review-gate.yml --repo "$REPO" --ref "$WORKFLOW_REF" \
             -f pull_request="$PR_NUMBER"
           echo "Base branch advancement invalidated regular review for PR #$PR_NUMBER."

--- a/.github/workflows/review-base-advance.yml
+++ b/.github/workflows/review-base-advance.yml
@@ -10,7 +10,8 @@ on:
         type: string
 
 permissions:
-  pull-requests: read
+  actions: write
+  pull-requests: write
   statuses: write
 
 jobs:
@@ -53,10 +54,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
-    # A base update must stop any in-flight evaluator before it can stamp a
-    # stale success. Normal review events use the same group and queue here.
+    # Keep this invalidator independent from normal evaluation so a later
+    # review event cannot replace it while it is waiting for a runner. Its
+    # follow-up evaluation observes the durable marker under the gate lock.
     concurrency:
-      group: review-gate-${{ matrix.pr_number }}
+      group: review-gate-base-advance-${{ matrix.pr_number }}
       cancel-in-progress: true
     runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
     steps:
@@ -77,15 +79,15 @@ jobs:
           }
           pr_state="$(
             gh api "repos/$REPO/pulls/$PR_NUMBER" \
-              | jq -er '[.base.ref, .head.sha] | @tsv'
+              | jq -er '[.node_id, .base.ref, .head.sha, ((.auto_merge != null) | tostring)] | @tsv'
           )"
-          IFS=$'\t' read -r current_base head_sha <<< "$pr_state"
+          IFS=$'\t' read -r pr_node_id current_base head_sha auto_merge_enabled <<< "$pr_state"
           if [[ "$current_base" != "$BASE_BRANCH" ]]; then
             echo "PR #$PR_NUMBER no longer targets $BASE_BRANCH; skipping it."
             exit 0
           fi
-          if [[ ! "$head_sha" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "Could not resolve a valid PR head SHA for #$PR_NUMBER." >&2
+          if [[ ! "$pr_node_id" =~ ^PR_ || ! "$head_sha" =~ ^[0-9a-f]{40}$ || ! "$auto_merge_enabled" =~ ^(true|false)$ ]]; then
+            echo "Could not resolve the current PR state for #$PR_NUMBER." >&2
             exit 1
           fi
 
@@ -98,6 +100,15 @@ jobs:
               -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
           }
           stamp_pending "$REVIEW_GATE_CONTEXT"
+          if [[ "$auto_merge_enabled" == "true" ]]; then
+            # shellcheck disable=SC2016 # GraphQL expands this variable, not the shell.
+            gh api graphql \
+              -f query='mutation($pullRequestId: ID!) { disablePullRequestAutoMerge(input: {pullRequestId: $pullRequestId}) { pullRequest { id } } }' \
+              -F pullRequestId="$pr_node_id" >/dev/null
+            echo "Disabled automatic merge for PR #$PR_NUMBER."
+          fi
           stamp_pending "$REVIEW_BASE_CONTEXT"
           stamp_pending "$REVIEW_GATE_CONTEXT"
+          gh workflow run review-gate.yml --repo "$REPO" \
+            -f pull_request="$PR_NUMBER"
           echo "Base branch advancement invalidated regular review for PR #$PR_NUMBER."

--- a/.github/workflows/review-base-advance.yml
+++ b/.github/workflows/review-base-advance.yml
@@ -46,14 +46,19 @@ jobs:
             exit 1
           fi
           base_pushed_at="${BASE_PUSHED_AT:-0}"
-          open_prs="$(gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate --slurp)"
-          gate_runs="$(gh api "repos/$REPO/actions/workflows/review-gate.yml/runs?per_page=100" --paginate --slurp)"
+          # Workflow histories can exceed the platform argument limit; retain
+          # paginated API JSON in scoped temporary files instead of argv.
+          review_gate_prs_file="$(mktemp)"
+          review_gate_runs_file="$(mktemp)"
+          trap 'rm -f "$review_gate_prs_file" "$review_gate_runs_file"' EXIT
+          gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate > "$review_gate_prs_file"
+          gh api "repos/$REPO/actions/workflows/review-gate.yml/runs?per_page=100" --paginate > "$review_gate_runs_file"
           # Push-triggered invalidation is deliberately conservative: only a
           # PR/head recorded by a review-gate run created before this base push
           # can be invalidated. A PR opened later or given a fresh head while
           # this job waited is left to its newer event-driven evaluation.
           matrix="$(
-            jq -cn --argjson prs "$open_prs" --argjson runs "$gate_runs" \
+            jq -cn --slurpfile prs "$review_gate_prs_file" --slurpfile runs "$review_gate_runs_file" \
               --arg base "$BASE_BRANCH" --arg event "$EVENT_NAME" \
               --argjson pushed_at "$base_pushed_at" '
                 def snapshot_before_base_push($number):

--- a/.github/workflows/review-base-advance.yml
+++ b/.github/workflows/review-base-advance.yml
@@ -1,0 +1,103 @@
+name: Invalidate Review Gates on Base Advance
+
+on:
+  push:
+  workflow_dispatch:
+    inputs:
+      base_branch:
+        description: Base branch whose open pull requests should be invalidated
+        required: false
+        type: string
+
+permissions:
+  pull-requests: read
+  statuses: write
+
+jobs:
+  discover:
+    name: discover-targeting-prs
+    runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
+    outputs:
+      matrix: ${{ steps.prs.outputs.matrix }}
+      count: ${{ steps.prs.outputs.count }}
+    steps:
+      - id: prs
+        name: Find pull requests targeting the advanced branch
+        env:
+          BASE_BRANCH: ${{ inputs.base_branch || github.ref_name }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+          command -v gh >/dev/null 2>&1 || {
+            echo "GitHub CLI (gh) is required."
+            exit 1
+          }
+          if [[ -z "$BASE_BRANCH" ]]; then
+            echo "Could not resolve the advanced base branch." >&2
+            exit 1
+          fi
+          matrix="$(
+            gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate --slurp \
+              | jq -c --arg base "$BASE_BRANCH" \
+                  '{include: [.[][] | select(.base.ref == $base) | {pr_number: .number}]}'
+          )"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "count=$(jq '.include | length' <<< "$matrix")" >> "$GITHUB_OUTPUT"
+
+  invalidate:
+    name: invalidate (${{ matrix.pr_number }})
+    needs: discover
+    if: needs.discover.outputs.count != '0'
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
+    # A base update must stop any in-flight evaluator before it can stamp a
+    # stale success. Normal review events use the same group and queue here.
+    concurrency:
+      group: review-gate-${{ matrix.pr_number }}
+      cancel-in-progress: true
+    runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
+    steps:
+      - name: Persist a base-change marker and revoke the required gate
+        env:
+          BASE_BRANCH: ${{ inputs.base_branch || github.ref_name }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ matrix.pr_number }}
+          REPO: ${{ github.repository }}
+          REVIEW_BASE_CONTEXT: review-gate-base-change
+          REVIEW_GATE_CONTEXT: review-gate
+        run: |
+          set -euo pipefail
+          export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+          command -v gh >/dev/null 2>&1 || {
+            echo "GitHub CLI (gh) is required."
+            exit 1
+          }
+          pr_state="$(
+            gh api "repos/$REPO/pulls/$PR_NUMBER" \
+              | jq -er '[.base.ref, .head.sha] | @tsv'
+          )"
+          IFS=$'\t' read -r current_base head_sha <<< "$pr_state"
+          if [[ "$current_base" != "$BASE_BRANCH" ]]; then
+            echo "PR #$PR_NUMBER no longer targets $BASE_BRANCH; skipping it."
+            exit 0
+          fi
+          if [[ ! "$head_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Could not resolve a valid PR head SHA for #$PR_NUMBER." >&2
+            exit 1
+          fi
+
+          stamp_pending() {
+            local context="$1"
+            gh api "repos/$REPO/statuses/$head_sha" --silent \
+              -f state=pending \
+              -f context="$context" \
+              -f description="Base changed; push a new head before @codex review" \
+              -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
+          }
+          stamp_pending "$REVIEW_GATE_CONTEXT"
+          stamp_pending "$REVIEW_BASE_CONTEXT"
+          stamp_pending "$REVIEW_GATE_CONTEXT"
+          echo "Base branch advancement invalidated regular review for PR #$PR_NUMBER."

--- a/.github/workflows/review-base-advance.yml
+++ b/.github/workflows/review-base-advance.yml
@@ -26,6 +26,8 @@ jobs:
         name: Find pull requests targeting the advanced branch
         env:
           BASE_BRANCH: ${{ inputs.base_branch || github.ref_name }}
+          BASE_PUSHED_AT: ${{ github.event.repository.pushed_at }}
+          EVENT_NAME: ${{ github.event_name }}
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
@@ -39,12 +41,39 @@ jobs:
             echo "Could not resolve the advanced base branch." >&2
             exit 1
           fi
+          if [[ "$EVENT_NAME" == "push" && ! "$BASE_PUSHED_AT" =~ ^[0-9]+$ ]]; then
+            echo "Could not determine when the base branch was advanced." >&2
+            exit 1
+          fi
+          base_pushed_at="${BASE_PUSHED_AT:-0}"
+          open_prs="$(gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate --slurp)"
+          gate_runs="$(gh api "repos/$REPO/actions/workflows/review-gate.yml/runs?per_page=100" --paginate --slurp)"
+          # Push-triggered invalidation is deliberately conservative: only a
+          # PR/head recorded by a review-gate run created before this base push
+          # can be invalidated. A PR opened later or given a fresh head while
+          # this job waited is left to its newer event-driven evaluation.
           matrix="$(
-            gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate --slurp \
-              | jq -c --arg base "$BASE_BRANCH" \
-                  '{include: [.[][]
-                    | select(.base.ref == $base)
-                    | {pr_number: .number, event_head_sha: .head.sha}]}'
+            jq -cn --argjson prs "$open_prs" --argjson runs "$gate_runs" \
+              --arg base "$BASE_BRANCH" --arg event "$EVENT_NAME" \
+              --argjson pushed_at "$base_pushed_at" '
+                def snapshot_before_base_push($number):
+                  [$runs[] | .workflow_runs[]?
+                   | select(any(.pull_requests[]?; .number == $number))
+                   | select((.created_at | fromdateiso8601) <= $pushed_at)
+                   | {created_at, head_sha}]
+                  | sort_by(.created_at)
+                  | last;
+                {include: [$prs[][]
+                  | select(.base.ref == $base)
+                  | . as $pr
+                  | if $event == "workflow_dispatch" then
+                      {pr_number: $pr.number, event_head_sha: $pr.head.sha}
+                    else
+                      (snapshot_before_base_push($pr.number)) as $snapshot
+                      | select($snapshot != null)
+                      | select($snapshot.head_sha == $pr.head.sha)
+                      | {pr_number: $pr.number, event_head_sha: $snapshot.head_sha}
+                    end]}'
           )"
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
           echo "count=$(jq '.include | length' <<< "$matrix")" >> "$GITHUB_OUTPUT"
@@ -147,6 +176,6 @@ jobs:
           stamp_pending "$REVIEW_BASE_CONTEXT" "$marker_description"
           cancel_active_gate_runs
           stamp_pending "$REVIEW_GATE_CONTEXT" "$gate_description"
-          gh workflow run review-gate.yml --repo "$REPO" \
+          gh workflow run review-gate.yml --repo "$REPO" --ref "$current_base" \
             -f pull_request="$PR_NUMBER"
           echo "Base branch advancement invalidated regular review for PR #$PR_NUMBER."

--- a/.github/workflows/review-base-change.yml
+++ b/.github/workflows/review-base-change.yml
@@ -4,13 +4,15 @@ on:
   pull_request_target:
     types: [edited]
 
-# A retarget preempts an evaluator for the same PR. Normal review events queue
-# behind it, so the durable base marker is written before any later success.
+# A retarget persists independently from evaluation. After its durable marker is
+# written, it dispatches an evaluator that queues behind any in-flight review
+# and therefore cannot be overwritten by that review's final success stamp.
 concurrency:
-  group: review-gate-${{ github.event.pull_request.number }}
+  group: review-gate-base-change-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:
+  actions: write
   statuses: write
 
 jobs:
@@ -22,6 +24,7 @@ jobs:
       - name: Revoke the required gate and persist a base-change marker
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           REVIEW_GATE_CONTEXT: review-gate
@@ -35,6 +38,10 @@ jobs:
           }
           if [[ ! "$EVENT_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
             echo "The base-change event did not provide a valid head SHA."
+            exit 1
+          fi
+          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+            echo "The base-change event did not provide a valid pull request number."
             exit 1
           fi
 
@@ -52,6 +59,8 @@ jobs:
           stamp_status "$REVIEW_GATE_CONTEXT"
           stamp_status "$REVIEW_BASE_CONTEXT"
           # Write the required context again after the marker. This makes the
-          # invalidation win if an evaluator was finishing as the PR retargeted.
+          # current state fail closed before the follow-up evaluator runs.
           stamp_status "$REVIEW_GATE_CONTEXT"
+          gh workflow run review-gate.yml --repo "$REPO" \
+            -f pull_request="$PR_NUMBER"
           echo "A base change invalidated ordinary review for ${EVENT_HEAD_SHA:0:10}."

--- a/.github/workflows/review-base-change.yml
+++ b/.github/workflows/review-base-change.yml
@@ -17,9 +17,7 @@ permissions:
 jobs:
   invalidate:
     name: mark-base-change
-    if: >-
-      github.event.changes.base != null
-      && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.changes.base != null
     runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
     steps:
       - name: Revoke the required gate and persist a base-change marker
@@ -29,7 +27,7 @@ jobs:
           REPO: ${{ github.repository }}
           EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          WORKFLOW_REF: ${{ github.event.pull_request.head.ref }}
+          WORKFLOW_REF: ${{ github.event.pull_request.base.ref }}
           REVIEW_GATE_CONTEXT: review-gate
           REVIEW_BASE_CONTEXT: review-gate-base-change
         run: |
@@ -95,6 +93,12 @@ jobs:
           # Write the required context again after the marker. This makes the
           # current state fail closed before the follow-up evaluator runs.
           stamp_status "$REVIEW_GATE_CONTEXT" "$gate_description"
+          if ! gh api \
+            "repos/$REPO/contents/.github/workflows/review-gate.yml?ref=$WORKFLOW_REF" \
+            --silent >/dev/null 2>&1; then
+            echo "Trusted review-gate evaluator is not installed on $WORKFLOW_REF; leaving the required gate pending."
+            exit 0
+          fi
           gh workflow run review-gate.yml --repo "$REPO" --ref "$WORKFLOW_REF" \
             -f pull_request="$PR_NUMBER"
           echo "A base change invalidated ordinary review for ${EVENT_HEAD_SHA:0:10}."

--- a/.github/workflows/review-base-change.yml
+++ b/.github/workflows/review-base-change.yml
@@ -4,8 +4,12 @@ on:
   pull_request_target:
     types: [edited]
 
-# Do not add workflow concurrency here. Every base-retarget event must persist
-# its marker, even if ordinary review evaluation is busy or replaced.
+# A retarget preempts an evaluator for the same PR. Normal review events queue
+# behind it, so the durable base marker is written before any later success.
+concurrency:
+  group: review-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   statuses: write
 

--- a/.github/workflows/review-base-change.yml
+++ b/.github/workflows/review-base-change.yml
@@ -15,11 +15,12 @@ jobs:
     if: github.event.changes.base != null
     runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
     steps:
-      - name: Persist base-change marker on the retargeted head
+      - name: Revoke the required gate and persist a base-change marker
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REVIEW_GATE_CONTEXT: review-gate
           REVIEW_BASE_CONTEXT: review-gate-base-change
         run: |
           set -euo pipefail
@@ -32,9 +33,18 @@ jobs:
             echo "The base-change event did not provide a valid head SHA."
             exit 1
           fi
-          gh api "repos/$REPO/statuses/$EVENT_HEAD_SHA" --silent \
-            -f state=pending \
-            -f context="$REVIEW_BASE_CONTEXT" \
-            -f description="Base changed; push a new head before @codex review" \
-            -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
+
+          stamp_status() {
+            local context="$1"
+            gh api "repos/$REPO/statuses/$EVENT_HEAD_SHA" --silent \
+              -f state=pending \
+              -f context="$context" \
+              -f description="Base changed; push a new head before @codex review" \
+              -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
+          }
+
+          # Revoke the required context first. Even if the durable marker write
+          # later fails, a retarget cannot retain a stale green review gate.
+          stamp_status "$REVIEW_GATE_CONTEXT"
+          stamp_status "$REVIEW_BASE_CONTEXT"
           echo "A base change invalidated ordinary review for ${EVENT_HEAD_SHA:0:10}."

--- a/.github/workflows/review-base-change.yml
+++ b/.github/workflows/review-base-change.yml
@@ -1,0 +1,40 @@
+name: Invalidate Review Gate on Base Change
+
+on:
+  pull_request_target:
+    types: [edited]
+
+# Do not add workflow concurrency here. Every base-retarget event must persist
+# its marker, even if ordinary review evaluation is busy or replaced.
+permissions:
+  statuses: write
+
+jobs:
+  invalidate:
+    name: mark-base-change
+    if: github.event.changes.base != null
+    runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
+    steps:
+      - name: Persist base-change marker on the retargeted head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REVIEW_BASE_CONTEXT: review-gate-base-change
+        run: |
+          set -euo pipefail
+          export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+          command -v gh >/dev/null 2>&1 || {
+            echo "GitHub CLI (gh) is required."
+            exit 1
+          }
+          if [[ ! "$EVENT_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "The base-change event did not provide a valid head SHA."
+            exit 1
+          fi
+          gh api "repos/$REPO/statuses/$EVENT_HEAD_SHA" --silent \
+            -f state=pending \
+            -f context="$REVIEW_BASE_CONTEXT" \
+            -f description="Base changed; push a new head before @codex review" \
+            -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
+          echo "A base change invalidated ordinary review for ${EVENT_HEAD_SHA:0:10}."

--- a/.github/workflows/review-base-change.yml
+++ b/.github/workflows/review-base-change.yml
@@ -4,11 +4,10 @@ on:
   pull_request_target:
     types: [edited]
 
-# A retarget persists independently from evaluation. After its durable marker is
-# written, it dispatches an evaluator that queues behind any in-flight review
-# and therefore cannot be overwritten by that review's final success stamp.
+# A retarget takes the evaluator's per-PR lock, cancelling any in-flight
+# evaluation before it writes the durable marker and dispatches a replacement.
 concurrency:
-  group: review-gate-base-change-${{ github.event.pull_request.number }}
+  group: review-gate-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:
@@ -28,6 +27,7 @@ jobs:
           REPO: ${{ github.repository }}
           EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          WORKFLOW_REF: ${{ github.event.pull_request.base.ref }}
           REVIEW_GATE_CONTEXT: review-gate
           REVIEW_BASE_CONTEXT: review-gate-base-change
         run: |
@@ -93,6 +93,6 @@ jobs:
           # Write the required context again after the marker. This makes the
           # current state fail closed before the follow-up evaluator runs.
           stamp_status "$REVIEW_GATE_CONTEXT" "$gate_description"
-          gh workflow run review-gate.yml --repo "$REPO" \
+          gh workflow run review-gate.yml --repo "$REPO" --ref "$WORKFLOW_REF" \
             -f pull_request="$PR_NUMBER"
           echo "A base change invalidated ordinary review for ${EVENT_HEAD_SHA:0:10}."

--- a/.github/workflows/review-base-change.yml
+++ b/.github/workflows/review-base-change.yml
@@ -26,6 +26,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+          EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           REVIEW_GATE_CONTEXT: review-gate
           REVIEW_BASE_CONTEXT: review-gate-base-change
@@ -40,6 +41,10 @@ jobs:
             echo "The base-change event did not provide a valid head SHA."
             exit 1
           fi
+          if [[ ! "$EVENT_BASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "The base-change event did not provide a valid base SHA."
+            exit 1
+          fi
           if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
             echo "The base-change event did not provide a valid pull request number."
             exit 1
@@ -47,20 +52,47 @@ jobs:
 
           stamp_status() {
             local context="$1"
+            local description="$2"
             gh api "repos/$REPO/statuses/$EVENT_HEAD_SHA" --silent \
               -f state=pending \
               -f context="$context" \
-              -f description="Base changed; push a new head before @codex review" \
+              -f description="$description" \
               -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
+          }
+
+          gate_description="Base changed; push a new head before @codex review"
+          marker_description="Base changed for PR #$PR_NUMBER at base $EVENT_BASE_SHA; push a new head before @codex review"
+
+          active_gate_runs() {
+            gh api "repos/$REPO/actions/workflows/review-gate.yml/runs?per_page=100" --paginate --slurp \
+              | jq -r --argjson pr "$PR_NUMBER" --arg run_name "review-gate #$PR_NUMBER" '.[] | .workflow_runs[]?
+                  | select(.status != "completed")
+                  | select(any(.pull_requests[]?; .number == $pr) or .display_title == $run_name)
+                  | .id'
+          }
+
+          cancel_active_gate_runs() {
+            for run_id in $(active_gate_runs); do
+              gh run cancel "$run_id" --repo "$REPO" || true
+            done
+            for _attempt in $(seq 1 15); do
+              if [[ -z "$(active_gate_runs)" ]]; then
+                return 0
+              fi
+              sleep 2
+            done
+            echo "Review-gate runs for PR #$PR_NUMBER did not stop in time." >&2
+            exit 1
           }
 
           # Revoke the required context first. Even if the durable marker write
           # later fails, a retarget cannot retain a stale green review gate.
-          stamp_status "$REVIEW_GATE_CONTEXT"
-          stamp_status "$REVIEW_BASE_CONTEXT"
+          stamp_status "$REVIEW_GATE_CONTEXT" "$gate_description"
+          stamp_status "$REVIEW_BASE_CONTEXT" "$marker_description"
+          cancel_active_gate_runs
           # Write the required context again after the marker. This makes the
           # current state fail closed before the follow-up evaluator runs.
-          stamp_status "$REVIEW_GATE_CONTEXT"
+          stamp_status "$REVIEW_GATE_CONTEXT" "$gate_description"
           gh workflow run review-gate.yml --repo "$REPO" \
             -f pull_request="$PR_NUMBER"
           echo "A base change invalidated ordinary review for ${EVENT_HEAD_SHA:0:10}."

--- a/.github/workflows/review-base-change.yml
+++ b/.github/workflows/review-base-change.yml
@@ -12,6 +12,7 @@ concurrency:
 
 permissions:
   actions: write
+  contents: read
   statuses: write
 
 jobs:
@@ -27,7 +28,7 @@ jobs:
           REPO: ${{ github.repository }}
           EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          WORKFLOW_REF: ${{ github.event.pull_request.base.ref }}
+          WORKFLOW_REF: ${{ github.event.repository.default_branch }}
           REVIEW_GATE_CONTEXT: review-gate
           REVIEW_BASE_CONTEXT: review-gate-base-change
         run: |

--- a/.github/workflows/review-base-change.yml
+++ b/.github/workflows/review-base-change.yml
@@ -62,8 +62,8 @@ jobs:
               -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
           }
 
-          gate_description="Base changed; request a fresh @codex review"
-          marker_description="Base changed for PR #$PR_NUMBER at base $EVENT_BASE_SHA; request a fresh @codex review"
+          gate_description="Base changed; push a new head before @codex review"
+          marker_description="Base changed for PR #$PR_NUMBER at base $EVENT_BASE_SHA; push a new head before @codex review"
 
           active_gate_runs() {
             gh api "repos/$REPO/actions/workflows/review-gate.yml/runs?per_page=100" --paginate --slurp \

--- a/.github/workflows/review-base-change.yml
+++ b/.github/workflows/review-base-change.yml
@@ -47,4 +47,7 @@ jobs:
           # later fails, a retarget cannot retain a stale green review gate.
           stamp_status "$REVIEW_GATE_CONTEXT"
           stamp_status "$REVIEW_BASE_CONTEXT"
+          # Write the required context again after the marker. This makes the
+          # invalidation win if an evaluator was finishing as the PR retargeted.
+          stamp_status "$REVIEW_GATE_CONTEXT"
           echo "A base change invalidated ordinary review for ${EVENT_HEAD_SHA:0:10}."

--- a/.github/workflows/review-base-change.yml
+++ b/.github/workflows/review-base-change.yml
@@ -62,8 +62,8 @@ jobs:
               -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
           }
 
-          gate_description="Base changed; push a new head before @codex review"
-          marker_description="Base changed for PR #$PR_NUMBER at base $EVENT_BASE_SHA; push a new head before @codex review"
+          gate_description="Base changed; request a fresh @codex review"
+          marker_description="Base changed for PR #$PR_NUMBER at base $EVENT_BASE_SHA; request a fresh @codex review"
 
           active_gate_runs() {
             gh api "repos/$REPO/actions/workflows/review-gate.yml/runs?per_page=100" --paginate --slurp \

--- a/.github/workflows/review-base-change.yml
+++ b/.github/workflows/review-base-change.yml
@@ -17,7 +17,9 @@ permissions:
 jobs:
   invalidate:
     name: mark-base-change
-    if: github.event.changes.base != null
+    if: >-
+      github.event.changes.base != null
+      && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
     steps:
       - name: Revoke the required gate and persist a base-change marker
@@ -27,7 +29,7 @@ jobs:
           REPO: ${{ github.repository }}
           EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          WORKFLOW_REF: ${{ github.event.pull_request.base.ref }}
+          WORKFLOW_REF: ${{ github.event.pull_request.head.ref }}
           REVIEW_GATE_CONTEXT: review-gate
           REVIEW_BASE_CONTEXT: review-gate-base-change
         run: |

--- a/.github/workflows/review-base-change.yml
+++ b/.github/workflows/review-base-change.yml
@@ -4,10 +4,11 @@ on:
   pull_request_target:
     types: [edited]
 
-# A retarget takes the evaluator's per-PR lock, cancelling any in-flight
-# evaluation before it writes the durable marker and dispatches a replacement.
+# A retarget has its own per-PR lock so later review deliveries cannot cancel
+# it before the durable marker is written. It explicitly stops active
+# evaluators below, then restamps pending before dispatching a replacement.
 concurrency:
-  group: review-gate-${{ github.event.pull_request.number }}
+  group: review-gate-base-change-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/review-fork-regular-review.yml
+++ b/.github/workflows/review-fork-regular-review.yml
@@ -1,0 +1,116 @@
+name: Reconcile Fork Regular Codex Review Events
+
+on:
+  workflow_run:
+    workflows: ["Route Regular Codex Review Events"]
+    types: [completed]
+
+# workflow_run runs from the default branch and can write even when the source
+# pull_request_review workflow received a read-only fork token. Never check out
+# or execute source-run or pull-request code here.
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+  statuses: write
+
+jobs:
+  reconcile:
+    if: >-
+      github.event.workflow_run.conclusion == 'success'
+      && github.event.workflow_run.event == 'pull_request_review'
+    concurrency:
+      group: review-gate-fork-review-${{ github.event.workflow_run.id }}
+      cancel-in-progress: false
+    runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
+    steps:
+      - name: Revoke the gate for a classified fork review
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          REVIEW_BOT_EVENT_LOGIN: chatgpt-codex-connector[bot]
+          REVIEW_GATE_CONTEXT: review-gate
+          REVIEW_REVIEW_CONTEXT: review-gate-regular-review
+          SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+          WORKFLOW_REF: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+          command -v gh >/dev/null 2>&1 || {
+            echo "GitHub CLI (gh) is required." >&2
+            exit 1
+          }
+          command -v jq >/dev/null || {
+            echo "jq is required to reconcile fork reviews." >&2
+            exit 1
+          }
+          [[ "$SOURCE_RUN_ID" =~ ^[1-9][0-9]*$ && -n "$WORKFLOW_REF" ]] || exit 1
+
+          # The unprivileged source job cannot write a status. Its dynamic job
+          # name is the only handoff, so parse it strictly and revalidate the
+          # review and current PR head via the GitHub API before any mutation.
+          signal="$(
+            gh api "repos/$REPO/actions/runs/$SOURCE_RUN_ID/jobs?per_page=100" --paginate --slurp \
+              | jq -cer '
+                  [.[] | .jobs[]?
+                   | select(.conclusion == "success")
+                   | .name
+                   | capture("^fork-regular-review-(?<pr>[1-9][0-9]*)-(?<head>[0-9a-f]{40})-(?<review>[1-9][0-9]*)-(?<invalidated>true|false)$")]
+                  | if length == 1 then .[0] else null end'
+          )"
+          [[ "$signal" != "null" ]] || exit 0
+          pr_number="$(jq -r '.pr' <<< "$signal")"
+          event_head_sha="$(jq -r '.head' <<< "$signal")"
+          review_id="$(jq -r '.review' <<< "$signal")"
+          review_invalidated="$(jq -r '.invalidated' <<< "$signal")"
+          [[ "$pr_number" =~ ^[1-9][0-9]*$ \
+            && "$event_head_sha" =~ ^[0-9a-f]{40}$ \
+            && "$review_id" =~ ^[1-9][0-9]*$ \
+            && "$review_invalidated" =~ ^(true|false)$ ]] || exit 1
+
+          source_pr_number="$(
+            gh api "repos/$REPO/actions/runs/$SOURCE_RUN_ID" \
+              | jq -er '[.pull_requests[]?.number] | if length == 1 then .[0] else empty end'
+          )" || exit 0
+          [[ "$source_pr_number" == "$pr_number" ]] || exit 0
+
+          pr_state="$(
+            gh api "repos/$REPO/pulls/$pr_number" \
+              | jq -er '[.head.sha, .state, (.head.repo.full_name // "")] | @tsv'
+          )" || exit 0
+          IFS=$'\t' read -r current_head_sha pr_state head_repository <<< "$pr_state"
+          [[ "$current_head_sha" == "$event_head_sha" \
+            && "$pr_state" == "open" \
+            && "$head_repository" != "$REPO" ]] || exit 0
+          review_state="$(
+            gh api "repos/$REPO/pulls/$pr_number/reviews/$review_id" \
+              | jq -er '[.user.login, .commit_id] | @tsv'
+          )" || exit 0
+          IFS=$'\t' read -r review_author review_commit_sha <<< "$review_state"
+          [[ "$review_author" == "$REVIEW_BOT_EVENT_LOGIN" \
+            && "$review_commit_sha" == "$event_head_sha" ]] || exit 0
+
+          stamp_pending() {
+            local context="$1"
+            local description="$2"
+            gh api "repos/$REPO/statuses/$event_head_sha" --silent \
+              -f state=pending \
+              -f context="$context" \
+              -f description="$description" \
+              -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
+          }
+          stamp_pending "$REVIEW_GATE_CONTEXT" \
+            "Review state changed; evaluating regular Codex review"
+          if [[ "$review_invalidated" == "true" ]]; then
+            stamp_pending "$REVIEW_REVIEW_CONTEXT" \
+              "Regular review invalidated; require a newer normal review"
+          fi
+          if ! gh api \
+            "repos/$REPO/contents/.github/workflows/review-gate.yml?ref=$WORKFLOW_REF" \
+            --silent >/dev/null 2>&1; then
+            echo "Trusted review-gate evaluator is not installed on $WORKFLOW_REF; leaving the required gate pending."
+            exit 0
+          fi
+          gh workflow run review-gate.yml --repo "$REPO" --ref "$WORKFLOW_REF" \
+            -f pull_request="$pr_number"
+          echo "Dispatched fork regular-review evaluation for PR #$pr_number."

--- a/.github/workflows/review-fork-regular-review.yml
+++ b/.github/workflows/review-fork-regular-review.yml
@@ -15,24 +15,23 @@ permissions:
   statuses: write
 
 jobs:
-  reconcile:
+  route:
     if: >-
       github.event.workflow_run.conclusion == 'success'
       && github.event.workflow_run.event == 'pull_request_review'
-    concurrency:
-      group: review-gate-fork-review-${{ github.event.workflow_run.id }}
-      cancel-in-progress: false
+    outputs:
+      event_head_sha: ${{ steps.signal.outputs.event_head_sha }}
+      pr_number: ${{ steps.signal.outputs.pr_number }}
+      review_id: ${{ steps.signal.outputs.review_id }}
+      valid: ${{ steps.signal.outputs.valid }}
     runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
     steps:
-      - name: Revoke the gate for a classified fork review
+      - id: signal
+        name: Validate the unprivileged fork-review handoff
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          REVIEW_BOT_EVENT_LOGIN: chatgpt-codex-connector[bot]
-          REVIEW_GATE_CONTEXT: review-gate
-          REVIEW_REVIEW_CONTEXT: review-gate-regular-review
           SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
-          WORKFLOW_REF: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
           export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
@@ -44,11 +43,12 @@ jobs:
             echo "jq is required to reconcile fork reviews." >&2
             exit 1
           }
-          [[ "$SOURCE_RUN_ID" =~ ^[1-9][0-9]*$ && -n "$WORKFLOW_REF" ]] || exit 1
+          echo "valid=false" >> "$GITHUB_OUTPUT"
+          [[ "$SOURCE_RUN_ID" =~ ^[1-9][0-9]*$ ]] || exit 1
 
           # The unprivileged source job cannot write a status. Its dynamic job
-          # name is the only handoff, so parse it strictly and revalidate the
-          # review and current PR head via the GitHub API before any mutation.
+          # name is the only handoff, so parse it strictly before entering the
+          # shared per-PR gate lock in the trusted reconcile job.
           signal="$(
             gh api "repos/$REPO/actions/runs/$SOURCE_RUN_ID/jobs?per_page=100" --paginate --slurp \
               | jq -cer '
@@ -62,11 +62,9 @@ jobs:
           pr_number="$(jq -r '.pr' <<< "$signal")"
           event_head_sha="$(jq -r '.head' <<< "$signal")"
           review_id="$(jq -r '.review' <<< "$signal")"
-          review_invalidated="$(jq -r '.invalidated' <<< "$signal")"
           [[ "$pr_number" =~ ^[1-9][0-9]*$ \
             && "$event_head_sha" =~ ^[0-9a-f]{40}$ \
-            && "$review_id" =~ ^[1-9][0-9]*$ \
-            && "$review_invalidated" =~ ^(true|false)$ ]] || exit 1
+            && "$review_id" =~ ^[1-9][0-9]*$ ]] || exit 1
 
           source_pr_number="$(
             gh api "repos/$REPO/actions/runs/$SOURCE_RUN_ID" \
@@ -74,26 +72,96 @@ jobs:
           )" || exit 0
           [[ "$source_pr_number" == "$pr_number" ]] || exit 0
 
+          {
+            echo "event_head_sha=$event_head_sha"
+            echo "pr_number=$pr_number"
+            echo "review_id=$review_id"
+            echo "valid=true"
+          } >> "$GITHUB_OUTPUT"
+
+  reconcile:
+    needs: route
+    if: needs.route.outputs.valid == 'true'
+    concurrency:
+      group: review-gate-${{ needs.route.outputs.pr_number }}
+      cancel-in-progress: true
+    runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
+    steps:
+      - name: Revoke the gate for the current fork review state
+        env:
+          EVENT_HEAD_SHA: ${{ needs.route.outputs.event_head_sha }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ needs.route.outputs.pr_number }}
+          REPO: ${{ github.repository }}
+          REVIEW_BOT_EVENT_LOGIN: chatgpt-codex-connector[bot]
+          REVIEW_GATE_CONTEXT: review-gate
+          REVIEW_ID: ${{ needs.route.outputs.review_id }}
+          REVIEW_REVIEW_CONTEXT: review-gate-regular-review
+          WORKFLOW_REF: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+          command -v gh >/dev/null 2>&1 || {
+            echo "GitHub CLI (gh) is required." >&2
+            exit 1
+          }
+          command -v jq >/dev/null || {
+            echo "jq is required to reconcile fork reviews." >&2
+            exit 1
+          }
+          [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ \
+            && "$EVENT_HEAD_SHA" =~ ^[0-9a-f]{40}$ \
+            && "$REVIEW_ID" =~ ^[1-9][0-9]*$ \
+            && -n "$WORKFLOW_REF" ]] || exit 1
+
           pr_state="$(
-            gh api "repos/$REPO/pulls/$pr_number" \
+            gh api "repos/$REPO/pulls/$PR_NUMBER" \
               | jq -er '[.head.sha, .state, (.head.repo.full_name // "")] | @tsv'
           )" || exit 0
           IFS=$'\t' read -r current_head_sha pr_state head_repository <<< "$pr_state"
-          [[ "$current_head_sha" == "$event_head_sha" \
+          [[ "$current_head_sha" == "$EVENT_HEAD_SHA" \
             && "$pr_state" == "open" \
             && "$head_repository" != "$REPO" ]] || exit 0
-          review_state="$(
-            gh api "repos/$REPO/pulls/$pr_number/reviews/$review_id" \
-              | jq -er '[.user.login, .commit_id] | @tsv'
+
+          current_review="$(
+            gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID"
           )" || exit 0
-          IFS=$'\t' read -r review_author review_commit_sha <<< "$review_state"
+          review_state="$(
+            jq -er '[.user.login, .commit_id, .state] | @tsv' <<< "$current_review"
+          )"
+          IFS=$'\t' read -r review_author review_commit_sha review_state <<< "$review_state"
+          review_body="$(jq -r '.body // ""' <<< "$current_review")"
           [[ "$review_author" == "$REVIEW_BOT_EVENT_LOGIN" \
-            && "$review_commit_sha" == "$event_head_sha" ]] || exit 0
+            && "$review_commit_sha" == "$EVENT_HEAD_SHA" ]] || exit 0
+
+          body_is_regular_review() {
+            local review_body="$1"
+            printf '%s' "$review_body" \
+              | jq -e -R -s '
+                  def regular_heading:
+                    ascii_downcase
+                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review(?:[[:space:]]*:|[[:space:]]|$)|^[[:space:]]*(?:#{1,6}[[:space:]]+)?review result(?:[[:space:]]*:|[[:space:]]|$)");
+                  def security_heading:
+                    ascii_downcase
+                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?security(?:[[:space:]-]+)review(?:[[:space:]]*:|[[:space:]]|$)");
+                  def availability_notice:
+                    ascii_downcase
+                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?(?:review|review[[:space:]]+result)(?:[[:space:]]*:|[[:space:]]|$)[[:space:]]*(?:you have reached[^\\r\\n]*(?:usage[[:space:]]+limits?|quota)|(?:codex[[:space:]]+)?(?:review[[:space:]]+)?(?:is[[:space:]]+)?(?:currently[[:space:]]+)?(?:unavailable|at[[:space:]]+capacity|rate[[:space:]-]*limited)|(?:could not|unable to)[[:space:]]+(?:start|complete|perform)[[:space:]]+(?:the[[:space:]]+)?(?:codex[[:space:]]+)?review|[^\\r\\n]*try again later)");
+                  select(regular_heading)
+                  | select(security_heading | not)
+                  | select(availability_notice | not)' >/dev/null
+          }
+
+          review_invalidated=true
+          if [[ "$review_state" != "DISMISSED" ]] \
+            && body_is_regular_review "$review_body"; then
+            review_invalidated=false
+          fi
 
           stamp_pending() {
             local context="$1"
             local description="$2"
-            gh api "repos/$REPO/statuses/$event_head_sha" --silent \
+            gh api "repos/$REPO/statuses/$EVENT_HEAD_SHA" --silent \
               -f state=pending \
               -f context="$context" \
               -f description="$description" \
@@ -112,5 +180,5 @@ jobs:
             exit 0
           fi
           gh workflow run review-gate.yml --repo "$REPO" --ref "$WORKFLOW_REF" \
-            -f pull_request="$pr_number"
-          echo "Dispatched fork regular-review evaluation for PR #$pr_number."
+            -f pull_request="$PR_NUMBER"
+          echo "Dispatched fork regular-review evaluation for PR #$PR_NUMBER."

--- a/.github/workflows/review-gate-audit.yml
+++ b/.github/workflows/review-gate-audit.yml
@@ -1,0 +1,106 @@
+name: Audit Active Regular Review Findings
+
+on:
+  schedule:
+    - cron: '17,47 * * * *'
+  workflow_dispatch:
+
+# GitHub Actions does not expose review-thread reopening as an Actions trigger.
+# This quiet audit only revokes an already-successful gate when such a regular
+# finding is active; it never posts comments or requests another review.
+permissions:
+  pull-requests: read
+  statuses: write
+
+jobs:
+  audit:
+    name: audit-open-prs
+    runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
+    steps:
+      - name: Revoke successful gates with active regular-review findings
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          REVIEW_BOT_LOGIN: chatgpt-codex-connector
+          REVIEW_GATE_CONTEXT: review-gate
+        run: |
+          set -euo pipefail
+          export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+          command -v gh >/dev/null 2>&1 || {
+            echo "GitHub CLI (gh) is required."
+            exit 1
+          }
+          command -v jq >/dev/null || {
+            echo "jq is required to audit review threads." >&2
+            exit 1
+          }
+
+          current_gate_state() {
+            local head_sha="$1"
+            gh api "repos/$REPO/commits/$head_sha/statuses?per_page=100" --paginate --slurp \
+              | jq -r --arg context "$REVIEW_GATE_CONTEXT" \
+                  '([.[][] | select(.context == $context)] | max_by(.updated_at)? | .state) // "missing"'
+          }
+
+          active_regular_finding_count() {
+            local pr_number="$1"
+            local head_sha="$2"
+            local head_prefix="${head_sha:0:10}"
+            review_owner="$(printf '%s' "$REPO" | cut -d/ -f1)"
+            review_repo="$(printf '%s' "$REPO" | cut -d/ -f2)"
+            # shellcheck disable=SC2016 # GraphQL expands these variables, not the shell.
+            gh api graphql --paginate \
+              -f query='query($owner: String!, $name: String!, $number: Int!, $endCursor: String) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { reviewThreads(first: 100, after: $endCursor) { nodes { isResolved isOutdated comments(first: 100) { nodes { replyTo { databaseId } author { login } pullRequestReview { body author { login } commit { oid } } } } pageInfo { hasNextPage endCursor } } } } } }' \
+              -F owner="$review_owner" \
+              -F name="$review_repo" \
+              -F number="$pr_number" \
+              | jq -rs --arg bot "$REVIEW_BOT_LOGIN" --arg head "$head_sha" --arg prefix "$head_prefix" '
+                  def regular_heading:
+                    ascii_downcase
+                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review(?:[[:space:]]*:|[[:space:]]|$)");
+                  def security_heading:
+                    ascii_downcase
+                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?security(?:[[:space:]-]+)review(?:[[:space:]]*:|[[:space:]]|$)");
+                  def exact_head:
+                    test("(?im)\\*{0,2}reviewed commit:\\*{0,2}[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60");
+                  def stock_clean_envelope:
+                    test("(?is)^[[:space:]]*#{1,6}[^\\r\\n]*codex[[:space:]]+review[[:space:]]*\\r?\\n[[:space:]]*\\r?\\n[[:space:]]*here are some automated review suggestions for this pull request\\.[[:space:]]*\\r?\\n[[:space:]]*\\r?\\n[[:space:]]*\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*\\r?\\n[[:space:]]*<details>");
+                  [.[]
+                   | .data.repository.pullRequest.reviewThreads.nodes[]?
+                   | select(.isResolved | not)
+                   | select(.isOutdated | not)
+                   | .comments.nodes[]?
+                   | select(.replyTo == null)
+                   | select((.author.login // "") == $bot)
+                   | select(.pullRequestReview != null)
+                   | select((.pullRequestReview.author.login // "") == $bot)
+                   | select((.pullRequestReview.commit.oid // "") == $head)
+                   | (.pullRequestReview.body // "") as $body
+                   | select($body | regular_heading)
+                   | select(($body | security_heading) | not)
+                   | select($body | exact_head)
+                   | select($body | stock_clean_envelope)]
+                  | length'
+          }
+
+          open_prs="$(
+            gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate --slurp \
+              | jq -r '.[][] | [.number, .head.sha] | @tsv'
+          )"
+          while IFS=$'\t' read -r pr_number head_sha; do
+            [[ -n "$pr_number" ]] || continue
+            [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]] || continue
+            if [[ "$(current_gate_state "$head_sha")" != "success" ]]; then
+              continue
+            fi
+            findings="$(active_regular_finding_count "$pr_number" "$head_sha")"
+            if [[ "$findings" -eq 0 ]]; then
+              continue
+            fi
+            gh api "repos/$REPO/statuses/$head_sha" --silent \
+              -f state=pending \
+              -f context="$REVIEW_GATE_CONTEXT" \
+              -f description="Active regular Codex findings require a fresh review" \
+              -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
+            echo "Revoked review-gate for PR #$pr_number with $findings active regular finding(s)."
+          done <<< "$open_prs"

--- a/.github/workflows/review-gate-audit.yml
+++ b/.github/workflows/review-gate-audit.yml
@@ -12,7 +12,7 @@ on:
 permissions:
   actions: write
   pull-requests: read
-  statuses: read
+  statuses: write
 
 jobs:
   discover:
@@ -81,6 +81,15 @@ jobs:
                   '([.[][] | select(.context == $context)] | max_by(.updated_at)? | .state) // "missing"'
           }
 
+          stamp_pending() {
+            local head_sha="$1"
+            gh api "repos/$REPO/statuses/$head_sha" --silent \
+              -f state=pending \
+              -f context="$REVIEW_GATE_CONTEXT" \
+              -f description="Trusted evaluator unavailable; regular review must be re-evaluated" \
+              -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
+          }
+
           active_regular_finding_count() {
             local pr_number="$1"
             local head_sha="$2"
@@ -129,12 +138,10 @@ jobs:
 
           pr_state="$(
             gh api "repos/$REPO/pulls/$PR_NUMBER" 2>/dev/null \
-              | jq -er '[.head.sha, .head.ref, .head.repo.full_name] | @tsv'
+              | jq -er '[.head.sha, .base.ref] | @tsv'
           )" || exit 0
-          IFS=$'\t' read -r head_sha workflow_ref head_repository <<< "$pr_state"
-          # A dispatch runs the workflow definition from the PR branch. Do
-          # that only for a branch owned by this repository.
-          [[ "$head_sha" =~ ^[0-9a-f]{40}$ && -n "$workflow_ref" && "$head_repository" == "$REPO" ]] || exit 0
+          IFS=$'\t' read -r head_sha workflow_ref <<< "$pr_state"
+          [[ "$head_sha" =~ ^[0-9a-f]{40}$ && -n "$workflow_ref" ]] || exit 0
           if [[ "$(current_gate_state "$head_sha")" != "success" ]]; then
             exit 0
           fi
@@ -149,6 +156,13 @@ jobs:
           fi
           findings="$(active_regular_finding_count "$PR_NUMBER" "$head_sha")"
           if [[ "$findings" -eq 0 ]]; then
+            exit 0
+          fi
+          if ! gh api \
+            "repos/$REPO/contents/.github/workflows/review-gate.yml?ref=$workflow_ref" \
+            --silent >/dev/null 2>&1; then
+            stamp_pending "$head_sha"
+            echo "Trusted review-gate evaluator is not installed on $workflow_ref; revoked the required gate."
             exit 0
           fi
           gh workflow run review-gate.yml --repo "$REPO" --ref "$workflow_ref" \

--- a/.github/workflows/review-gate-audit.yml
+++ b/.github/workflows/review-gate-audit.yml
@@ -7,10 +7,13 @@ on:
 
 # GitHub Actions does not expose review-thread reopening as an Actions trigger.
 # Protected branches require conversation resolution, so an active or reopened
-# thread blocks a merge immediately. This quiet audit reconciles the custom
-# regular-review status without posting comments or requesting another review.
+# thread blocks a merge immediately. This quiet audit also reconciles fork
+# review events and transient router failures without posting comments or
+# requesting another review.
 permissions:
   actions: write
+  contents: read
+  issues: read
   pull-requests: read
   statuses: write
 
@@ -61,7 +64,9 @@ jobs:
           PR_NUMBER: ${{ matrix.pr_number }}
           REPO: ${{ github.repository }}
           REVIEW_BOT_LOGIN: chatgpt-codex-connector
+          REVIEW_BOT_EVENT_LOGIN: chatgpt-codex-connector[bot]
           REVIEW_GATE_CONTEXT: review-gate
+          WORKFLOW_REF: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
           export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
@@ -74,20 +79,93 @@ jobs:
             exit 1
           }
 
-          current_gate_state() {
+          current_gate_snapshot() {
             local head_sha="$1"
             gh api "repos/$REPO/commits/$head_sha/statuses?per_page=100" --paginate --slurp \
-              | jq -r --arg context "$REVIEW_GATE_CONTEXT" \
-                  '([.[][] | select(.context == $context)] | max_by(.updated_at)? | .state) // "missing"'
+              | jq -c --arg context "$REVIEW_GATE_CONTEXT" '
+                  ([.[][]
+                    | select(.context == $context)
+                    | {state, updated_at}]
+                   | max_by(.updated_at)?) as $latest
+                  | if $latest == null then
+                      {state: "missing", updated_at: ""}
+                    else
+                      $latest
+                    end'
           }
 
           stamp_pending() {
             local head_sha="$1"
+            local description="$2"
             gh api "repos/$REPO/statuses/$head_sha" --silent \
               -f state=pending \
               -f context="$REVIEW_GATE_CONTEXT" \
-              -f description="Trusted evaluator unavailable; regular review must be re-evaluated" \
+              -f description="$description" \
               -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
+          }
+
+          latest_regular_comment_at() {
+            local head_sha="$1"
+            local head_prefix="${head_sha:0:10}"
+            gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100" --paginate --slurp \
+              | jq -r --arg bot "$REVIEW_BOT_EVENT_LOGIN" --arg head "$head_sha" --arg prefix "$head_prefix" '
+                  def regular_heading:
+                    ascii_downcase
+                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review(?:[[:space:]]*:|[[:space:]]|$)|^[[:space:]]*(?:#{1,6}[[:space:]]+)?review result(?:[[:space:]]*:|[[:space:]]|$)");
+                  def security_heading:
+                    ascii_downcase
+                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?security(?:[[:space:]-]+)review(?:[[:space:]]*:|[[:space:]]|$)");
+                  def availability_notice:
+                    ascii_downcase
+                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?(?:review|review[[:space:]]+result)(?:[[:space:]]*:|[[:space:]]|$)[[:space:]]*(?:you have reached[^\\r\\n]*(?:usage[[:space:]]+limits?|quota)|(?:codex[[:space:]]+)?(?:review[[:space:]]+)?(?:is[[:space:]]+)?(?:currently[[:space:]]+)?(?:unavailable|at[[:space:]]+capacity|rate[[:space:]-]*limited)|(?:could not|unable to)[[:space:]]+(?:start|complete|perform)[[:space:]]+(?:the[[:space:]]+)?(?:codex[[:space:]]+)?review|[^\\r\\n]*try again later)");
+                  def exact_head:
+                    test("(?im)\\*{0,2}reviewed commit:\\*{0,2}[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60");
+                  [.[][]
+                   | select((.user.login // "") == $bot)
+                   | (.body // "") as $body
+                   | select($body | regular_heading)
+                   | select(($body | security_heading) | not)
+                   | select(($body | availability_notice) | not)
+                   | select($body | exact_head)
+                   | (.updated_at // .created_at)]
+                  | max // empty'
+          }
+
+          latest_regular_review_at() {
+            local head_sha="$1"
+            local head_prefix="${head_sha:0:10}"
+            review_owner="$(printf '%s' "$REPO" | cut -d/ -f1)"
+            review_repo="$(printf '%s' "$REPO" | cut -d/ -f2)"
+            # Keep dismissed normal reviews in the timestamp so the trusted
+            # evaluator can revoke a fork PR's formerly clean gate.
+            # shellcheck disable=SC2016 # GraphQL expands these variables, not the shell.
+            gh api graphql --paginate \
+              -f query='query($owner: String!, $name: String!, $number: Int!, $endCursor: String) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { reviews(first: 100, after: $endCursor) { nodes { state submittedAt updatedAt body author { login } commit { oid } } pageInfo { hasNextPage endCursor } } } } }' \
+              -F owner="$review_owner" \
+              -F name="$review_repo" \
+              -F number="$PR_NUMBER" \
+              | jq -rs -r --arg bot "$REVIEW_BOT_LOGIN" --arg head "$head_sha" --arg prefix "$head_prefix" '
+                  def regular_heading:
+                    ascii_downcase
+                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review(?:[[:space:]]*:|[[:space:]]|$)|^[[:space:]]*(?:#{1,6}[[:space:]]+)?review result(?:[[:space:]]*:|[[:space:]]|$)");
+                  def security_heading:
+                    ascii_downcase
+                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?security(?:[[:space:]-]+)review(?:[[:space:]]*:|[[:space:]]|$)");
+                  def availability_notice:
+                    ascii_downcase
+                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?(?:review|review[[:space:]]+result)(?:[[:space:]]*:|[[:space:]]|$)[[:space:]]*(?:you have reached[^\\r\\n]*(?:usage[[:space:]]+limits?|quota)|(?:codex[[:space:]]+)?(?:review[[:space:]]+)?(?:is[[:space:]]+)?(?:currently[[:space:]]+)?(?:unavailable|at[[:space:]]+capacity|rate[[:space:]-]*limited)|(?:could not|unable to)[[:space:]]+(?:start|complete|perform)[[:space:]]+(?:the[[:space:]]+)?(?:codex[[:space:]]+)?review|[^\\r\\n]*try again later)");
+                  def exact_head:
+                    test("(?im)\\*{0,2}reviewed commit:\\*{0,2}[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60");
+                  [.[].data.repository.pullRequest.reviews.nodes[]?
+                   | select((.author.login // "") == $bot)
+                   | select((.commit.oid // "") == $head)
+                   | (.body // "") as $body
+                   | select($body | regular_heading)
+                   | select(($body | security_heading) | not)
+                   | select(($body | availability_notice) | not)
+                   | select($body | exact_head)
+                   | (.updatedAt // .submittedAt)]
+                  | max // empty'
           }
 
           active_regular_finding_count() {
@@ -138,11 +216,44 @@ jobs:
 
           pr_state="$(
             gh api "repos/$REPO/pulls/$PR_NUMBER" 2>/dev/null \
-              | jq -er '[.head.sha, .base.ref] | @tsv'
+              | jq -er '[.head.sha, (.head.repo.full_name // "")] | @tsv'
           )" || exit 0
-          IFS=$'\t' read -r head_sha workflow_ref <<< "$pr_state"
-          [[ "$head_sha" =~ ^[0-9a-f]{40}$ && -n "$workflow_ref" ]] || exit 0
-          if [[ "$(current_gate_state "$head_sha")" != "success" ]]; then
+          IFS=$'\t' read -r head_sha head_repo <<< "$pr_state"
+          [[ "$head_sha" =~ ^[0-9a-f]{40}$ && -n "$WORKFLOW_REF" ]] || exit 0
+          gate_snapshot="$(current_gate_snapshot "$head_sha")"
+          gate_state="$(jq -r '.state' <<< "$gate_snapshot")"
+          gate_updated_at="$(jq -r '.updated_at // empty' <<< "$gate_snapshot")"
+
+          # A same-repository router stamps review-gate before it dispatches.
+          # If a normal issue-comment router failed before that mutation, the
+          # newer comment below replays safely under this default-branch audit.
+          # Fork review routers cannot write at all, so their current normal
+          # review is reconciled here by the same trusted path.
+          latest_evidence_at="$(latest_regular_comment_at "$head_sha")"
+          if [[ "$head_repo" != "$REPO" ]]; then
+            latest_review_at="$(latest_regular_review_at "$head_sha")"
+            if [[ -n "$latest_review_at" \
+              && ( -z "$latest_evidence_at" || "$latest_review_at" > "$latest_evidence_at" ) ]]; then
+              latest_evidence_at="$latest_review_at"
+            fi
+          fi
+          if [[ -n "$latest_evidence_at" \
+            && ( -z "$gate_updated_at" || "$latest_evidence_at" > "$gate_updated_at" ) ]]; then
+            stamp_pending "$head_sha" \
+              "Regular review state changed; evaluating trusted evidence"
+            if ! gh api \
+              "repos/$REPO/contents/.github/workflows/review-gate.yml?ref=$WORKFLOW_REF" \
+              --silent >/dev/null 2>&1; then
+              echo "Trusted review-gate evaluator is not installed on $WORKFLOW_REF; revoked the required gate."
+              exit 0
+            fi
+            gh workflow run review-gate.yml --repo "$REPO" --ref "$WORKFLOW_REF" \
+              -f pull_request="$PR_NUMBER"
+            echo "Dispatched trusted review-gate for a newer normal review delivery on PR #$PR_NUMBER."
+            exit 0
+          fi
+
+          if [[ "$gate_state" != "success" ]]; then
             exit 0
           fi
           findings="$(active_regular_finding_count "$PR_NUMBER" "$head_sha")"
@@ -151,20 +262,22 @@ jobs:
           fi
           # The evaluator may have completed while the first GraphQL read was
           # in flight. Recheck both state and findings under the shared lock.
-          if [[ "$(current_gate_state "$head_sha")" != "success" ]]; then
+          gate_snapshot="$(current_gate_snapshot "$head_sha")"
+          if [[ "$(jq -r '.state' <<< "$gate_snapshot")" != "success" ]]; then
             exit 0
           fi
           findings="$(active_regular_finding_count "$PR_NUMBER" "$head_sha")"
           if [[ "$findings" -eq 0 ]]; then
             exit 0
           fi
+          stamp_pending "$head_sha" \
+            "Active regular review findings; evaluating trusted evidence"
           if ! gh api \
-            "repos/$REPO/contents/.github/workflows/review-gate.yml?ref=$workflow_ref" \
+            "repos/$REPO/contents/.github/workflows/review-gate.yml?ref=$WORKFLOW_REF" \
             --silent >/dev/null 2>&1; then
-            stamp_pending "$head_sha"
-            echo "Trusted review-gate evaluator is not installed on $workflow_ref; revoked the required gate."
+            echo "Trusted review-gate evaluator is not installed on $WORKFLOW_REF; revoked the required gate."
             exit 0
           fi
-          gh workflow run review-gate.yml --repo "$REPO" --ref "$workflow_ref" \
+          gh workflow run review-gate.yml --repo "$REPO" --ref "$WORKFLOW_REF" \
             -f pull_request="$PR_NUMBER"
           echo "Dispatched review-gate for PR #$PR_NUMBER with $findings active regular finding(s)."

--- a/.github/workflows/review-gate-audit.yml
+++ b/.github/workflows/review-gate-audit.yml
@@ -129,10 +129,12 @@ jobs:
 
           pr_state="$(
             gh api "repos/$REPO/pulls/$PR_NUMBER" 2>/dev/null \
-              | jq -er '[.head.sha, .base.ref] | @tsv'
+              | jq -er '[.head.sha, .head.ref, .head.repo.full_name] | @tsv'
           )" || exit 0
-          IFS=$'\t' read -r head_sha workflow_ref <<< "$pr_state"
-          [[ "$head_sha" =~ ^[0-9a-f]{40}$ && -n "$workflow_ref" ]] || exit 0
+          IFS=$'\t' read -r head_sha workflow_ref head_repository <<< "$pr_state"
+          # A dispatch runs the workflow definition from the PR branch. Do
+          # that only for a branch owned by this repository.
+          [[ "$head_sha" =~ ^[0-9a-f]{40}$ && -n "$workflow_ref" && "$head_repository" == "$REPO" ]] || exit 0
           if [[ "$(current_gate_state "$head_sha")" != "success" ]]; then
             exit 0
           fi

--- a/.github/workflows/review-gate-audit.yml
+++ b/.github/workflows/review-gate-audit.yml
@@ -218,6 +218,7 @@ jobs:
                     test("(?im)\\*{0,2}reviewed commit:\\*{0,2}[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60");
                   def stock_clean_envelope:
                     test("(?is)^[[:space:]]*#{1,6}[^\\r\\n]*codex[[:space:]]+review[[:space:]]*\\r?\\n[[:space:]]*\\r?\\n[[:space:]]*here are some automated review suggestions for this pull request\\.[[:space:]]*\\r?\\n[[:space:]]*\\r?\\n[[:space:]]*\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*\\r?\\n[[:space:]]*<details>")
+                    or test("(?is)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review:[[:space:]]*didn.t find any major issues\\.[^\\r\\n]*(?:\\r?\\n[[:space:]]*)+\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*(?:\\r?\\n[[:space:]]*)+<details>[[:space:]]*<summary>[^\\r\\n]*codex[[:space:]]+in[[:space:]]+github")
                     or test("(?is)^[[:space:]]*#{1,6}[^\\r\\n]*(?:codex[[:space:]]+review|review result):[[:space:]]*(?:didn.t find any issues|no issues found)\\.[[:space:]]*(?:\\r?\\n[[:space:]]*)*\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*$");
                   [.[]
                    | .data.repository.pullRequest.reviewThreads.nodes[]?

--- a/.github/workflows/review-gate-audit.yml
+++ b/.github/workflows/review-gate-audit.yml
@@ -85,10 +85,10 @@ jobs:
               | jq -c --arg context "$REVIEW_GATE_CONTEXT" '
                   ([.[][]
                     | select(.context == $context)
-                    | {state, updated_at}]
+                    | {state, updated_at, description}]
                    | max_by(.updated_at)?) as $latest
                   | if $latest == null then
-                      {state: "missing", updated_at: ""}
+                      {state: "missing", updated_at: "", description: ""}
                     else
                       $latest
                     end'
@@ -104,7 +104,32 @@ jobs:
               -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
           }
 
-          latest_regular_comment_at() {
+          is_reconciliation_pending() {
+            local description="$1"
+            case "$description" in
+              "Review state changed; evaluating regular Codex review"|"Regular issue-comment verdict; evaluating review"|"Regular review state changed; evaluating trusted evidence"|"Active regular review findings; evaluating trusted evidence"|"Evaluating regular Codex review on "*)
+                return 0
+                ;;
+              *)
+                return 1
+                ;;
+            esac
+          }
+
+          dispatch_trusted_evaluator() {
+            local reason="$1"
+            if ! gh api \
+              "repos/$REPO/contents/.github/workflows/review-gate.yml?ref=$WORKFLOW_REF" \
+              --silent >/dev/null 2>&1; then
+              echo "Trusted review-gate evaluator is not installed on $WORKFLOW_REF; revoked the required gate."
+              return 0
+            fi
+            gh workflow run review-gate.yml --repo "$REPO" --ref "$WORKFLOW_REF" \
+              -f pull_request="$PR_NUMBER"
+            echo "Dispatched trusted review-gate for $reason on PR #$PR_NUMBER."
+          }
+
+          current_regular_comment_records() {
             local head_sha="$1"
             local head_prefix="${head_sha:0:10}"
             gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100" --paginate --slurp \
@@ -127,24 +152,22 @@ jobs:
                    | select(($body | security_heading) | not)
                    | select(($body | availability_notice) | not)
                    | select($body | exact_head)
-                   | (.updated_at // .created_at)]
-                  | max // empty'
+                   | {id: ("issue-comment:" + (.id | tostring)),
+                      at: (.updated_at // .created_at)}]'
           }
 
-          latest_regular_review_at() {
+          current_regular_review_records() {
             local head_sha="$1"
             local head_prefix="${head_sha:0:10}"
             review_owner="$(printf '%s' "$REPO" | cut -d/ -f1)"
             review_repo="$(printf '%s' "$REPO" | cut -d/ -f2)"
-            # Keep dismissed normal reviews in the timestamp so the trusted
-            # evaluator can revoke a fork PR's formerly clean gate.
             # shellcheck disable=SC2016 # GraphQL expands these variables, not the shell.
             gh api graphql --paginate \
-              -f query='query($owner: String!, $name: String!, $number: Int!, $endCursor: String) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { reviews(first: 100, after: $endCursor) { nodes { state submittedAt updatedAt body author { login } commit { oid } } pageInfo { hasNextPage endCursor } } } } }' \
+              -f query='query($owner: String!, $name: String!, $number: Int!, $endCursor: String) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { reviews(first: 100, after: $endCursor) { nodes { databaseId state submittedAt updatedAt body author { login } commit { oid } } pageInfo { hasNextPage endCursor } } } } }' \
               -F owner="$review_owner" \
               -F name="$review_repo" \
               -F number="$PR_NUMBER" \
-              | jq -rs -r --arg bot "$REVIEW_BOT_LOGIN" --arg head "$head_sha" --arg prefix "$head_prefix" '
+              | jq -rs -c --arg bot "$REVIEW_BOT_LOGIN" --arg head "$head_sha" --arg prefix "$head_prefix" '
                   def regular_heading:
                     ascii_downcase
                     | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review(?:[[:space:]]*:|[[:space:]]|$)|^[[:space:]]*(?:#{1,6}[[:space:]]+)?review result(?:[[:space:]]*:|[[:space:]]|$)");
@@ -158,14 +181,15 @@ jobs:
                     test("(?im)\\*{0,2}reviewed commit:\\*{0,2}[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60");
                   [.[].data.repository.pullRequest.reviews.nodes[]?
                    | select((.author.login // "") == $bot)
+                   | select((.state // "") != "DISMISSED")
                    | select((.commit.oid // "") == $head)
                    | (.body // "") as $body
                    | select($body | regular_heading)
                    | select(($body | security_heading) | not)
                    | select(($body | availability_notice) | not)
                    | select($body | exact_head)
-                   | (.updatedAt // .submittedAt)]
-                  | max // empty'
+                   | {id: ("review:" + (.databaseId | tostring)),
+                      at: (.updatedAt // .submittedAt)}]'
           }
 
           active_regular_finding_count() {
@@ -176,7 +200,7 @@ jobs:
             review_repo="$(printf '%s' "$REPO" | cut -d/ -f2)"
             # shellcheck disable=SC2016 # GraphQL expands these variables, not the shell.
             gh api graphql --paginate \
-              -f query='query($owner: String!, $name: String!, $number: Int!, $endCursor: String) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { reviewThreads(first: 100, after: $endCursor) { nodes { isResolved isOutdated comments(first: 100) { nodes { replyTo { databaseId } author { login } pullRequestReview { body author { login } commit { oid } } } } pageInfo { hasNextPage endCursor } } } } } }' \
+              -f query='query($owner: String!, $name: String!, $number: Int!, $endCursor: String) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { reviewThreads(first: 100, after: $endCursor) { nodes { isResolved isOutdated comments(first: 100) { nodes { replyTo { databaseId } author { login } pullRequestReview { state body author { login } commit { oid } } } } pageInfo { hasNextPage endCursor } } } } } }' \
               -F owner="$review_owner" \
               -F name="$review_repo" \
               -F number="$pr_number" \
@@ -204,6 +228,7 @@ jobs:
                    | select((.author.login // "") == $bot)
                    | select(.pullRequestReview != null)
                    | select((.pullRequestReview.author.login // "") == $bot)
+                   | select((.pullRequestReview.state // "") != "DISMISSED")
                    | select((.pullRequestReview.commit.oid // "") == $head)
                    | (.pullRequestReview.body // "") as $body
                    | select($body | regular_heading)
@@ -214,42 +239,55 @@ jobs:
                   | length'
           }
 
-          pr_state="$(
+          head_sha="$(
             gh api "repos/$REPO/pulls/$PR_NUMBER" 2>/dev/null \
-              | jq -er '[.head.sha, (.head.repo.full_name // "")] | @tsv'
+              | jq -er '.head.sha'
           )" || exit 0
-          IFS=$'\t' read -r head_sha head_repo <<< "$pr_state"
           [[ "$head_sha" =~ ^[0-9a-f]{40}$ && -n "$WORKFLOW_REF" ]] || exit 0
           gate_snapshot="$(current_gate_snapshot "$head_sha")"
           gate_state="$(jq -r '.state' <<< "$gate_snapshot")"
           gate_updated_at="$(jq -r '.updated_at // empty' <<< "$gate_snapshot")"
+          gate_description="$(jq -r '.description // empty' <<< "$gate_snapshot")"
+          comment_records="$(current_regular_comment_records "$head_sha")"
+          review_records="$(current_regular_review_records "$head_sha")"
+          evidence_records="$(jq -cn --argjson comments "$comment_records" --argjson reviews "$review_records" '$comments + $reviews')"
+          latest_evidence_at="$(jq -r '[.[].at] | max // empty' <<< "$evidence_records")"
+          evidence_ids="$(jq -c '[.[].id]' <<< "$evidence_records")"
+          evidence_marker="$(
+            jq -r '
+              (.description // "") as $description
+              | if ($description | test("; evidence (review|issue-comment):[1-9][0-9]*$")) then
+                  ($description | capture("; evidence (?<id>(?:review|issue-comment):[1-9][0-9]*)$").id)
+                else
+                  ""
+                end' <<< "$gate_snapshot"
+          )"
 
-          # A same-repository router stamps review-gate before it dispatches.
-          # If a normal issue-comment router failed before that mutation, the
-          # newer comment below replays safely under this default-branch audit.
-          # Fork review routers cannot write at all, so their current normal
-          # review is reconciled here by the same trusted path.
-          latest_evidence_at="$(latest_regular_comment_at "$head_sha")"
-          if [[ "$head_repo" != "$REPO" ]]; then
-            latest_review_at="$(latest_regular_review_at "$head_sha")"
-            if [[ -n "$latest_review_at" \
-              && ( -z "$latest_evidence_at" || "$latest_review_at" > "$latest_evidence_at" ) ]]; then
-              latest_evidence_at="$latest_review_at"
-            fi
+          # Reconcile every head through the trusted default-branch workflow.
+          # The stored marker tracks the exact normal delivery that earned a
+          # clean gate, so edits to a review cannot be masked by a separate
+          # security review or availability notice.
+          needs_reconciliation=false
+          reconciliation_reason=""
+          if [[ -n "$latest_evidence_at" && ( -z "$gate_updated_at" || "$latest_evidence_at" > "$gate_updated_at" ) ]]; then
+            needs_reconciliation=true
+            reconciliation_reason="a newer normal review delivery"
+          elif [[ "$gate_state" == "pending" ]] && is_reconciliation_pending "$gate_description"; then
+            needs_reconciliation=true
+            reconciliation_reason="a pending normal review evaluation"
+          elif [[ "$gate_state" == "success" && -n "$evidence_marker" ]] && ! jq -e --arg evidence "$evidence_marker" 'index($evidence) != null' <<< "$evidence_ids" >/dev/null; then
+            needs_reconciliation=true
+            reconciliation_reason="clean normal evidence that is no longer current"
+          elif [[ "$gate_state" == "success" && -z "$evidence_marker" ]]; then
+            needs_reconciliation=true
+            reconciliation_reason="legacy clean normal evidence"
           fi
-          if [[ -n "$latest_evidence_at" \
-            && ( -z "$gate_updated_at" || "$latest_evidence_at" > "$gate_updated_at" ) ]]; then
-            stamp_pending "$head_sha" \
-              "Regular review state changed; evaluating trusted evidence"
-            if ! gh api \
-              "repos/$REPO/contents/.github/workflows/review-gate.yml?ref=$WORKFLOW_REF" \
-              --silent >/dev/null 2>&1; then
-              echo "Trusted review-gate evaluator is not installed on $WORKFLOW_REF; revoked the required gate."
-              exit 0
+          if [[ "$needs_reconciliation" == "true" ]]; then
+            if [[ "$gate_state" != "pending" ]] || ! is_reconciliation_pending "$gate_description"; then
+              stamp_pending "$head_sha" \
+                "Regular review state changed; evaluating trusted evidence"
             fi
-            gh workflow run review-gate.yml --repo "$REPO" --ref "$WORKFLOW_REF" \
-              -f pull_request="$PR_NUMBER"
-            echo "Dispatched trusted review-gate for a newer normal review delivery on PR #$PR_NUMBER."
+            dispatch_trusted_evaluator "$reconciliation_reason"
             exit 0
           fi
 
@@ -272,12 +310,4 @@ jobs:
           fi
           stamp_pending "$head_sha" \
             "Active regular review findings; evaluating trusted evidence"
-          if ! gh api \
-            "repos/$REPO/contents/.github/workflows/review-gate.yml?ref=$WORKFLOW_REF" \
-            --silent >/dev/null 2>&1; then
-            echo "Trusted review-gate evaluator is not installed on $WORKFLOW_REF; revoked the required gate."
-            exit 0
-          fi
-          gh workflow run review-gate.yml --repo "$REPO" --ref "$WORKFLOW_REF" \
-            -f pull_request="$PR_NUMBER"
-          echo "Dispatched review-gate for PR #$PR_NUMBER with $findings active regular finding(s)."
+          dispatch_trusted_evaluator "$findings active regular finding(s)"

--- a/.github/workflows/review-gate-audit.yml
+++ b/.github/workflows/review-gate-audit.yml
@@ -2,7 +2,7 @@ name: Audit Active Regular Review Findings
 
 on:
   schedule:
-    - cron: '17,47 * * * *'
+    - cron: '*/5 * * * *'
   workflow_dispatch:
 
 # GitHub Actions does not expose review-thread reopening as an Actions trigger.
@@ -13,13 +13,50 @@ permissions:
   statuses: write
 
 jobs:
+  discover:
+    name: discover-open-prs
+    runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
+    outputs:
+      matrix: ${{ steps.prs.outputs.matrix }}
+      count: ${{ steps.prs.outputs.count }}
+    steps:
+      - id: prs
+        name: Enumerate open pull requests
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+          command -v gh >/dev/null 2>&1 || {
+            echo "GitHub CLI (gh) is required."
+            exit 1
+          }
+          matrix="$(
+            gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate --slurp \
+              | jq -c '{include: [.[][] | {pr_number: .number}]}'
+          )"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "count=$(jq '.include | length' <<< "$matrix")" >> "$GITHUB_OUTPUT"
+
   audit:
-    name: audit-open-prs
+    name: audit (${{ matrix.pr_number }})
+    needs: discover
+    if: needs.discover.outputs.count != '0'
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
+    # Serialize the final recheck and status mutation with the evaluator. This
+    # remains quiet: it never posts a comment or requests a review.
+    concurrency:
+      group: review-gate-${{ matrix.pr_number }}
+      cancel-in-progress: false
     runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
     steps:
       - name: Revoke successful gates with active regular-review findings
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ matrix.pr_number }}
           REPO: ${{ github.repository }}
           REVIEW_BOT_LOGIN: chatgpt-codex-connector
           REVIEW_GATE_CONTEXT: review-gate
@@ -57,7 +94,7 @@ jobs:
               | jq -rs --arg bot "$REVIEW_BOT_LOGIN" --arg head "$head_sha" --arg prefix "$head_prefix" '
                   def regular_heading:
                     ascii_downcase
-                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review(?:[[:space:]]*:|[[:space:]]|$)");
+                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review(?:[[:space:]]*:|[[:space:]]|$)|^[[:space:]]*(?:#{1,6}[[:space:]]+)?review result(?:[[:space:]]*:|[[:space:]]|$)");
                   def security_heading:
                     ascii_downcase
                     | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?security(?:[[:space:]-]+)review(?:[[:space:]]*:|[[:space:]]|$)");
@@ -83,24 +120,30 @@ jobs:
                   | length'
           }
 
-          open_prs="$(
-            gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate --slurp \
-              | jq -r '.[][] | [.number, .head.sha] | @tsv'
-          )"
-          while IFS=$'\t' read -r pr_number head_sha; do
-            [[ -n "$pr_number" ]] || continue
-            [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]] || continue
-            if [[ "$(current_gate_state "$head_sha")" != "success" ]]; then
-              continue
-            fi
-            findings="$(active_regular_finding_count "$pr_number" "$head_sha")"
-            if [[ "$findings" -eq 0 ]]; then
-              continue
-            fi
-            gh api "repos/$REPO/statuses/$head_sha" --silent \
-              -f state=pending \
-              -f context="$REVIEW_GATE_CONTEXT" \
-              -f description="Active regular Codex findings require a fresh review" \
-              -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
-            echo "Revoked review-gate for PR #$pr_number with $findings active regular finding(s)."
-          done <<< "$open_prs"
+          head_sha="$(
+            gh api "repos/$REPO/pulls/$PR_NUMBER" 2>/dev/null \
+              | jq -er '.head.sha'
+          )" || exit 0
+          [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]] || exit 0
+          if [[ "$(current_gate_state "$head_sha")" != "success" ]]; then
+            exit 0
+          fi
+          findings="$(active_regular_finding_count "$PR_NUMBER" "$head_sha")"
+          if [[ "$findings" -eq 0 ]]; then
+            exit 0
+          fi
+          # The evaluator may have completed while the first GraphQL read was
+          # in flight. Recheck both state and findings under the shared lock.
+          if [[ "$(current_gate_state "$head_sha")" != "success" ]]; then
+            exit 0
+          fi
+          findings="$(active_regular_finding_count "$PR_NUMBER" "$head_sha")"
+          if [[ "$findings" -eq 0 ]]; then
+            exit 0
+          fi
+          gh api "repos/$REPO/statuses/$head_sha" --silent \
+            -f state=pending \
+            -f context="$REVIEW_GATE_CONTEXT" \
+            -f description="Active regular Codex findings require a fresh review" \
+            -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
+          echo "Revoked review-gate for PR #$PR_NUMBER with $findings active regular finding(s)."

--- a/.github/workflows/review-gate-audit.yml
+++ b/.github/workflows/review-gate-audit.yml
@@ -6,11 +6,12 @@ on:
   workflow_dispatch:
 
 # GitHub Actions does not expose review-thread reopening as an Actions trigger.
-# This quiet audit only revokes an already-successful gate when such a regular
-# finding is active; it never posts comments or requests another review.
+# Protected branches require conversation resolution, so an active or reopened
+# thread blocks a merge immediately. This quiet audit reconciles the custom
+# regular-review status without posting comments or requesting another review.
 permissions:
+  actions: write
   pull-requests: read
-  statuses: write
 
 jobs:
   discover:
@@ -46,10 +47,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
-    # Serialize the final recheck and status mutation with the evaluator. This
-    # remains quiet: it never posts a comment or requests a review.
+    # Keep audits off the evaluator's queue. A findings result dispatches a
+    # fresh evaluator, which rechecks the current state under its own lock.
     concurrency:
-      group: review-gate-${{ matrix.pr_number }}
+      group: review-gate-audit-${{ matrix.pr_number }}
       cancel-in-progress: false
     runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
     steps:
@@ -101,7 +102,8 @@ jobs:
                   def exact_head:
                     test("(?im)\\*{0,2}reviewed commit:\\*{0,2}[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60");
                   def stock_clean_envelope:
-                    test("(?is)^[[:space:]]*#{1,6}[^\\r\\n]*codex[[:space:]]+review[[:space:]]*\\r?\\n[[:space:]]*\\r?\\n[[:space:]]*here are some automated review suggestions for this pull request\\.[[:space:]]*\\r?\\n[[:space:]]*\\r?\\n[[:space:]]*\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*\\r?\\n[[:space:]]*<details>");
+                    test("(?is)^[[:space:]]*#{1,6}[^\\r\\n]*codex[[:space:]]+review[[:space:]]*\\r?\\n[[:space:]]*\\r?\\n[[:space:]]*here are some automated review suggestions for this pull request\\.[[:space:]]*\\r?\\n[[:space:]]*\\r?\\n[[:space:]]*\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*\\r?\\n[[:space:]]*<details>")
+                    or test("(?is)^[[:space:]]*#{1,6}[^\\r\\n]*(?:codex[[:space:]]+review|review result):[[:space:]]*(?:didn.t find any issues|no issues found)\\.[[:space:]]*(?:\\r?\\n[[:space:]]*)*\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*$");
                   [.[]
                    | .data.repository.pullRequest.reviewThreads.nodes[]?
                    | select(.isResolved | not)
@@ -141,9 +143,5 @@ jobs:
           if [[ "$findings" -eq 0 ]]; then
             exit 0
           fi
-          gh api "repos/$REPO/statuses/$head_sha" --silent \
-            -f state=pending \
-            -f context="$REVIEW_GATE_CONTEXT" \
-            -f description="Active regular Codex findings require a fresh review" \
-            -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
-          echo "Revoked review-gate for PR #$PR_NUMBER with $findings active regular finding(s)."
+          gh workflow run review-gate.yml --repo "$REPO" -f pull_request="$PR_NUMBER"
+          echo "Dispatched review-gate for PR #$PR_NUMBER with $findings active regular finding(s)."

--- a/.github/workflows/review-gate-audit.yml
+++ b/.github/workflows/review-gate-audit.yml
@@ -48,10 +48,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
-    # Keep audits off the evaluator's queue. A findings result dispatches a
-    # fresh evaluator, which rechecks the current state under its own lock.
+    # Recheck under the evaluator's per-PR lock so an in-flight success cannot
+    # race a findings-triggered follow-up dispatch.
     concurrency:
-      group: review-gate-audit-${{ matrix.pr_number }}
+      group: review-gate-${{ matrix.pr_number }}
       cancel-in-progress: false
     runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
     steps:
@@ -127,11 +127,12 @@ jobs:
                   | length'
           }
 
-          head_sha="$(
+          pr_state="$(
             gh api "repos/$REPO/pulls/$PR_NUMBER" 2>/dev/null \
-              | jq -er '.head.sha'
+              | jq -er '[.head.sha, .base.ref] | @tsv'
           )" || exit 0
-          [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]] || exit 0
+          IFS=$'\t' read -r head_sha workflow_ref <<< "$pr_state"
+          [[ "$head_sha" =~ ^[0-9a-f]{40}$ && -n "$workflow_ref" ]] || exit 0
           if [[ "$(current_gate_state "$head_sha")" != "success" ]]; then
             exit 0
           fi
@@ -148,5 +149,6 @@ jobs:
           if [[ "$findings" -eq 0 ]]; then
             exit 0
           fi
-          gh workflow run review-gate.yml --repo "$REPO" -f pull_request="$PR_NUMBER"
+          gh workflow run review-gate.yml --repo "$REPO" --ref "$workflow_ref" \
+            -f pull_request="$PR_NUMBER"
           echo "Dispatched review-gate for PR #$PR_NUMBER with $findings active regular finding(s)."

--- a/.github/workflows/review-gate-audit.yml
+++ b/.github/workflows/review-gate-audit.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   actions: write
   pull-requests: read
+  statuses: read
 
 jobs:
   discover:
@@ -99,6 +100,9 @@ jobs:
                   def security_heading:
                     ascii_downcase
                     | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?security(?:[[:space:]-]+)review(?:[[:space:]]*:|[[:space:]]|$)");
+                  def availability_notice:
+                    ascii_downcase
+                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?(?:review|review[[:space:]]+result)(?:[[:space:]]*:|[[:space:]]|$)[[:space:]]*(?:you have reached[^\\r\\n]*(?:usage[[:space:]]+limits?|quota)|(?:codex[[:space:]]+)?(?:review[[:space:]]+)?(?:is[[:space:]]+)?(?:currently[[:space:]]+)?(?:unavailable|at[[:space:]]+capacity|rate[[:space:]-]*limited)|(?:could not|unable to)[[:space:]]+(?:start|complete|perform)[[:space:]]+(?:the[[:space:]]+)?(?:codex[[:space:]]+)?review|[^\\r\\n]*try again later)");
                   def exact_head:
                     test("(?im)\\*{0,2}reviewed commit:\\*{0,2}[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60");
                   def stock_clean_envelope:
@@ -117,6 +121,7 @@ jobs:
                    | (.pullRequestReview.body // "") as $body
                    | select($body | regular_heading)
                    | select(($body | security_heading) | not)
+                   | select(($body | availability_notice) | not)
                    | select($body | exact_head)
                    | select($body | stock_clean_envelope)]
                   | length'

--- a/.github/workflows/review-gate-rollout.yml
+++ b/.github/workflows/review-gate-rollout.yml
@@ -59,15 +59,16 @@ jobs:
               echo "Could not resolve automatic-merge state for PR #$pr_number."
               exit 1
             fi
-            if [[ "$auto_merge_enabled" != "true" ]]; then
-              continue
-            fi
-
+            # Every open head may retain a success from a less strict version of
+            # the gate. Reset it before considering whether it was auto-armed.
             gh api "repos/$REPO/statuses/$head_sha" --silent \
               -f state=pending \
               -f context="$REVIEW_GATE_CONTEXT" \
               -f description="Disarming automatic merge; waiting for @codex review" \
               -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
+            if [[ "$auto_merge_enabled" != "true" ]]; then
+              continue
+            fi
             # shellcheck disable=SC2016 # GraphQL expands this variable, not the shell.
             gh api graphql \
               -f query='mutation($pullRequestId: ID!) { disablePullRequestAutoMerge(input: {pullRequestId: $pullRequestId}) { pullRequest { id } } }' \

--- a/.github/workflows/review-gate-rollout.yml
+++ b/.github/workflows/review-gate-rollout.yml
@@ -113,11 +113,11 @@ jobs:
             gh api "repos/$REPO/actions/workflows/review-gate.yml/runs?per_page=100" --paginate --slurp \
               | jq -r --argjson pr "$PR_NUMBER" '.[] | .workflow_runs[]?
                   | select(.status != "completed")
-                  | select(any(.pull_requests[]?; .number == $pr))
+                  | select(any(.pull_requests[]?; .number == $pr) or .event == "workflow_dispatch")
                   | .id'
           }
           for run_id in $(active_gate_runs); do
-            gh run cancel "$run_id" --repo "$REPO"
+            gh run cancel "$run_id" --repo "$REPO" || true
           done
           for _attempt in $(seq 1 15); do
             if [[ -z "$(active_gate_runs)" ]]; then
@@ -132,7 +132,7 @@ jobs:
 
           pr_state="$(
             gh api "repos/$REPO/pulls/$PR_NUMBER" \
-              | jq -er '[.node_id, .head.sha, ((.auto_merge // false) | tostring)] | @tsv'
+              | jq -er '[.node_id, .head.sha, ((.auto_merge != null) | tostring)] | @tsv'
           )"
           IFS=$'\t' read -r pr_node_id head_sha auto_merge_enabled <<< "$pr_state"
           if [[ ! "$pr_node_id" =~ ^PR_ || ! "$head_sha" =~ ^[0-9a-f]{40}$ || ! "$auto_merge_enabled" =~ ^(true|false)$ ]]; then

--- a/.github/workflows/review-gate-rollout.yml
+++ b/.github/workflows/review-gate-rollout.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - .github/workflows/review-gate.yml
+      - .github/workflows/review-regular-review.yml
+      - .github/workflows/review-regular-comment.yml
       - .github/workflows/review-base-change.yml
       - .github/workflows/review-base-advance.yml
       - .github/workflows/review-gate-audit.yml
@@ -111,9 +113,9 @@ jobs:
 
           active_gate_runs() {
             gh api "repos/$REPO/actions/workflows/review-gate.yml/runs?per_page=100" --paginate --slurp \
-              | jq -r --argjson pr "$PR_NUMBER" '.[] | .workflow_runs[]?
+              | jq -r --argjson pr "$PR_NUMBER" --arg run_name "review-gate #$PR_NUMBER" '.[] | .workflow_runs[]?
                   | select(.status != "completed")
-                  | select(any(.pull_requests[]?; .number == $pr) or .event == "workflow_dispatch")
+                  | select(any(.pull_requests[]?; .number == $pr) or .display_title == $run_name or .event == "workflow_dispatch" or .event == "issue_comment")
                   | .id'
           }
           for run_id in $(active_gate_runs); do

--- a/.github/workflows/review-gate-rollout.yml
+++ b/.github/workflows/review-gate-rollout.yml
@@ -39,10 +39,6 @@ jobs:
             echo "GitHub CLI (gh) is required."
             exit 1
           }
-          if [[ "$(gh api "repos/$REPO" --jq '.allow_auto_merge')" != "false" ]]; then
-            echo "Repository auto-merge must be disabled before the manual review gate is rolled out." >&2
-            exit 1
-          fi
           matrix="$(
             gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate --slurp \
               | jq -c '{include: [.[][] | {pr_number: .number}]}'
@@ -86,7 +82,7 @@ jobs:
 
   disarm-open-prs:
     name: disarm-open-prs (${{ matrix.pr_number }})
-    needs: [discover, cancel-legacy-auto-merge-runs]
+    needs: discover
     if: needs.discover.outputs.count != '0'
     strategy:
       fail-fast: false
@@ -183,3 +179,29 @@ jobs:
           # This is the final write under the per-PR lock. It cannot be
           # resurrected by a queued evaluator before that evaluator rechecks.
           stamp_pending
+
+  verify-repository-policy:
+    name: verify-repository-auto-merge-disabled
+    needs: [discover, cancel-legacy-auto-merge-runs, disarm-open-prs]
+    if: always()
+    runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
+    steps:
+      - name: Verify cleanup completed and repository auto-merge is disabled
+        env:
+          CANCEL_RESULT: ${{ needs.cancel-legacy-auto-merge-runs.result }}
+          DISARM_RESULT: ${{ needs.disarm-open-prs.result }}
+          DISCOVER_RESULT: ${{ needs.discover.result }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [[ "$DISCOVER_RESULT" != "success" \
+            || "$CANCEL_RESULT" != "success" \
+            || ( "$DISARM_RESULT" != "success" && "$DISARM_RESULT" != "skipped" ) ]]; then
+            echo "Review-gate rollout cleanup did not complete successfully." >&2
+            exit 1
+          fi
+          if [[ "$(gh api "repos/$REPO" --jq '.allow_auto_merge')" != "false" ]]; then
+            echo "Repository auto-merge must be disabled for the manual review gate." >&2
+            exit 1
+          fi

--- a/.github/workflows/review-gate-rollout.yml
+++ b/.github/workflows/review-gate-rollout.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - .github/workflows/review-gate.yml
       - .github/workflows/review-regular-review.yml
+      - .github/workflows/review-fork-regular-review.yml
       - .github/workflows/review-regular-comment.yml
       - .github/workflows/review-base-change.yml
       - .github/workflows/review-base-advance.yml

--- a/.github/workflows/review-gate-rollout.yml
+++ b/.github/workflows/review-gate-rollout.yml
@@ -1,0 +1,76 @@
+name: Disarm Existing Automatic Merge Requests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/review-gate.yml
+      - .github/workflows/review-base-change.yml
+      - .github/workflows/review-gate-rollout.yml
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  statuses: write
+
+jobs:
+  disarm-open-prs:
+    name: disarm-open-prs
+    runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
+    steps:
+      - name: Revoke review gates and disable existing automatic merges
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          REVIEW_GATE_CONTEXT: review-gate
+        run: |
+          set -euo pipefail
+          export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+          command -v gh >/dev/null 2>&1 || {
+            echo "GitHub CLI (gh) is required."
+            exit 1
+          }
+          command -v jq >/dev/null || {
+            echo "jq is required to inspect open pull requests."
+            exit 1
+          }
+
+          review_owner="$(printf '%s' "$REPO" | cut -d/ -f1)"
+          review_repo="$(printf '%s' "$REPO" | cut -d/ -f2)"
+          open_prs="$(
+            gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate --slurp \
+              | jq -r '.[][] | .number'
+          )"
+          for pr_number in $open_prs; do
+            pr_state="$(
+              # shellcheck disable=SC2016 # GraphQL expands these variables, not the shell.
+              gh api graphql \
+                -f query='query($owner: String!, $name: String!, $number: Int!) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { id headRefOid autoMergeRequest { enabledAt } } } }' \
+                -F owner="$review_owner" \
+                -F name="$review_repo" \
+                -F number="$pr_number" \
+                | jq -er '.data.repository.pullRequest as $pr
+                    | select($pr != null)
+                    | [$pr.id, $pr.headRefOid, (($pr.autoMergeRequest != null) | tostring)]
+                    | @tsv'
+            )"
+            IFS=$'\t' read -r pr_node_id head_sha auto_merge_enabled <<< "$pr_state"
+            if [[ ! "$pr_node_id" =~ ^PR_ || ! "$head_sha" =~ ^[0-9a-f]{40}$ || ! "$auto_merge_enabled" =~ ^(true|false)$ ]]; then
+              echo "Could not resolve automatic-merge state for PR #$pr_number."
+              exit 1
+            fi
+            if [[ "$auto_merge_enabled" != "true" ]]; then
+              continue
+            fi
+
+            gh api "repos/$REPO/statuses/$head_sha" --silent \
+              -f state=pending \
+              -f context="$REVIEW_GATE_CONTEXT" \
+              -f description="Disarming automatic merge; waiting for @codex review" \
+              -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
+            # shellcheck disable=SC2016 # GraphQL expands this variable, not the shell.
+            gh api graphql \
+              -f query='mutation($pullRequestId: ID!) { disablePullRequestAutoMerge(input: {pullRequestId: $pullRequestId}) { pullRequest { id } } }' \
+              -F pullRequestId="$pr_node_id" >/dev/null
+            echo "Disabled automatic merge for PR #$pr_number."
+          done

--- a/.github/workflows/review-gate-rollout.yml
+++ b/.github/workflows/review-gate-rollout.yml
@@ -39,6 +39,10 @@ jobs:
             echo "GitHub CLI (gh) is required."
             exit 1
           }
+          if [[ "$(gh api "repos/$REPO" --jq '.allow_auto_merge')" != "false" ]]; then
+            echo "Repository auto-merge must be disabled before the manual review gate is rolled out." >&2
+            exit 1
+          fi
           matrix="$(
             gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate --slurp \
               | jq -c '{include: [.[][] | {pr_number: .number}]}'
@@ -112,27 +116,6 @@ jobs:
             exit 1
           }
 
-          active_gate_runs() {
-            gh api "repos/$REPO/actions/workflows/review-gate.yml/runs?per_page=100" --paginate --slurp \
-              | jq -r --argjson pr "$PR_NUMBER" --arg run_name "review-gate #$PR_NUMBER" '.[] | .workflow_runs[]?
-                  | select(.status != "completed")
-                  | select(any(.pull_requests[]?; .number == $pr) or .display_title == $run_name or .event == "workflow_dispatch" or .event == "issue_comment")
-                  | .id'
-          }
-          for run_id in $(active_gate_runs); do
-            gh run cancel "$run_id" --repo "$REPO" || true
-          done
-          for _attempt in $(seq 1 15); do
-            if [[ -z "$(active_gate_runs)" ]]; then
-              break
-            fi
-            sleep 2
-          done
-          if [[ -n "$(active_gate_runs)" ]]; then
-            echo "Review-gate runs for PR #$PR_NUMBER did not stop in time." >&2
-            exit 1
-          fi
-
           pr_state="$(
             gh api "repos/$REPO/pulls/$PR_NUMBER" \
               | jq -er '[.node_id, .head.sha, ((.auto_merge != null) | tostring)] | @tsv'
@@ -150,6 +133,43 @@ jobs:
               -f description="Disarming automatic merge; waiting for @codex review" \
               -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
           }
+          # Revoke the gate before waiting for an evaluator to stop. A prior
+          # success must never remain actionable during the cancellation poll.
+          stamp_pending
+
+          active_gate_runs() {
+            gh api "repos/$REPO/actions/workflows/review-gate.yml/runs?per_page=100" --paginate --slurp \
+              | jq -r --argjson pr "$PR_NUMBER" --arg run_name "review-gate #$PR_NUMBER" '.[] | .workflow_runs[]?
+                  | select(.status != "completed")
+                  | select(any(.pull_requests[]?; .number == $pr) or .display_title == $run_name)
+                  | .id'
+          }
+          for run_id in $(active_gate_runs); do
+            gh run cancel "$run_id" --repo "$REPO" || true
+          done
+          for _attempt in $(seq 1 15); do
+            if [[ -z "$(active_gate_runs)" ]]; then
+              break
+            fi
+            sleep 2
+          done
+          if [[ -n "$(active_gate_runs)" ]]; then
+            echo "Review-gate runs for PR #$PR_NUMBER did not stop in time." >&2
+            exit 1
+          fi
+
+          # Refresh the PR after cancellation in case its head or auto-merge
+          # state changed while this rollout job held the per-PR lock.
+          pr_state="$(
+            gh api "repos/$REPO/pulls/$PR_NUMBER" \
+              | jq -er '[.node_id, .head.sha, ((.auto_merge != null) | tostring)] | @tsv'
+          )"
+          IFS=$'\t' read -r pr_node_id head_sha auto_merge_enabled <<< "$pr_state"
+          if [[ ! "$pr_node_id" =~ ^PR_ || ! "$head_sha" =~ ^[0-9a-f]{40}$ || ! "$auto_merge_enabled" =~ ^(true|false)$ ]]; then
+            echo "Could not resolve automatic-merge state for PR #$PR_NUMBER." >&2
+            exit 1
+          fi
+
           # Reset every open head, including PRs that were already manually
           # disarmed but may carry an older-policy success status.
           stamp_pending

--- a/.github/workflows/review-gate-rollout.yml
+++ b/.github/workflows/review-gate-rollout.yml
@@ -68,7 +68,7 @@ jobs:
                   | .id'
           }
           for run_id in $(active_legacy_runs); do
-            gh run cancel "$run_id" --repo "$REPO"
+            gh run cancel "$run_id" --repo "$REPO" || true
           done
           for _attempt in $(seq 1 15); do
             if [[ -z "$(active_legacy_runs)" ]]; then

--- a/.github/workflows/review-gate-rollout.yml
+++ b/.github/workflows/review-gate-rollout.yml
@@ -6,21 +6,95 @@ on:
     paths:
       - .github/workflows/review-gate.yml
       - .github/workflows/review-base-change.yml
+      - .github/workflows/review-base-advance.yml
+      - .github/workflows/review-gate-audit.yml
       - .github/workflows/review-gate-rollout.yml
   workflow_dispatch:
 
 permissions:
+  actions: write
   pull-requests: write
   statuses: write
 
 jobs:
-  disarm-open-prs:
-    name: disarm-open-prs
+  discover:
+    name: discover-open-prs
     runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
+    outputs:
+      matrix: ${{ steps.prs.outputs.matrix }}
+      count: ${{ steps.prs.outputs.count }}
     steps:
-      - name: Revoke review gates and disable existing automatic merges
+      - id: prs
+        name: Enumerate open pull requests
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+          command -v gh >/dev/null 2>&1 || {
+            echo "GitHub CLI (gh) is required."
+            exit 1
+          }
+          matrix="$(
+            gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate --slurp \
+              | jq -c '{include: [.[][] | {pr_number: .number}]}'
+          )"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "count=$(jq '.include | length' <<< "$matrix")" >> "$GITHUB_OUTPUT"
+
+  cancel-legacy-auto-merge-runs:
+    name: cancel-legacy-auto-merge-runs
+    runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
+    steps:
+      - name: Cancel queued or running retired auto-merge workflows
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+          command -v gh >/dev/null 2>&1 || {
+            echo "GitHub CLI (gh) is required."
+            exit 1
+          }
+          active_legacy_runs() {
+            gh api "repos/$REPO/actions/runs?per_page=100" --paginate --slurp \
+              | jq -r '.[] | .workflow_runs[]?
+                  | select(.status != "completed")
+                  | select(.path == ".github/workflows/auto-merge.yml" or .path == ".github/workflows/auto-merge.yaml")
+                  | .id'
+          }
+          for run_id in $(active_legacy_runs); do
+            gh run cancel "$run_id" --repo "$REPO"
+          done
+          for _attempt in $(seq 1 15); do
+            if [[ -z "$(active_legacy_runs)" ]]; then
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Retired auto-merge workflow runs did not stop in time." >&2
+          exit 1
+
+  disarm-open-prs:
+    name: disarm-open-prs (${{ matrix.pr_number }})
+    needs: [discover, cancel-legacy-auto-merge-runs]
+    if: needs.discover.outputs.count != '0'
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
+    # This preempts a previous-policy evaluator for this PR. A new evaluator
+    # queues behind the sweep and observes its final pending status.
+    concurrency:
+      group: review-gate-${{ matrix.pr_number }}
+      cancel-in-progress: true
+    runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
+    steps:
+      - name: Revoke the gate and disable automatic merge
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ matrix.pr_number }}
           REPO: ${{ github.repository }}
           REVIEW_GATE_CONTEXT: review-gate
         run: |
@@ -35,43 +109,54 @@ jobs:
             exit 1
           }
 
-          review_owner="$(printf '%s' "$REPO" | cut -d/ -f1)"
-          review_repo="$(printf '%s' "$REPO" | cut -d/ -f2)"
-          open_prs="$(
-            gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate --slurp \
-              | jq -r '.[][] | .number'
-          )"
-          for pr_number in $open_prs; do
-            pr_state="$(
-              # shellcheck disable=SC2016 # GraphQL expands these variables, not the shell.
-              gh api graphql \
-                -f query='query($owner: String!, $name: String!, $number: Int!) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { id headRefOid autoMergeRequest { enabledAt } } } }' \
-                -F owner="$review_owner" \
-                -F name="$review_repo" \
-                -F number="$pr_number" \
-                | jq -er '.data.repository.pullRequest as $pr
-                    | select($pr != null)
-                    | [$pr.id, $pr.headRefOid, (($pr.autoMergeRequest != null) | tostring)]
-                    | @tsv'
-            )"
-            IFS=$'\t' read -r pr_node_id head_sha auto_merge_enabled <<< "$pr_state"
-            if [[ ! "$pr_node_id" =~ ^PR_ || ! "$head_sha" =~ ^[0-9a-f]{40}$ || ! "$auto_merge_enabled" =~ ^(true|false)$ ]]; then
-              echo "Could not resolve automatic-merge state for PR #$pr_number."
-              exit 1
+          active_gate_runs() {
+            gh api "repos/$REPO/actions/workflows/review-gate.yml/runs?per_page=100" --paginate --slurp \
+              | jq -r --argjson pr "$PR_NUMBER" '.[] | .workflow_runs[]?
+                  | select(.status != "completed")
+                  | select(any(.pull_requests[]?; .number == $pr))
+                  | .id'
+          }
+          for run_id in $(active_gate_runs); do
+            gh run cancel "$run_id" --repo "$REPO"
+          done
+          for _attempt in $(seq 1 15); do
+            if [[ -z "$(active_gate_runs)" ]]; then
+              break
             fi
-            # Every open head may retain a success from a less strict version of
-            # the gate. Reset it before considering whether it was auto-armed.
+            sleep 2
+          done
+          if [[ -n "$(active_gate_runs)" ]]; then
+            echo "Review-gate runs for PR #$PR_NUMBER did not stop in time." >&2
+            exit 1
+          fi
+
+          pr_state="$(
+            gh api "repos/$REPO/pulls/$PR_NUMBER" \
+              | jq -er '[.node_id, .head.sha, ((.auto_merge // false) | tostring)] | @tsv'
+          )"
+          IFS=$'\t' read -r pr_node_id head_sha auto_merge_enabled <<< "$pr_state"
+          if [[ ! "$pr_node_id" =~ ^PR_ || ! "$head_sha" =~ ^[0-9a-f]{40}$ || ! "$auto_merge_enabled" =~ ^(true|false)$ ]]; then
+            echo "Could not resolve automatic-merge state for PR #$PR_NUMBER." >&2
+            exit 1
+          fi
+
+          stamp_pending() {
             gh api "repos/$REPO/statuses/$head_sha" --silent \
               -f state=pending \
               -f context="$REVIEW_GATE_CONTEXT" \
               -f description="Disarming automatic merge; waiting for @codex review" \
               -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
-            if [[ "$auto_merge_enabled" != "true" ]]; then
-              continue
-            fi
+          }
+          # Reset every open head, including PRs that were already manually
+          # disarmed but may carry an older-policy success status.
+          stamp_pending
+          if [[ "$auto_merge_enabled" == "true" ]]; then
             # shellcheck disable=SC2016 # GraphQL expands this variable, not the shell.
             gh api graphql \
               -f query='mutation($pullRequestId: ID!) { disablePullRequestAutoMerge(input: {pullRequestId: $pullRequestId}) { pullRequest { id } } }' \
               -F pullRequestId="$pr_node_id" >/dev/null
-            echo "Disabled automatic merge for PR #$pr_number."
-          done
+            echo "Disabled automatic merge for PR #$PR_NUMBER."
+          fi
+          # This is the final write under the per-PR lock. It cannot be
+          # resurrected by a queued evaluator before that evaluator rechecks.
+          stamp_pending

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -144,7 +144,7 @@ jobs:
             exit 0
           fi
           head_prefix="$(printf '%.10s' "$head_sha")"
-          base_marker_description="Base changed for PR #$pr_number at base $base_sha at $(date -u +%Y-%m-%dT%H:%M:%SZ); request a fresh @codex review"
+          base_marker_description="Base changed for PR #$pr_number at base $base_sha at $(date -u +%Y-%m-%dT%H:%M:%SZ); push a new head before @codex review"
 
           stamp_status() {
             local context="$1"
@@ -177,26 +177,13 @@ jobs:
               -F pullRequestId="$pull_request_id" >/dev/null
           }
 
-          latest_base_change_at() {
-            local marker_times retarget_times
-            marker_times="$(
-              gh api "repos/$REPO/commits/$head_sha/statuses?per_page=100" --paginate --slurp \
-                | jq -r --arg context "$REVIEW_BASE_CONTEXT" --arg prefix "Base changed for PR #$pr_number at base " '
-                    [.[][] | select(.context == $context and .state == "pending")
-                     | select((.description // "") | startswith($prefix))
-                     | (.description // "") as $description
-                     | if ($description | test(" at [0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z;"))
-                       then ($description | capture(" at (?<at>[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z);").at)
-                       else .updated_at end] | .[]?'
-            )"
-            # shellcheck disable=SC2016 # GraphQL expands these variables, not the shell.
-            retarget_times="$(gh api graphql --paginate \
-              -f query='query($owner: String!, $name: String!, $number: Int!, $endCursor: String) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { timelineItems(first: 100, after: $endCursor, itemTypes: [BASE_REF_CHANGED_EVENT]) { nodes { ... on BaseRefChangedEvent { createdAt } } pageInfo { hasNextPage endCursor } } } } }' \
-              -F owner="$review_owner" \
-              -F name="$review_repo" \
-              -F number="$pr_number" \
-              | jq -rs -r '[.[] | .data.repository.pullRequest.timelineItems.nodes[]? | .createdAt] | .[]?')"
-            printf '%s\n%s\n' "$marker_times" "$retarget_times" | awk 'NF' | sort | tail -n 1
+          base_change_marker_exists() {
+            gh api "repos/$REPO/commits/$head_sha/statuses?per_page=100" --paginate --slurp \
+              | jq -e --arg context "$REVIEW_BASE_CONTEXT" --arg prefix "Base changed for PR #$pr_number at base " '
+                  any(.[][];
+                    .context == $context
+                    and .state == "pending"
+                    and ((.description // "") | startswith($prefix)))' >/dev/null
           }
 
           latest_regular_issue_comment_at() {
@@ -220,8 +207,12 @@ jobs:
                   [.[][]
                    | select(.context == $context)
                    | select(.state == "pending")
-                   | select((.description // "") | startswith("Regular review invalidated;"))
-                   | .updated_at]
+                   | (.description // "") as $description
+                   | select($description | startswith("Regular review invalidated"))
+                   | if ($description | test("^Regular review invalidated at [0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z;"))
+                     then ($description | capture("^Regular review invalidated at (?<at>[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z);").at)
+                     else .updated_at
+                     end]
                   | max // empty'
           }
 
@@ -352,7 +343,7 @@ jobs:
           }
 
           read_gate_snapshot() {
-            local evidence deliveries reviews review_ids thread_summary verdict_selection verdict finding_count base_changed_at latest_finding_at issue_comment_at review_invalidation_at
+            local evidence deliveries reviews review_ids thread_summary verdict_selection verdict finding_count latest_finding_at issue_comment_at review_invalidation_at
             evidence="$(regular_evidence)"
             deliveries="$(jq -c '.deliveries' <<< "$evidence")"
             reviews="$(jq -c '[.deliveries[] | select(.source == "review")]' <<< "$evidence")"
@@ -385,24 +376,30 @@ jobs:
             verdict="$(jq -c '.verdict' <<< "$verdict_selection")"
             latest_finding_at="$(jq -r '.latest_finding_at' <<< "$verdict_selection")"
             finding_count="$(jq '[.[].active_count] | add // 0' <<< "$thread_summary")"
-            base_changed_at="$(latest_base_change_at)"
             jq -cn \
               --argjson verdict "$verdict" \
               --argjson finding_count "$finding_count" \
-              --arg base_changed_at "$base_changed_at" \
               --arg latest_finding_at "$latest_finding_at" \
               '{verdict: $verdict,
                 finding_count: $finding_count,
-                base_changed_at: $base_changed_at,
                 latest_finding_at: $latest_finding_at}'
           }
 
           require_clean_regular_snapshot() {
             local gate_snapshot="$1"
-            local verdict verdict_at finding_count base_changed_at latest_finding_at
+            local verdict verdict_at finding_count latest_finding_at
             verdict="$(jq -c '.verdict' <<< "$gate_snapshot")"
             latest_finding_at="$(jq -r '.latest_finding_at // empty' <<< "$gate_snapshot")"
             finding_count="$(jq -r '.finding_count' <<< "$gate_snapshot")"
+            if [[ "$finding_count" -gt 0 && -n "$latest_finding_at" ]]; then
+              stamp_status "$REVIEW_REVIEW_CONTEXT" pending \
+                "Regular review invalidated at $latest_finding_at; active regular findings require a newer clean normal verdict"
+            fi
+            if base_change_marker_exists; then
+              stamp_review_gate pending "Base changed; push a new head before @codex review"
+              echo "The base-change marker requires a new PR head and regular review."
+              exit 0
+            fi
             if [[ "$verdict" == "null" ]]; then
               if [[ -n "$latest_finding_at" ]]; then
                 stamp_review_gate pending "Waiting for fresh clean Codex review on $head_prefix"
@@ -414,17 +411,10 @@ jobs:
               exit 0
             fi
             verdict_at="$(jq -r '.at // empty' <<< "$verdict")"
-            base_changed_at="$(jq -r '.base_changed_at' <<< "$gate_snapshot")"
             if [[ -z "$verdict_at" || "$finding_count" -gt 0 ]]; then
               stamp_review_gate pending "Codex reported findings on $head_prefix"
               echo "Codex reported $finding_count active regular-review finding(s) on the exact head."
               echo "Fix them, push a new head, and tag @codex review again."
-              exit 0
-            fi
-            if [[ -n "$base_changed_at" && ( "$base_changed_at" == "$verdict_at" || "$base_changed_at" > "$verdict_at" ) ]]; then
-              stamp_base_change_marker
-              stamp_review_gate pending "Base changed; request a fresh @codex review"
-              echo "The PR base changed after the regular review; request a fresh regular review."
               exit 0
             fi
           }
@@ -473,8 +463,8 @@ jobs:
           fi
           if [[ "$final_base_sha" != "$base_sha" ]]; then
             stamp_base_change_marker
-            stamp_review_gate pending "Base changed; request a fresh @codex review"
-            echo "The PR base changed during evaluation; request a fresh regular review."
+            stamp_review_gate pending "Base changed; push a new head before @codex review"
+            echo "The PR base changed during evaluation; push a new head before requesting a regular review."
             exit 0
           fi
           if [[ "$final_base_ref" != "$DEFAULT_BRANCH" || "$final_is_draft" != "false" || "$final_auto_merge_enabled" != "false" ]]; then
@@ -494,7 +484,7 @@ jobs:
           if [[ "$last_head_sha" != "$head_sha" || "$last_base_sha" != "$base_sha" || "$last_base_ref" != "$DEFAULT_BRANCH" || "$last_is_draft" != "false" || "$last_auto_merge_enabled" != "false" || "$last_pr_state" != "OPEN" ]]; then
             if [[ "$last_head_sha" == "$head_sha" && "$last_base_sha" != "$base_sha" ]]; then
               stamp_base_change_marker
-              stamp_review_gate pending "Base changed; request a fresh @codex review"
+              stamp_review_gate pending "Base changed; push a new head before @codex review"
             fi
             if [[ "$last_auto_merge_enabled" == "true" ]]; then
               disable_auto_merge "$last_pr_node_id"
@@ -528,7 +518,6 @@ jobs:
               exit 1
               ;;
           esac
-          stamp_status "$REVIEW_BASE_CONTEXT" success "Regular review revalidated base $base_sha"
           stamp_review_gate success "Clean regular Codex review for $head_prefix; evidence $evidence_marker"
           echo "The exact pull request head has an affirmative clean regular Codex review."
           echo "Security-review messages are intentionally not review-gate evidence."

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -144,7 +144,7 @@ jobs:
             exit 0
           fi
           head_prefix="$(printf '%.10s' "$head_sha")"
-          base_marker_description="Base changed for PR #$pr_number at base $base_sha; push a new head before @codex review"
+          base_marker_description="Base changed for PR #$pr_number at base $base_sha at $(date -u +%Y-%m-%dT%H:%M:%SZ); request a fresh @codex review"
 
           stamp_status() {
             local context="$1"
@@ -177,24 +177,26 @@ jobs:
               -F pullRequestId="$pull_request_id" >/dev/null
           }
 
-          base_change_marker_exists() {
-            gh api "repos/$REPO/commits/$head_sha/statuses?per_page=100" --paginate --slurp \
-              | jq -e --arg context "$REVIEW_BASE_CONTEXT" --arg prefix "Base changed for PR #$pr_number at base " '
-                  any(.[][];
-                    (.context == $context)
-                    and (.state == "pending")
-                    and ((.description // "") | startswith($prefix)))' \
-              >/dev/null
-          }
-
           latest_base_change_at() {
+            local marker_times retarget_times
+            marker_times="$(
+              gh api "repos/$REPO/commits/$head_sha/statuses?per_page=100" --paginate --slurp \
+                | jq -r --arg context "$REVIEW_BASE_CONTEXT" --arg prefix "Base changed for PR #$pr_number at base " '
+                    [.[][] | select(.context == $context and .state == "pending")
+                     | select((.description // "") | startswith($prefix))
+                     | (.description // "") as $description
+                     | if ($description | test(" at [0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z;"))
+                       then ($description | capture(" at (?<at>[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z);").at)
+                       else .updated_at end] | .[]?'
+            )"
             # shellcheck disable=SC2016 # GraphQL expands these variables, not the shell.
-            gh api graphql --paginate \
+            retarget_times="$(gh api graphql --paginate \
               -f query='query($owner: String!, $name: String!, $number: Int!, $endCursor: String) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { timelineItems(first: 100, after: $endCursor, itemTypes: [BASE_REF_CHANGED_EVENT]) { nodes { ... on BaseRefChangedEvent { createdAt } } pageInfo { hasNextPage endCursor } } } } }' \
               -F owner="$review_owner" \
               -F name="$review_repo" \
               -F number="$pr_number" \
-              | jq -rs -r '[.[] | .data.repository.pullRequest.timelineItems.nodes[]? | .createdAt] | max // empty'
+              | jq -rs -r '[.[] | .data.repository.pullRequest.timelineItems.nodes[]? | .createdAt] | .[]?')"
+            printf '%s\n%s\n' "$marker_times" "$retarget_times" | awk 'NF' | sort | tail -n 1
           }
 
           latest_regular_issue_comment_at() {
@@ -417,8 +419,8 @@ jobs:
             fi
             if [[ -n "$base_changed_at" && ( "$base_changed_at" == "$verdict_at" || "$base_changed_at" > "$verdict_at" ) ]]; then
               stamp_base_change_marker
-              stamp_review_gate pending "Base changed; push a new head before @codex review"
-              echo "The PR base changed after the regular review; a new head is required."
+              stamp_review_gate pending "Base changed; request a fresh @codex review"
+              echo "The PR base changed after the regular review; request a fresh regular review."
               exit 0
             fi
           }
@@ -446,12 +448,6 @@ jobs:
             echo "Refusing to use regular-review evidence for an ambiguous or mismatched open PR head."
             exit 0
           fi
-          if base_change_marker_exists; then
-            stamp_review_gate pending "Base changed; push a new head before @codex review"
-            echo "The base-change marker requires a fresh PR head and regular review."
-            exit 0
-          fi
-
           # The event head was revoked before its first API read. Revoke the
           # resolved head as well for manual dispatches and stale event payloads.
           stamp_review_gate pending "Evaluating regular Codex review on $head_prefix"
@@ -473,8 +469,8 @@ jobs:
           fi
           if [[ "$final_base_sha" != "$base_sha" ]]; then
             stamp_base_change_marker
-            stamp_review_gate pending "Base changed; push a new head before @codex review"
-            echo "The PR base changed during evaluation; a new head is required."
+            stamp_review_gate pending "Base changed; request a fresh @codex review"
+            echo "The PR base changed during evaluation; request a fresh regular review."
             exit 0
           fi
           if [[ "$final_base_ref" != "$DEFAULT_BRANCH" || "$final_is_draft" != "false" || "$final_auto_merge_enabled" != "false" ]]; then
@@ -486,11 +482,6 @@ jobs:
             echo "The PR became draft or automatic merge was enabled during evaluation."
             exit 0
           fi
-          if base_change_marker_exists; then
-            stamp_review_gate pending "Base changed; push a new head before @codex review"
-            echo "A base-change marker arrived during evaluation."
-            exit 0
-          fi
           final_gate_snapshot="$(read_gate_snapshot)"
           require_clean_regular_snapshot "$final_gate_snapshot"
 
@@ -499,18 +490,13 @@ jobs:
           if [[ "$last_head_sha" != "$head_sha" || "$last_base_sha" != "$base_sha" || "$last_base_ref" != "$DEFAULT_BRANCH" || "$last_is_draft" != "false" || "$last_auto_merge_enabled" != "false" || "$last_pr_state" != "OPEN" ]]; then
             if [[ "$last_head_sha" == "$head_sha" && "$last_base_sha" != "$base_sha" ]]; then
               stamp_base_change_marker
-              stamp_review_gate pending "Base changed; push a new head before @codex review"
+              stamp_review_gate pending "Base changed; request a fresh @codex review"
             fi
             if [[ "$last_auto_merge_enabled" == "true" ]]; then
               disable_auto_merge "$last_pr_node_id"
               echo "Disabled automatic merge that was enabled during final revalidation."
             fi
             echo "The PR state changed during final revalidation; it was not marked successful."
-            exit 0
-          fi
-          if base_change_marker_exists; then
-            stamp_review_gate pending "Base changed; push a new head before @codex review"
-            echo "A base-change marker arrived during final revalidation."
             exit 0
           fi
           final_shared_head_count="$(shared_open_head_count)"
@@ -538,6 +524,7 @@ jobs:
               exit 1
               ;;
           esac
+          stamp_status "$REVIEW_BASE_CONTEXT" success "Regular review revalidated base $base_sha"
           stamp_review_gate success "Clean regular Codex review for $head_prefix; evidence $evidence_marker"
           echo "The exact pull request head has an affirmative clean regular Codex review."
           echo "Security-review messages are intentionally not review-gate evidence."

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -4,7 +4,9 @@ run-name: "review-gate #${{ inputs.pull_request || github.event.pull_request.num
 
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize, ready_for_review]
+    # Repository-level auto-merge is disabled; this event is defense in depth
+    # if that administrative policy ever drifts.
+    types: [opened, reopened, synchronize, ready_for_review, auto_merge_enabled]
   workflow_dispatch:
     inputs:
       pull_request:
@@ -35,6 +37,7 @@ jobs:
     steps:
       - name: Evaluate exact-head regular Codex review
         env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           GH_TOKEN: ${{ github.token }}
           INPUT_PR: ${{ inputs.pull_request }}
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -105,7 +108,7 @@ jobs:
           read_pr_snapshot() {
             # shellcheck disable=SC2016 # GraphQL expands these variables, not the shell.
             gh api graphql \
-              -f query='query($owner: String!, $name: String!, $number: Int!) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { id state headRefOid baseRefOid isDraft autoMergeRequest { enabledAt } } } }' \
+              -f query='query($owner: String!, $name: String!, $number: Int!) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { id state headRefOid baseRefOid baseRefName isDraft autoMergeRequest { enabledAt } } } }' \
               -F owner="$review_owner" \
               -F name="$review_repo" \
               -F number="$pr_number" \
@@ -114,6 +117,7 @@ jobs:
                   | select($pr != null)
                   | [$pr.headRefOid,
                      $pr.baseRefOid,
+                     $pr.baseRefName,
                      ($pr.isDraft | tostring),
                      $pr.id,
                      (($pr.autoMergeRequest != null) | tostring),
@@ -122,7 +126,7 @@ jobs:
           }
 
           pr_snapshot="$(read_pr_snapshot)"
-          IFS=$'\t' read -r head_sha base_sha is_draft pr_node_id auto_merge_enabled pr_state <<< "$pr_snapshot"
+          IFS=$'\t' read -r head_sha base_sha base_ref is_draft pr_node_id auto_merge_enabled pr_state <<< "$pr_snapshot"
           if [[ ! "$head_sha" =~ ^[0-9a-f]{40}$ || ! "$base_sha" =~ ^[0-9a-f]{40}$ ]]; then
             echo "Could not resolve valid pull request head and base SHAs."
             exit 1
@@ -425,6 +429,11 @@ jobs:
             disable_auto_merge "$pr_node_id"
             echo "Disabled automatic merge for PR #$pr_number."
           fi
+          if [[ -z "$DEFAULT_BRANCH" || "$base_ref" != "$DEFAULT_BRANCH" ]]; then
+            stamp_review_gate pending "Retarget to the repository default branch before review"
+            echo "PR #$pr_number targets unsupported base '$base_ref'; expected '$DEFAULT_BRANCH'."
+            exit 0
+          fi
 
           if [[ "$is_draft" == "true" ]]; then
             stamp_review_gate pending "Waiting for pull request to leave draft"
@@ -453,7 +462,7 @@ jobs:
           # catches a new result, finding, comment, head, or base change that
           # arrived while the first snapshot was being evaluated.
           final_pr_snapshot="$(read_pr_snapshot)"
-          IFS=$'\t' read -r final_head_sha final_base_sha final_is_draft final_pr_node_id final_auto_merge_enabled final_pr_state <<< "$final_pr_snapshot"
+          IFS=$'\t' read -r final_head_sha final_base_sha final_base_ref final_is_draft final_pr_node_id final_auto_merge_enabled final_pr_state <<< "$final_pr_snapshot"
           if [[ "$final_pr_state" != "OPEN" ]]; then
             echo "The PR was closed during evaluation; it was not marked successful."
             exit 0
@@ -468,7 +477,7 @@ jobs:
             echo "The PR base changed during evaluation; a new head is required."
             exit 0
           fi
-          if [[ "$final_is_draft" != "false" || "$final_auto_merge_enabled" != "false" ]]; then
+          if [[ "$final_base_ref" != "$DEFAULT_BRANCH" || "$final_is_draft" != "false" || "$final_auto_merge_enabled" != "false" ]]; then
             if [[ "$final_auto_merge_enabled" == "true" ]]; then
               disable_auto_merge "$final_pr_node_id"
               echo "Disabled automatic merge that was enabled during evaluation."
@@ -486,8 +495,8 @@ jobs:
           require_clean_regular_snapshot "$final_gate_snapshot"
 
           last_pr_snapshot="$(read_pr_snapshot)"
-          IFS=$'\t' read -r last_head_sha last_base_sha last_is_draft last_pr_node_id last_auto_merge_enabled last_pr_state <<< "$last_pr_snapshot"
-          if [[ "$last_head_sha" != "$head_sha" || "$last_base_sha" != "$base_sha" || "$last_is_draft" != "false" || "$last_auto_merge_enabled" != "false" || "$last_pr_state" != "OPEN" ]]; then
+          IFS=$'\t' read -r last_head_sha last_base_sha last_base_ref last_is_draft last_pr_node_id last_auto_merge_enabled last_pr_state <<< "$last_pr_snapshot"
+          if [[ "$last_head_sha" != "$head_sha" || "$last_base_sha" != "$base_sha" || "$last_base_ref" != "$DEFAULT_BRANCH" || "$last_is_draft" != "false" || "$last_auto_merge_enabled" != "false" || "$last_pr_state" != "OPEN" ]]; then
             if [[ "$last_head_sha" == "$head_sha" && "$last_base_sha" != "$base_sha" ]]; then
               stamp_base_change_marker
               stamp_review_gate pending "Base changed; push a new head before @codex review"

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -1,12 +1,10 @@
 name: Codex Review Gate
 
+run-name: "review-gate #${{ inputs.pull_request || github.event.pull_request.number }}"
+
 on:
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review, auto_merge_enabled]
-  pull_request_review:
-    types: [submitted, edited, dismissed]
-  issue_comment:
-    types: [created, edited, deleted]
   workflow_dispatch:
     inputs:
       pull_request:
@@ -14,11 +12,11 @@ on:
         required: true
         type: string
 
-# The latest review-state event wins. Every event stamps the exact head pending
-# before its first fallible lookup, so a new auto-merge or review event cancels
-# any stale evaluator instead of allowing it to publish a late success.
+# The latest state-changing PR event wins. Dedicated routers classify review and
+# issue-comment events before dispatching here, so ignored security activity
+# cannot cancel an evaluator that is enforcing this gate.
 concurrency:
-  group: review-gate-${{ github.event.pull_request.number || github.event.issue.number || inputs.pull_request || github.ref }}
+  group: review-gate-${{ github.event.pull_request.number || inputs.pull_request || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -33,7 +31,6 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch'
       || github.event.pull_request.number != null
-      || github.event.issue.pull_request != null
     runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
     steps:
       - name: Evaluate exact-head regular Codex review
@@ -41,13 +38,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           INPUT_PR: ${{ inputs.pull_request }}
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
-          EVENT_ISSUE_PR_NUMBER: ${{ github.event.issue.number }}
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          EVENT_REVIEW_AUTHOR: ${{ github.event.review.user.login }}
-          EVENT_REVIEW_BODY: ${{ github.event.review.body }}
-          EVENT_COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
-          EVENT_COMMENT_BODY: ${{ github.event.comment.body }}
-          EVENT_NAME: ${{ github.event_name }}
           REPO: ${{ github.repository }}
           REVIEW_BOT: chatgpt-codex-connector[bot]
           REVIEW_BOT_LOGIN: chatgpt-codex-connector
@@ -55,6 +46,7 @@ jobs:
           REVIEW_GATE_CONTEXT: review-gate
           REVIEW_BASE_CONTEXT: review-gate-base-change
           REVIEW_COMMENT_CONTEXT: review-gate-regular-comment
+          REVIEW_REVIEW_CONTEXT: review-gate-regular-review
         run: |
           set -euo pipefail
           export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
@@ -67,14 +59,14 @@ jobs:
             exit 1
           }
 
-          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+          if [[ "${GITHUB_EVENT_NAME:-}" == "workflow_dispatch" ]]; then
             if [[ ! "${INPUT_PR:-}" =~ ^[1-9][0-9]*$ ]]; then
               echo "Pull request input must be a positive integer."
               exit 1
             fi
             pr_number="$INPUT_PR"
           else
-            pr_number="${EVENT_PR_NUMBER:-${EVENT_ISSUE_PR_NUMBER:-}}"
+            pr_number="$EVENT_PR_NUMBER"
           fi
 
           if [[ ! "$pr_number" =~ ^[1-9][0-9]*$ ]]; then
@@ -102,32 +94,9 @@ jobs:
               -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
           }
 
-          event_pull_request_review_is_regular() {
-            [[ "$EVENT_REVIEW_AUTHOR" == "$REVIEW_BOT_EVENT_LOGIN" ]] || return 1
-            printf '%s' "$EVENT_REVIEW_BODY" \
-              | jq -e -R -s '
-                  def regular_heading:
-                    ascii_downcase
-                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review(?:[[:space:]]*:|[[:space:]]|$)|^[[:space:]]*(?:#{1,6}[[:space:]]+)?review result(?:[[:space:]]*:|[[:space:]]|$)");
-                  def security_heading:
-                    ascii_downcase
-                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?security(?:[[:space:]-]+)review(?:[[:space:]]*:|[[:space:]]|$)");
-                  select(regular_heading)
-                  | select(security_heading | not)' >/dev/null
-          }
-
-          # Security and other non-regular PR review events never change this
-          # status. Inline-thread changes are handled by the quiet audit, so a
-          # security review cannot momentarily block the regular-review path.
-          if [[ "$EVENT_NAME" == "pull_request_review" ]] && ! event_pull_request_review_is_regular; then
-            echo "Ignoring a non-regular pull request review."
-            exit 0
-          fi
-
-          # Regular PR-review event payloads carry the exact head. Revoke its
-          # prior success before the first fallible API lookup. Issue comments
-          # are never qualifying evidence and are classified before they can
-          # invalidate this regular-review gate.
+          # PR-state event payloads carry the exact head. Revoke its prior
+          # success before the first fallible lookup; dedicated routers have
+          # already classified review and issue-comment events.
           if [[ -n "$event_head_sha" ]]; then
             stamp_status_for_sha "$event_head_sha" "$REVIEW_GATE_CONTEXT" pending \
               "Review state changed; evaluating regular Codex review"
@@ -166,32 +135,7 @@ jobs:
             exit 0
           fi
           head_prefix="$(printf '%.10s' "$head_sha")"
-
-          event_issue_comment_is_regular() {
-            printf '%s' "$EVENT_COMMENT_BODY" \
-              | jq -e -R -s --arg head "$head_sha" --arg prefix "$head_prefix" '
-                  def regular_heading:
-                    ascii_downcase
-                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review(?:[[:space:]]*:|[[:space:]]|$)|^[[:space:]]*(?:#{1,6}[[:space:]]+)?review result(?:[[:space:]]*:|[[:space:]]|$)");
-                  def security_heading:
-                    ascii_downcase
-                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?security(?:[[:space:]-]+)review(?:[[:space:]]*:|[[:space:]]|$)");
-                  def exact_head:
-                    test("(?im)\\*{0,2}reviewed commit:\\*{0,2}[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60");
-                  select(regular_heading)
-                  | select(security_heading | not)
-                  | select(exact_head)' >/dev/null
-          }
-
-          # Only an exact-head, bot-authored regular-review issue comment can
-          # invalidate this gate. Security-review messages and all other
-          # comments are outside the regular-review protocol.
-          if [[ "$EVENT_NAME" == "issue_comment" ]]; then
-            if [[ "$EVENT_COMMENT_AUTHOR" != "$REVIEW_BOT_EVENT_LOGIN" ]] || ! event_issue_comment_is_regular; then
-              echo "Ignoring a non-regular issue comment."
-              exit 0
-            fi
-          fi
+          base_marker_description="Base changed for PR #$pr_number at base $base_sha; push a new head before @codex review"
 
           stamp_status() {
             local context="$1"
@@ -206,15 +150,8 @@ jobs:
 
           stamp_base_change_marker() {
             stamp_status "$REVIEW_BASE_CONTEXT" pending \
-              "Base changed; push a new head before @codex review"
+              "$base_marker_description"
           }
-
-          if [[ "$EVENT_NAME" == "issue_comment" ]]; then
-            # A normal regular-review issue comment can only invalidate. A
-            # later submitted PR review must explicitly clear this marker.
-            stamp_status "$REVIEW_COMMENT_CONTEXT" pending \
-              "Regular issue-comment verdict; require a newer PR review"
-          fi
 
           disable_auto_merge() {
             local pull_request_id="$1"
@@ -233,11 +170,11 @@ jobs:
 
           base_change_marker_exists() {
             gh api "repos/$REPO/commits/$head_sha/statuses?per_page=100" --paginate --slurp \
-              | jq -e --arg context "$REVIEW_BASE_CONTEXT" '
+              | jq -e --arg context "$REVIEW_BASE_CONTEXT" --arg description "$base_marker_description" '
                   any(.[][];
                     (.context == $context)
                     and (.state == "pending")
-                    and ((.description // "") | startswith("Base changed; push a new head before @codex review")))' \
+                    and ((.description // "") == $description))' \
               >/dev/null
           }
 
@@ -257,14 +194,25 @@ jobs:
                   [.[][]
                    | select(.context == $context)
                    | select(.state == "pending")
-                   | select((.description // "") | startswith("Regular issue-comment verdict;"))
+                   | select((.description // "") | startswith("Regular issue-comment invalidated;"))
                    | .updated_at]
                   | max // empty'
           }
 
-          # Submitted PR reviews are the only qualifying clean evidence. Normal
-          # issue-comment verdicts can invalidate that evidence, while security
-          # review results and availability notices are ignored completely.
+          latest_regular_review_invalidation_at() {
+            gh api "repos/$REPO/commits/$head_sha/statuses?per_page=100" --paginate --slurp \
+              | jq -r --arg context "$REVIEW_REVIEW_CONTEXT" '
+                  [.[][]
+                   | select(.context == $context)
+                   | select(.state == "pending")
+                   | select((.description // "") | startswith("Regular review invalidated;"))
+                   | .updated_at]
+                  | max // empty'
+          }
+
+          # Exact-head regular PR reviews and explicit clean regular issue
+          # comments can qualify. Findings-bearing issue comments invalidate;
+          # security review results and availability notices are ignored.
           regular_evidence() {
             local review_records issue_comment_records
             review_records="$(
@@ -283,11 +231,13 @@ jobs:
                       | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?security(?:[[:space:]-]+)review(?:[[:space:]]*:|[[:space:]]|$)");
                     def exact_head:
                       test("(?im)\\*{0,2}reviewed commit:\\*{0,2}[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60");
-                    # The connector stock review envelope has no body-only
-                    # findings. Textual "no major/blocking issues" claims are
-                    # intentionally not accepted as a clean verdict.
+                    # A "no major/blocking issues" claim must carry the
+                    # known connector footer; a body-only claim is not a
+                    # clean verdict.
                     def stock_clean_envelope:
-                      test("(?is)^[[:space:]]*#{1,6}[^\\r\\n]*codex[[:space:]]+review[[:space:]]*\\r?\\n[[:space:]]*\\r?\\n[[:space:]]*here are some automated review suggestions for this pull request\\.[[:space:]]*\\r?\\n[[:space:]]*\\r?\\n[[:space:]]*\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*\\r?\\n[[:space:]]*<details>");
+                      test("(?is)^[[:space:]]*#{1,6}[^\\r\\n]*codex[[:space:]]+review[[:space:]]*\\r?\\n[[:space:]]*\\r?\\n[[:space:]]*here are some automated review suggestions for this pull request\\.[[:space:]]*\\r?\\n[[:space:]]*\\r?\\n[[:space:]]*\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*\\r?\\n[[:space:]]*<details>")
+                      or test("(?is)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review:[[:space:]]*didn.t find any major issues\\.[^\\r\\n]*(?:\\r?\\n[[:space:]]*)+\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*(?:\\r?\\n[[:space:]]*)+<details>[[:space:]]*<summary>[^\\r\\n]*codex[[:space:]]+in[[:space:]]+github")
+                      or test("(?is)^[[:space:]]*#{1,6}[^\\r\\n]*(?:codex[[:space:]]+review|review result):[[:space:]]*(?:didn.t find any issues|no issues found)\\.[[:space:]]*(?:\\r?\\n[[:space:]]*)*\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*$");
                     [.[]
                      | .data.repository.pullRequest.reviews.nodes[]?
                      | select((.author.login // "") == $bot)
@@ -314,7 +264,9 @@ jobs:
                     def exact_head:
                       test("(?im)\\*{0,2}reviewed commit:\\*{0,2}[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60");
                     def stock_clean_envelope:
-                      test("(?is)^[[:space:]]*#{1,6}[^\\r\\n]*codex[[:space:]]+review[[:space:]]*\\r?\\n[[:space:]]*\\r?\\n[[:space:]]*here are some automated review suggestions for this pull request\\.[[:space:]]*\\r?\\n[[:space:]]*\\r?\\n[[:space:]]*\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*\\r?\\n[[:space:]]*<details>");
+                      test("(?is)^[[:space:]]*#{1,6}[^\\r\\n]*codex[[:space:]]+review[[:space:]]*\\r?\\n[[:space:]]*\\r?\\n[[:space:]]*here are some automated review suggestions for this pull request\\.[[:space:]]*\\r?\\n[[:space:]]*\\r?\\n[[:space:]]*\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*\\r?\\n[[:space:]]*<details>")
+                      or test("(?is)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review:[[:space:]]*didn.t find any major issues\\.[^\\r\\n]*(?:\\r?\\n[[:space:]]*)+\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*(?:\\r?\\n[[:space:]]*)+<details>[[:space:]]*<summary>[^\\r\\n]*codex[[:space:]]+in[[:space:]]+github")
+                      or test("(?is)^[[:space:]]*#{1,6}[^\\r\\n]*(?:codex[[:space:]]+review|review result):[[:space:]]*(?:didn.t find any issues|no issues found)\\.[[:space:]]*(?:\\r?\\n[[:space:]]*)*\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*$");
                     [.[][]
                      | select((.user.login // "") == $bot)
                      | (.body // "") as $body
@@ -368,7 +320,7 @@ jobs:
           }
 
           read_gate_snapshot() {
-            local evidence deliveries reviews review_ids thread_summary verdict_selection verdict finding_count base_changed_at latest_finding_at issue_comment_at
+            local evidence deliveries reviews review_ids thread_summary verdict_selection verdict finding_count base_changed_at latest_finding_at issue_comment_at review_invalidation_at
             evidence="$(regular_evidence)"
             deliveries="$(jq -c '.deliveries' <<< "$evidence")"
             reviews="$(jq -c '[.deliveries[] | select(.source == "review")]' <<< "$evidence")"
@@ -376,18 +328,20 @@ jobs:
             thread_summary="$(regular_review_thread_summary "$review_ids")"
             verdict_selection="$(
               issue_comment_at="$(latest_regular_issue_comment_at)"
-              jq -cn --argjson deliveries "$deliveries" --argjson reviews "$reviews" --argjson thread_summary "$thread_summary" --arg issue_comment_at "$issue_comment_at" '
+              review_invalidation_at="$(latest_regular_review_invalidation_at)"
+              jq -cn --argjson deliveries "$deliveries" --argjson reviews "$reviews" --argjson thread_summary "$thread_summary" --arg issue_comment_at "$issue_comment_at" --arg review_invalidation_at "$review_invalidation_at" '
                 ($thread_summary | map(select(.total_count > 0) | .id)) as $finding_ids
                 | (([$deliveries[] | select(.clean | not) | .at]
                     + [$reviews[]
                        | select(.id as $id | ($finding_ids | index($id)) != null)
                        | .at]
-                    + (if $issue_comment_at == "" then [] else [$issue_comment_at] end))
+                    + (if $issue_comment_at == "" then [] else [$issue_comment_at] end)
+                    + (if $review_invalidation_at == "" then [] else [$review_invalidation_at] end))
                    | max // "") as $latest_finding_at
                 | ($deliveries | sort_by(.at) | last) as $latest_delivery
                 | {verdict:
                      (if $latest_delivery != null
-                           and $latest_delivery.source == "review"
+                           and ($latest_delivery.source == "review" or $latest_delivery.source == "issue_comment")
                            and $latest_delivery.clean
                            and (($finding_ids | index($latest_delivery.id)) == null)
                            and $latest_delivery.at > $latest_finding_at

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -512,7 +512,24 @@ jobs:
             exit 0
           fi
 
-          stamp_review_gate success "Clean regular Codex review for $head_prefix"
+          evidence_source="$(jq -r '.verdict.source // empty' <<< "$final_gate_snapshot")"
+          evidence_id="$(jq -r '.verdict.id // empty' <<< "$final_gate_snapshot")"
+          case "$evidence_source" in
+            review)
+              [[ "$evidence_id" =~ ^[1-9][0-9]*$ ]] || exit 1
+              evidence_marker="review:$evidence_id"
+              ;;
+            issue_comment)
+              evidence_comment_id="${evidence_id#issue-comment-}"
+              [[ "$evidence_comment_id" =~ ^[1-9][0-9]*$ ]] || exit 1
+              evidence_marker="issue-comment:$evidence_comment_id"
+              ;;
+            *)
+              echo "Could not persist the current clean regular-review evidence." >&2
+              exit 1
+              ;;
+          esac
+          stamp_review_gate success "Clean regular Codex review for $head_prefix; evidence $evidence_marker"
           echo "The exact pull request head has an affirmative clean regular Codex review."
           echo "Security-review messages are intentionally not review-gate evidence."
           echo "This workflow never enables or performs a merge."

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -4,7 +4,7 @@ run-name: "review-gate #${{ inputs.pull_request || github.event.pull_request.num
 
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize, ready_for_review, auto_merge_enabled]
+    types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch:
     inputs:
       pull_request:

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -229,6 +229,9 @@ jobs:
                     def security_heading:
                       ascii_downcase
                       | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?security(?:[[:space:]-]+)review(?:[[:space:]]*:|[[:space:]]|$)");
+                    def availability_notice:
+                      ascii_downcase
+                      | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?(?:review|review[[:space:]]+result)(?:[[:space:]]*:|[[:space:]]|$)[[:space:]]*(?:you have reached[^\\r\\n]*(?:usage[[:space:]]+limits?|quota)|(?:codex[[:space:]]+)?(?:review[[:space:]]+)?(?:is[[:space:]]+)?(?:currently[[:space:]]+)?(?:unavailable|at[[:space:]]+capacity|rate[[:space:]-]*limited)|(?:could not|unable to)[[:space:]]+(?:start|complete|perform)[[:space:]]+(?:the[[:space:]]+)?(?:codex[[:space:]]+)?review|[^\\r\\n]*try again later)");
                     def exact_head:
                       test("(?im)\\*{0,2}reviewed commit:\\*{0,2}[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60");
                     # A "no major/blocking issues" claim must carry the
@@ -246,6 +249,7 @@ jobs:
                      | (.body // "") as $body
                      | select($body | regular_heading)
                      | select(($body | security_heading) | not)
+                     | select(($body | availability_notice) | not)
                      | select($body | exact_head)
                      | {at: (.updatedAt // .submittedAt),
                         id: (.databaseId | tostring),
@@ -261,6 +265,9 @@ jobs:
                     def security_heading:
                       ascii_downcase
                       | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?security(?:[[:space:]-]+)review(?:[[:space:]]*:|[[:space:]]|$)");
+                    def availability_notice:
+                      ascii_downcase
+                      | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?(?:review|review[[:space:]]+result)(?:[[:space:]]*:|[[:space:]]|$)[[:space:]]*(?:you have reached[^\\r\\n]*(?:usage[[:space:]]+limits?|quota)|(?:codex[[:space:]]+)?(?:review[[:space:]]+)?(?:is[[:space:]]+)?(?:currently[[:space:]]+)?(?:unavailable|at[[:space:]]+capacity|rate[[:space:]-]*limited)|(?:could not|unable to)[[:space:]]+(?:start|complete|perform)[[:space:]]+(?:the[[:space:]]+)?(?:codex[[:space:]]+)?review|[^\\r\\n]*try again later)");
                     def exact_head:
                       test("(?im)\\*{0,2}reviewed commit:\\*{0,2}[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60");
                     def stock_clean_envelope:
@@ -272,6 +279,7 @@ jobs:
                      | (.body // "") as $body
                      | select($body | regular_heading)
                      | select(($body | security_heading) | not)
+                     | select(($body | availability_notice) | not)
                      | select($body | exact_head)
                      | {at: (.updated_at // .created_at),
                         id: ("issue-comment-" + (.id | tostring)),

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -105,7 +105,7 @@ jobs:
           read_pr_snapshot() {
             # shellcheck disable=SC2016 # GraphQL expands these variables, not the shell.
             gh api graphql \
-              -f query='query($owner: String!, $name: String!, $number: Int!) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { id headRefOid baseRefOid isDraft autoMergeRequest { enabledAt } } } }' \
+              -f query='query($owner: String!, $name: String!, $number: Int!) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { id state headRefOid baseRefOid isDraft autoMergeRequest { enabledAt } } } }' \
               -F owner="$review_owner" \
               -F name="$review_repo" \
               -F number="$pr_number" \
@@ -116,19 +116,24 @@ jobs:
                      $pr.baseRefOid,
                      ($pr.isDraft | tostring),
                      $pr.id,
-                     (($pr.autoMergeRequest != null) | tostring)]
+                     (($pr.autoMergeRequest != null) | tostring),
+                     $pr.state]
                   | @tsv'
           }
 
           pr_snapshot="$(read_pr_snapshot)"
-          IFS=$'\t' read -r head_sha base_sha is_draft pr_node_id auto_merge_enabled <<< "$pr_snapshot"
+          IFS=$'\t' read -r head_sha base_sha is_draft pr_node_id auto_merge_enabled pr_state <<< "$pr_snapshot"
           if [[ ! "$head_sha" =~ ^[0-9a-f]{40}$ || ! "$base_sha" =~ ^[0-9a-f]{40}$ ]]; then
             echo "Could not resolve valid pull request head and base SHAs."
             exit 1
           fi
-          if [[ ! "$pr_node_id" =~ ^PR_ || ! "$is_draft" =~ ^(true|false)$ || ! "$auto_merge_enabled" =~ ^(true|false)$ ]]; then
+          if [[ ! "$pr_node_id" =~ ^PR_ || ! "$is_draft" =~ ^(true|false)$ || ! "$auto_merge_enabled" =~ ^(true|false)$ || ! "$pr_state" =~ ^(OPEN|CLOSED|MERGED)$ ]]; then
             echo "Could not resolve the pull request state for PR #$pr_number."
             exit 1
+          fi
+          if [[ "$pr_state" != "OPEN" ]]; then
+            echo "PR #$pr_number is no longer open; it will not publish review-gate."
+            exit 0
           fi
           if [[ -n "$event_head_sha" && "$event_head_sha" != "$head_sha" ]]; then
             echo "The event head changed before evaluation; the newer PR event will re-evaluate it."
@@ -270,9 +275,10 @@ jobs:
                       | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?(?:review|review[[:space:]]+result)(?:[[:space:]]*:|[[:space:]]|$)[[:space:]]*(?:you have reached[^\\r\\n]*(?:usage[[:space:]]+limits?|quota)|(?:codex[[:space:]]+)?(?:review[[:space:]]+)?(?:is[[:space:]]+)?(?:currently[[:space:]]+)?(?:unavailable|at[[:space:]]+capacity|rate[[:space:]-]*limited)|(?:could not|unable to)[[:space:]]+(?:start|complete|perform)[[:space:]]+(?:the[[:space:]]+)?(?:codex[[:space:]]+)?review|[^\\r\\n]*try again later)");
                     def exact_head:
                       test("(?im)\\*{0,2}reviewed commit:\\*{0,2}[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60");
-                    def stock_clean_envelope:
-                      test("(?is)^[[:space:]]*#{1,6}[^\\r\\n]*codex[[:space:]]+review[[:space:]]*\\r?\\n[[:space:]]*\\r?\\n[[:space:]]*here are some automated review suggestions for this pull request\\.[[:space:]]*\\r?\\n[[:space:]]*\\r?\\n[[:space:]]*\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*\\r?\\n[[:space:]]*<details>")
-                      or test("(?is)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review:[[:space:]]*didn.t find any major issues\\.[^\\r\\n]*(?:\\r?\\n[[:space:]]*)+\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*(?:\\r?\\n[[:space:]]*)+<details>[[:space:]]*<summary>[^\\r\\n]*codex[[:space:]]+in[[:space:]]+github")
+                    # An issue comment has no review-thread metadata. A generic
+                    # suggestions envelope therefore cannot prove a clean verdict.
+                    def stock_clean_issue_comment_envelope:
+                      test("(?is)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review:[[:space:]]*didn.t find any major issues\\.[^\\r\\n]*(?:\\r?\\n[[:space:]]*)+\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*(?:\\r?\\n[[:space:]]*)+<details>[[:space:]]*<summary>[^\\r\\n]*codex[[:space:]]+in[[:space:]]+github")
                       or test("(?is)^[[:space:]]*#{1,6}[^\\r\\n]*(?:codex[[:space:]]+review|review result):[[:space:]]*(?:didn.t find any issues|no issues found)\\.[[:space:]]*(?:\\r?\\n[[:space:]]*)*\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*$");
                     [.[][]
                      | select((.user.login // "") == $bot)
@@ -284,7 +290,7 @@ jobs:
                      | {at: (.updated_at // .created_at),
                         id: ("issue-comment-" + (.id | tostring)),
                         source: "issue_comment",
-                        clean: ($body | stock_clean_envelope)}]'
+                        clean: ($body | stock_clean_issue_comment_envelope)}]'
             )"
             jq -cn --argjson reviews "$review_records" --argjson issue_comments "$issue_comment_records" '
               {deliveries: ($reviews + $issue_comments),
@@ -325,6 +331,14 @@ jobs:
                   [.[][] | select((.head.sha // "") == $head) | .number]
                   | unique
                   | length'
+          }
+
+          shared_open_head_owner() {
+            gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate \
+              | jq -rs --arg head "$head_sha" '
+                  [.[][] | select((.head.sha // "") == $head) | .number]
+                  | unique
+                  | if length == 1 then .[0] | tostring else "" end'
           }
 
           read_gate_snapshot() {
@@ -417,9 +431,10 @@ jobs:
             exit 0
           fi
           shared_head_count="$(shared_open_head_count)"
-          if [[ "$shared_head_count" != "1" ]]; then
+          shared_head_owner="$(shared_open_head_owner)"
+          if [[ "$shared_head_count" != "1" || "$shared_head_owner" != "$pr_number" ]]; then
             stamp_review_gate pending "Current head is shared by multiple open pull requests"
-            echo "Refusing to share regular-review evidence across $shared_head_count open PRs."
+            echo "Refusing to use regular-review evidence for an ambiguous or mismatched open PR head."
             exit 0
           fi
           if base_change_marker_exists; then
@@ -438,7 +453,11 @@ jobs:
           # catches a new result, finding, comment, head, or base change that
           # arrived while the first snapshot was being evaluated.
           final_pr_snapshot="$(read_pr_snapshot)"
-          IFS=$'\t' read -r final_head_sha final_base_sha final_is_draft final_pr_node_id final_auto_merge_enabled <<< "$final_pr_snapshot"
+          IFS=$'\t' read -r final_head_sha final_base_sha final_is_draft final_pr_node_id final_auto_merge_enabled final_pr_state <<< "$final_pr_snapshot"
+          if [[ "$final_pr_state" != "OPEN" ]]; then
+            echo "The PR was closed during evaluation; it was not marked successful."
+            exit 0
+          fi
           if [[ "$final_head_sha" != "$head_sha" ]]; then
             echo "The PR head changed during evaluation; its synchronize event will re-evaluate it."
             exit 0
@@ -467,8 +486,8 @@ jobs:
           require_clean_regular_snapshot "$final_gate_snapshot"
 
           last_pr_snapshot="$(read_pr_snapshot)"
-          IFS=$'\t' read -r last_head_sha last_base_sha last_is_draft last_pr_node_id last_auto_merge_enabled <<< "$last_pr_snapshot"
-          if [[ "$last_head_sha" != "$head_sha" || "$last_base_sha" != "$base_sha" || "$last_is_draft" != "false" || "$last_auto_merge_enabled" != "false" ]]; then
+          IFS=$'\t' read -r last_head_sha last_base_sha last_is_draft last_pr_node_id last_auto_merge_enabled last_pr_state <<< "$last_pr_snapshot"
+          if [[ "$last_head_sha" != "$head_sha" || "$last_base_sha" != "$base_sha" || "$last_is_draft" != "false" || "$last_auto_merge_enabled" != "false" || "$last_pr_state" != "OPEN" ]]; then
             if [[ "$last_head_sha" == "$head_sha" && "$last_base_sha" != "$base_sha" ]]; then
               stamp_base_change_marker
               stamp_review_gate pending "Base changed; push a new head before @codex review"
@@ -486,9 +505,10 @@ jobs:
             exit 0
           fi
           final_shared_head_count="$(shared_open_head_count)"
-          if [[ "$final_shared_head_count" != "1" ]]; then
+          final_shared_head_owner="$(shared_open_head_owner)"
+          if [[ "$final_shared_head_count" != "1" || "$final_shared_head_owner" != "$pr_number" ]]; then
             stamp_review_gate pending "Current head is shared by multiple open pull requests"
-            echo "A second open PR shares this head; the gate was not marked successful."
+            echo "The current open PR head is ambiguous or no longer belongs to this PR."
             exit 0
           fi
 

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -2,7 +2,7 @@ name: Codex Review Gate
 
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, auto_merge_enabled]
   pull_request_review:
     types: [submitted, edited, dismissed]
   issue_comment:
@@ -16,14 +16,17 @@ on:
         required: true
         type: string
 
+# A newly delivered regular-review result or finding must replace a stale
+# evaluator before it can stamp success. Base-change invalidation has its own
+# workflow and intentionally does not share this concurrency group.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || inputs.pull_request || github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions:
   contents: read
   issues: read
-  pull-requests: read
+  pull-requests: write
   statuses: write
 
 jobs:
@@ -35,7 +38,7 @@ jobs:
       || github.event.pull_request.number != null
     runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
     steps:
-      - name: Evaluate exact-head Codex review
+      - name: Evaluate exact-head regular Codex review
         env:
           GH_TOKEN: ${{ github.token }}
           INPUT_PR: ${{ inputs.pull_request }}
@@ -44,13 +47,18 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           REPO: ${{ github.repository }}
           REVIEW_BOT: chatgpt-codex-connector[bot]
+          REVIEW_BOT_LOGIN: chatgpt-codex-connector
           REVIEW_GATE_CONTEXT: review-gate
+          REVIEW_BASE_CONTEXT: review-gate-base-change
         run: |
           set -euo pipefail
-
           export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
           command -v gh >/dev/null 2>&1 || {
             echo "GitHub CLI (gh) is required."
+            exit 1
+          }
+          command -v jq >/dev/null || {
+            echo "jq is required to evaluate review evidence on the hosted runner."
             exit 1
           }
 
@@ -71,92 +79,317 @@ jobs:
             exit 1
           fi
 
-          pr_ref="https://github.com/$REPO/pull/$pr_number"
-          head_sha="$(gh pr view "$pr_ref" --json headRefOid --jq '.headRefOid')"
-          if [[ ! "$head_sha" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "Could not resolve a valid pull request head SHA."
+          review_owner="$(printf '%s' "$REPO" | cut -d/ -f1)"
+          review_repo="$(printf '%s' "$REPO" | cut -d/ -f2)"
+
+          read_pr_snapshot() {
+            # shellcheck disable=SC2016 # GraphQL expands these variables, not the shell.
+            gh api graphql \
+              -f query='query($owner: String!, $name: String!, $number: Int!) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { id headRefOid baseRefOid isDraft autoMergeRequest { enabledAt } } } }' \
+              -F owner="$review_owner" \
+              -F name="$review_repo" \
+              -F number="$pr_number" \
+              | jq -er '
+                  .data.repository.pullRequest as $pr
+                  | select($pr != null)
+                  | [$pr.headRefOid,
+                     $pr.baseRefOid,
+                     ($pr.isDraft | tostring),
+                     $pr.id,
+                     (($pr.autoMergeRequest != null) | tostring)]
+                  | @tsv'
+          }
+
+          pr_snapshot="$(read_pr_snapshot)"
+          IFS=$'\t' read -r head_sha base_sha is_draft pr_node_id auto_merge_enabled <<< "$pr_snapshot"
+          if [[ ! "$head_sha" =~ ^[0-9a-f]{40}$ || ! "$base_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Could not resolve valid pull request head and base SHAs."
             exit 1
           fi
+          if [[ ! "$pr_node_id" =~ ^PR_ || ! "$is_draft" =~ ^(true|false)$ || ! "$auto_merge_enabled" =~ ^(true|false)$ ]]; then
+            echo "Could not resolve the pull request state for PR #$pr_number."
+            exit 1
+          fi
+          head_prefix="$(printf '%.10s' "$head_sha")"
 
-          stamp_review_gate() {
+          stamp_status() {
+            local context="$1"
+            local state="$2"
+            local description="$3"
             gh api "repos/$REPO/statuses/$head_sha" --silent \
-              -f state="$1" \
-              -f context="$REVIEW_GATE_CONTEXT" \
-              -f description="$2" \
+              -f state="$state" \
+              -f context="$context" \
+              -f description="$description" \
               -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
           }
 
-          if [[ "$(gh pr view "$pr_ref" --json isDraft --jq '.isDraft')" == "true" ]]; then
+          stamp_review_gate() {
+            stamp_status "$REVIEW_GATE_CONTEXT" "$1" "$2"
+          }
+
+          stamp_base_change_marker() {
+            stamp_status "$REVIEW_BASE_CONTEXT" pending \
+              "Base changed; push a new head before @codex review"
+          }
+
+          disable_auto_merge() {
+            local pull_request_id="$1"
+            if [[ ! "$pull_request_id" =~ ^PR_ ]]; then
+              echo "Could not resolve a pull request node ID to disable automatic merge."
+              exit 1
+            fi
+            # shellcheck disable=SC2016 # GraphQL expands this variable, not the shell.
+            gh api graphql \
+              -f query='mutation($pullRequestId: ID!) { disablePullRequestAutoMerge(input: {pullRequestId: $pullRequestId}) { pullRequest { id } } }' \
+              -F pullRequestId="$pull_request_id" >/dev/null
+          }
+
+          base_change_marker_exists() {
+            gh api "repos/$REPO/commits/$head_sha/statuses?per_page=100" --paginate --slurp \
+              | jq -e --arg context "$REVIEW_BASE_CONTEXT" '
+                  any(.[][];
+                    (.context == $context)
+                    and (.state == "pending")
+                    and ((.description // "") | startswith("Base changed; push a new head before @codex review")))' \
+              >/dev/null
+          }
+
+          latest_base_change_at() {
+            # shellcheck disable=SC2016 # GraphQL expands these variables, not the shell.
+            gh api graphql --paginate \
+              -f query='query($owner: String!, $name: String!, $number: Int!, $endCursor: String) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { timelineItems(first: 100, after: $endCursor, itemTypes: [BASE_REF_CHANGED_EVENT]) { nodes { ... on BaseRefChangedEvent { createdAt } } pageInfo { hasNextPage endCursor } } } } }' \
+              -F owner="$review_owner" \
+              -F name="$review_repo" \
+              -F number="$pr_number" \
+              | jq -rs -r '[.[] | .data.repository.pullRequest.timelineItems.nodes[]? | .createdAt] | max // empty'
+          }
+
+          # This function deliberately returns regular-review evidence only.
+          # Security-review results and availability notices are never selected,
+          # counted, or used in any review-gate decision.
+          regular_evidence() {
+            local issue_records review_records
+            issue_records="$(
+              gh api "repos/$REPO/issues/$pr_number/comments?per_page=100" --paginate --slurp \
+                | jq -c --arg bot "$REVIEW_BOT" --arg head "$head_sha" --arg prefix "$head_prefix" '
+                    def regular_heading:
+                      ascii_downcase
+                      | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review(?:[[:space:]]*:|[[:space:]]|$)|^[[:space:]]*(?:#{1,6}[[:space:]]+)?review result(?:[[:space:]]*:|[[:space:]]|$)");
+                    def security_heading:
+                      ascii_downcase
+                      | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?security(?:[[:space:]-]+)review(?:[[:space:]]*:|[[:space:]]|$)");
+                    def exact_head:
+                      test("(?im)\\*{0,2}reviewed commit:\\*{0,2}[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60");
+                    def clean_result:
+                      ascii_downcase
+                      | test("didn.t find( any)?( major)? issues|did not find( any)?( major)? issues|no (major |blocking )?(issues|findings)( found)?|found no (major |blocking )?(issues|findings)");
+                    [.[][]
+                     | select((.user.login // "") == $bot)
+                     | (.body // "") as $body
+                     | select($body | regular_heading)
+                     | select(($body | security_heading) | not)
+                     | select($body | exact_head)
+                     | {at: (.updated_at // .created_at),
+                        kind: (if ($body | clean_result) then "clean" else "findings" end),
+                        source: "issue", id: (.id | tostring)}]'
+            )"
+            review_records="$(
+              # shellcheck disable=SC2016 # GraphQL expands these variables, not the shell.
+              gh api graphql --paginate \
+                -f query='query($owner: String!, $name: String!, $number: Int!, $endCursor: String) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { reviews(first: 100, after: $endCursor) { nodes { databaseId state submittedAt updatedAt body author { login } } pageInfo { hasNextPage endCursor } } } } }' \
+                -F owner="$review_owner" \
+                -F name="$review_repo" \
+                -F number="$pr_number" \
+                | jq -cs --arg bot "$REVIEW_BOT_LOGIN" --arg head "$head_sha" --arg prefix "$head_prefix" '
+                    def regular_heading:
+                      ascii_downcase
+                      | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review(?:[[:space:]]*:|[[:space:]]|$)|^[[:space:]]*(?:#{1,6}[[:space:]]+)?review result(?:[[:space:]]*:|[[:space:]]|$)");
+                    def security_heading:
+                      ascii_downcase
+                      | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?security(?:[[:space:]-]+)review(?:[[:space:]]*:|[[:space:]]|$)");
+                    def exact_head:
+                      test("(?im)\\*{0,2}reviewed commit:\\*{0,2}[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60");
+                    def clean_result:
+                      ascii_downcase
+                      | test("didn.t find( any)?( major)? issues|did not find( any)?( major)? issues|no (major |blocking )?(issues|findings)( found)?|found no (major |blocking )?(issues|findings)");
+                    [.[]
+                     | .data.repository.pullRequest.reviews.nodes[]?
+                     | select((.author.login // "") == $bot)
+                     | select((.state // "") != "DISMISSED")
+                     | (.body // "") as $body
+                     | select($body | regular_heading)
+                     | select(($body | security_heading) | not)
+                     | select($body | exact_head)
+                     | {at: (.updatedAt // .submittedAt),
+                        kind: (if ($body | clean_result) then "clean" else "findings" end),
+                        source: "review", id: (.databaseId | tostring)}]'
+            )"
+            jq -cn --argjson issues "$issue_records" --argjson reviews "$review_records" '
+              {verdict: (([$issues[], $reviews[]] | sort_by(.at) | last) // null),
+               review_ids: [$reviews[].id]}'
+          }
+
+          active_regular_finding_count() {
+            local review_ids="$1"
+            # shellcheck disable=SC2016 # GraphQL expands these variables, not the shell.
+            gh api graphql --paginate \
+              -f query='query($owner: String!, $name: String!, $number: Int!, $endCursor: String) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { reviewThreads(first: 100, after: $endCursor) { nodes { isResolved isOutdated comments(first: 100) { nodes { commit { oid } originalCommit { oid } replyTo { databaseId } pullRequestReview { databaseId } author { login } } } } pageInfo { hasNextPage endCursor } } } } }' \
+              -F owner="$review_owner" \
+              -F name="$review_repo" \
+              -F number="$pr_number" \
+              | jq -rs --argjson review_ids "$review_ids" --arg bot "$REVIEW_BOT_LOGIN" --arg head "$head_sha" '
+                  [.[]
+                   | .data.repository.pullRequest.reviewThreads.nodes[]?
+                   | select(.isResolved | not)
+                   | select(.isOutdated | not)
+                   | .comments.nodes[]?
+                   | select((.author.login // "") == $bot)
+                   | select(.replyTo == null)
+                   | select((((.pullRequestReview.databaseId // -1) | tostring) as $review_id
+                       | ($review_ids | index($review_id))) != null)
+                   | select((.commit.oid // .originalCommit.oid // "") == $head)]
+                  | length'
+          }
+
+          latest_finding_gate_at() {
+            gh api "repos/$REPO/commits/$head_sha/statuses?per_page=100" --paginate --slurp \
+              | jq -r --arg context "$REVIEW_GATE_CONTEXT" '
+                  [.[][]
+                   | select(.context == $context)
+                   | select(.state == "pending")
+                   | select((.description // "") | startswith("Codex reported findings on "))
+                   | .updated_at]
+                  | max // empty'
+          }
+
+          read_gate_snapshot() {
+            local evidence verdict review_ids finding_count finding_gate_at base_changed_at
+            evidence="$(regular_evidence)"
+            verdict="$(jq -c '.verdict' <<< "$evidence")"
+            review_ids="$(jq -c '.review_ids' <<< "$evidence")"
+            finding_count="$(active_regular_finding_count "$review_ids")"
+            finding_gate_at="$(latest_finding_gate_at)"
+            base_changed_at="$(latest_base_change_at)"
+            jq -cn \
+              --argjson verdict "$verdict" \
+              --argjson finding_count "$finding_count" \
+              --arg finding_gate_at "$finding_gate_at" \
+              --arg base_changed_at "$base_changed_at" \
+              '{verdict: $verdict,
+                finding_count: $finding_count,
+                finding_gate_at: $finding_gate_at,
+                base_changed_at: $base_changed_at}'
+          }
+
+          require_clean_regular_snapshot() {
+            local gate_snapshot="$1"
+            local verdict verdict_at verdict_kind finding_count finding_gate_at base_changed_at
+            verdict="$(jq -c '.verdict' <<< "$gate_snapshot")"
+            if [[ "$verdict" == "null" ]]; then
+              stamp_review_gate pending "Waiting for @codex review on $head_prefix"
+              echo "No affirmative regular Codex verdict covers the exact head."
+              exit 0
+            fi
+            verdict_at="$(jq -r '.at // empty' <<< "$verdict")"
+            verdict_kind="$(jq -r '.kind // empty' <<< "$verdict")"
+            finding_count="$(jq -r '.finding_count' <<< "$gate_snapshot")"
+            finding_gate_at="$(jq -r '.finding_gate_at' <<< "$gate_snapshot")"
+            base_changed_at="$(jq -r '.base_changed_at' <<< "$gate_snapshot")"
+            if [[ -z "$verdict_at" || "$verdict_kind" != "clean" || "$finding_count" -gt 0 ]]; then
+              stamp_review_gate pending "Codex reported findings on $head_prefix"
+              echo "Codex reported $finding_count active regular-review finding(s) on the exact head."
+              echo "Fix them, push a new head, and tag @codex review again."
+              exit 0
+            fi
+            if [[ -n "$finding_gate_at" && ( "$finding_gate_at" == "$verdict_at" || "$finding_gate_at" > "$verdict_at" ) ]]; then
+              stamp_review_gate pending "Waiting for newer clean Codex review on $head_prefix"
+              echo "A prior regular finding requires a newer affirmative clean review."
+              exit 0
+            fi
+            if [[ -n "$base_changed_at" && ( "$base_changed_at" == "$verdict_at" || "$base_changed_at" > "$verdict_at" ) ]]; then
+              stamp_base_change_marker
+              stamp_review_gate pending "Base changed; push a new head before @codex review"
+              echo "The PR base changed after the regular review; a new head is required."
+              exit 0
+            fi
+          }
+
+          # A pre-policy or manually armed pull request must be made manual-only
+          # before this gate evaluates it. This mutation only disables auto-merge.
+          if [[ "$auto_merge_enabled" == "true" ]]; then
+            disable_auto_merge "$pr_node_id"
+            echo "Disabled automatic merge for PR #$pr_number."
+          fi
+
+          if [[ "$is_draft" == "true" ]]; then
             stamp_review_gate pending "Waiting for pull request to leave draft"
             exit 0
           fi
-
-          latest_verdict="$(
-            {
-              HEAD_PREFIX="${head_sha:0:10}" gh api \
-                "repos/$REPO/pulls/$pr_number/reviews?per_page=100" --paginate \
-                --jq '.[]
-                      | select(.user.login == env.REVIEW_BOT)
-                      | select(.state != "DISMISSED")
-                      | select((.body // "") | contains("Reviewed commit:"))
-                      | select((.body // "") | contains(env.HEAD_PREFIX))
-                      | [.submitted_at,
-                         (if ((.body // "") | ascii_downcase
-                              | test("didn.t find any major issues|found no major issues|no major issues found|no issues found"))
-                          then "clean" else "findings" end)]
-                      | @tsv'
-              HEAD_PREFIX="${head_sha:0:10}" gh api \
-                "repos/$REPO/issues/$pr_number/comments?per_page=100" --paginate \
-                --jq '.[]
-                      | select(.user.login == env.REVIEW_BOT)
-                      | select((.body // "") | contains("Reviewed commit:"))
-                      | select((.body // "") | contains(env.HEAD_PREFIX))
-                      | [.created_at,
-                         (if ((.body // "") | ascii_downcase
-                              | test("didn.t find any major issues|found no major issues|no major issues found|no issues found"))
-                          then "clean" else "findings" end)]
-                      | @tsv'
-            } | sort -k1,1 | tail -n 1
-          )"
-
-          if [[ -z "$latest_verdict" ]]; then
-            stamp_review_gate pending "Waiting for @codex review on ${head_sha:0:10}"
-            echo "No Codex verdict covers the exact pull request head."
-            exit 0
-          fi
-          IFS=$'\t' read -r verdict_at verdict_kind <<< "$latest_verdict"
-
-          finding_count="$(
-            HEAD_SHA="$head_sha" gh api \
-              "repos/$REPO/pulls/$pr_number/comments?per_page=100" --paginate \
-              --jq '[.[]
-                    | select(.user.login == env.REVIEW_BOT)
-                    | select(.in_reply_to_id == null)
-                    | select((.commit_id // .original_commit_id // "") == env.HEAD_SHA)]
-                    | length' \
-              | awk '{ total += $1 } END { print total + 0 }'
-          )"
-          latest_finding_at="$(
-            HEAD_SHA="$head_sha" gh api \
-              "repos/$REPO/pulls/$pr_number/comments?per_page=100" --paginate \
-              --jq '.[]
-                    | select(.user.login == env.REVIEW_BOT)
-                    | select(.in_reply_to_id == null)
-                    | select((.commit_id // .original_commit_id // "") == env.HEAD_SHA)
-                    | .created_at' \
-              | sort | tail -n 1
-          )"
-
-          if [[ "$verdict_kind" != "clean" \
-            || ( -n "$latest_finding_at" \
-              && ( "$latest_finding_at" == "$verdict_at" \
-                || "$latest_finding_at" > "$verdict_at" ) ) ]]; then
-            stamp_review_gate pending "Codex reported findings on ${head_sha:0:10}"
-            echo "Codex reported $finding_count finding(s) on the exact head."
-            echo "Fix them, push a new head, and tag @codex review again."
+          if base_change_marker_exists; then
+            stamp_review_gate pending "Base changed; push a new head before @codex review"
+            echo "The base-change marker requires a fresh PR head and regular review."
             exit 0
           fi
 
-          stamp_review_gate success "Clean Codex review for ${head_sha:0:10}"
-          echo "The exact pull request head has a clean Codex review."
+          # Clear any stale success before reads. Later review/comment events cancel
+          # this run and start a fresh evaluator rather than queue behind it.
+          stamp_review_gate pending "Evaluating regular Codex review on $head_prefix"
+          gate_snapshot="$(read_gate_snapshot)"
+          require_clean_regular_snapshot "$gate_snapshot"
+
+          # Re-read every merge-relevant input immediately before success. This
+          # catches a new result, finding, comment, head, or base change that
+          # arrived while the first snapshot was being evaluated.
+          final_pr_snapshot="$(read_pr_snapshot)"
+          IFS=$'\t' read -r final_head_sha final_base_sha final_is_draft final_pr_node_id final_auto_merge_enabled <<< "$final_pr_snapshot"
+          if [[ "$final_head_sha" != "$head_sha" ]]; then
+            echo "The PR head changed during evaluation; its synchronize event will re-evaluate it."
+            exit 0
+          fi
+          if [[ "$final_base_sha" != "$base_sha" ]]; then
+            stamp_base_change_marker
+            stamp_review_gate pending "Base changed; push a new head before @codex review"
+            echo "The PR base changed during evaluation; a new head is required."
+            exit 0
+          fi
+          if [[ "$final_is_draft" != "false" || "$final_auto_merge_enabled" != "false" ]]; then
+            if [[ "$final_auto_merge_enabled" == "true" ]]; then
+              disable_auto_merge "$final_pr_node_id"
+              echo "Disabled automatic merge that was enabled during evaluation."
+            fi
+            stamp_review_gate pending "Pull request state changed during review evaluation"
+            echo "The PR became draft or automatic merge was enabled during evaluation."
+            exit 0
+          fi
+          if base_change_marker_exists; then
+            stamp_review_gate pending "Base changed; push a new head before @codex review"
+            echo "A base-change marker arrived during evaluation."
+            exit 0
+          fi
+          final_gate_snapshot="$(read_gate_snapshot)"
+          require_clean_regular_snapshot "$final_gate_snapshot"
+
+          last_pr_snapshot="$(read_pr_snapshot)"
+          IFS=$'\t' read -r last_head_sha last_base_sha last_is_draft last_pr_node_id last_auto_merge_enabled <<< "$last_pr_snapshot"
+          if [[ "$last_head_sha" != "$head_sha" || "$last_base_sha" != "$base_sha" || "$last_is_draft" != "false" || "$last_auto_merge_enabled" != "false" ]]; then
+            if [[ "$last_head_sha" == "$head_sha" && "$last_base_sha" != "$base_sha" ]]; then
+              stamp_base_change_marker
+              stamp_review_gate pending "Base changed; push a new head before @codex review"
+            fi
+            if [[ "$last_auto_merge_enabled" == "true" ]]; then
+              disable_auto_merge "$last_pr_node_id"
+              echo "Disabled automatic merge that was enabled during final revalidation."
+            fi
+            echo "The PR state changed during final revalidation; it was not marked successful."
+            exit 0
+          fi
+          if base_change_marker_exists; then
+            stamp_review_gate pending "Base changed; push a new head before @codex review"
+            echo "A base-change marker arrived during final revalidation."
+            exit 0
+          fi
+
+          stamp_review_gate success "Clean regular Codex review for $head_prefix"
+          echo "The exact pull request head has an affirmative clean regular Codex review."
+          echo "Security-review messages are intentionally not review-gate evidence."
           echo "This workflow never enables or performs a merge."

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, reopened, synchronize, ready_for_review, auto_merge_enabled]
   pull_request_review:
     types: [submitted, edited, dismissed]
-  pull_request_review_comment:
+  issue_comment:
     types: [created, edited, deleted]
   workflow_dispatch:
     inputs:
@@ -14,15 +14,16 @@ on:
         required: true
         type: string
 
-# Base invalidation uses this same per-PR lock with cancellation enabled. Review
-# events queue instead of cancelling that invalidation, so a retarget cannot be
-# dropped between its final marker check and a status write.
+# The latest review-state event wins. Every event stamps the exact head pending
+# before its first fallible lookup, so a new auto-merge or review event cancels
+# any stale evaluator instead of allowing it to publish a late success.
 concurrency:
-  group: review-gate-${{ github.event.pull_request.number || inputs.pull_request || github.ref }}
-  cancel-in-progress: false
+  group: review-gate-${{ github.event.pull_request.number || github.event.issue.number || inputs.pull_request || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
+  issues: read
   pull-requests: write
   statuses: write
 
@@ -32,6 +33,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch'
       || github.event.pull_request.number != null
+      || github.event.issue.pull_request != null
     runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
     steps:
       - name: Evaluate exact-head regular Codex review
@@ -39,13 +41,20 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           INPUT_PR: ${{ inputs.pull_request }}
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_ISSUE_PR_NUMBER: ${{ github.event.issue.number }}
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_REVIEW_AUTHOR: ${{ github.event.review.user.login }}
+          EVENT_REVIEW_BODY: ${{ github.event.review.body }}
+          EVENT_COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_COMMENT_BODY: ${{ github.event.comment.body }}
           EVENT_NAME: ${{ github.event_name }}
           REPO: ${{ github.repository }}
           REVIEW_BOT: chatgpt-codex-connector[bot]
           REVIEW_BOT_LOGIN: chatgpt-codex-connector
+          REVIEW_BOT_EVENT_LOGIN: chatgpt-codex-connector[bot]
           REVIEW_GATE_CONTEXT: review-gate
           REVIEW_BASE_CONTEXT: review-gate-base-change
+          REVIEW_COMMENT_CONTEXT: review-gate-regular-comment
         run: |
           set -euo pipefail
           export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
@@ -65,7 +74,7 @@ jobs:
             fi
             pr_number="$INPUT_PR"
           else
-            pr_number="$EVENT_PR_NUMBER"
+            pr_number="${EVENT_PR_NUMBER:-${EVENT_ISSUE_PR_NUMBER:-}}"
           fi
 
           if [[ ! "$pr_number" =~ ^[1-9][0-9]*$ ]]; then
@@ -93,9 +102,32 @@ jobs:
               -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
           }
 
-          # PR-review event payloads carry the exact head. Revoke its prior
-          # success before the first fallible API lookup; issue comments are not
-          # evidence and do not trigger this workflow.
+          event_pull_request_review_is_regular() {
+            [[ "$EVENT_REVIEW_AUTHOR" == "$REVIEW_BOT_EVENT_LOGIN" ]] || return 1
+            printf '%s' "$EVENT_REVIEW_BODY" \
+              | jq -e -R -s '
+                  def regular_heading:
+                    ascii_downcase
+                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review(?:[[:space:]]*:|[[:space:]]|$)|^[[:space:]]*(?:#{1,6}[[:space:]]+)?review result(?:[[:space:]]*:|[[:space:]]|$)");
+                  def security_heading:
+                    ascii_downcase
+                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?security(?:[[:space:]-]+)review(?:[[:space:]]*:|[[:space:]]|$)");
+                  select(regular_heading)
+                  | select(security_heading | not)' >/dev/null
+          }
+
+          # Security and other non-regular PR review events never change this
+          # status. Inline-thread changes are handled by the quiet audit, so a
+          # security review cannot momentarily block the regular-review path.
+          if [[ "$EVENT_NAME" == "pull_request_review" ]] && ! event_pull_request_review_is_regular; then
+            echo "Ignoring a non-regular pull request review."
+            exit 0
+          fi
+
+          # Regular PR-review event payloads carry the exact head. Revoke its
+          # prior success before the first fallible API lookup. Issue comments
+          # are never qualifying evidence and are classified before they can
+          # invalidate this regular-review gate.
           if [[ -n "$event_head_sha" ]]; then
             stamp_status_for_sha "$event_head_sha" "$REVIEW_GATE_CONTEXT" pending \
               "Review state changed; evaluating regular Codex review"
@@ -135,6 +167,32 @@ jobs:
           fi
           head_prefix="$(printf '%.10s' "$head_sha")"
 
+          event_issue_comment_is_regular() {
+            printf '%s' "$EVENT_COMMENT_BODY" \
+              | jq -e -R -s --arg head "$head_sha" --arg prefix "$head_prefix" '
+                  def regular_heading:
+                    ascii_downcase
+                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review(?:[[:space:]]*:|[[:space:]]|$)|^[[:space:]]*(?:#{1,6}[[:space:]]+)?review result(?:[[:space:]]*:|[[:space:]]|$)");
+                  def security_heading:
+                    ascii_downcase
+                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?security(?:[[:space:]-]+)review(?:[[:space:]]*:|[[:space:]]|$)");
+                  def exact_head:
+                    test("(?im)\\*{0,2}reviewed commit:\\*{0,2}[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60");
+                  select(regular_heading)
+                  | select(security_heading | not)
+                  | select(exact_head)' >/dev/null
+          }
+
+          # Only an exact-head, bot-authored regular-review issue comment can
+          # invalidate this gate. Security-review messages and all other
+          # comments are outside the regular-review protocol.
+          if [[ "$EVENT_NAME" == "issue_comment" ]]; then
+            if [[ "$EVENT_COMMENT_AUTHOR" != "$REVIEW_BOT_EVENT_LOGIN" ]] || ! event_issue_comment_is_regular; then
+              echo "Ignoring a non-regular issue comment."
+              exit 0
+            fi
+          fi
+
           stamp_status() {
             local context="$1"
             local state="$2"
@@ -150,6 +208,13 @@ jobs:
             stamp_status "$REVIEW_BASE_CONTEXT" pending \
               "Base changed; push a new head before @codex review"
           }
+
+          if [[ "$EVENT_NAME" == "issue_comment" ]]; then
+            # A normal regular-review issue comment can only invalidate. A
+            # later submitted PR review must explicitly clear this marker.
+            stamp_status "$REVIEW_COMMENT_CONTEXT" pending \
+              "Regular issue-comment verdict; require a newer PR review"
+          fi
 
           disable_auto_merge() {
             local pull_request_id="$1"
@@ -186,11 +251,22 @@ jobs:
               | jq -rs -r '[.[] | .data.repository.pullRequest.timelineItems.nodes[]? | .createdAt] | max // empty'
           }
 
-          # This function deliberately returns regular-review evidence only.
-          # It reads only submitted PR reviews, never issue comments; security
-          # review results and availability notices cannot qualify or block it.
+          latest_regular_issue_comment_at() {
+            gh api "repos/$REPO/commits/$head_sha/statuses?per_page=100" --paginate --slurp \
+              | jq -r --arg context "$REVIEW_COMMENT_CONTEXT" '
+                  [.[][]
+                   | select(.context == $context)
+                   | select(.state == "pending")
+                   | select((.description // "") | startswith("Regular issue-comment verdict;"))
+                   | .updated_at]
+                  | max // empty'
+          }
+
+          # Submitted PR reviews are the only qualifying clean evidence. Normal
+          # issue-comment verdicts can invalidate that evidence, while security
+          # review results and availability notices are ignored completely.
           regular_evidence() {
-            local review_records
+            local review_records issue_comment_records
             review_records="$(
               # shellcheck disable=SC2016 # GraphQL expands these variables, not the shell.
               gh api graphql --paginate \
@@ -221,16 +297,41 @@ jobs:
                      | select($body | regular_heading)
                      | select(($body | security_heading) | not)
                      | select($body | exact_head)
-                     | select($body | stock_clean_envelope)
                      | {at: (.updatedAt // .submittedAt),
-                        id: (.databaseId | tostring)}]'
+                        id: (.databaseId | tostring),
+                        source: "review",
+                        clean: ($body | stock_clean_envelope)}]'
             )"
-            jq -cn --argjson reviews "$review_records" '
-              {verdict: (($reviews | sort_by(.at) | last) // null),
+            issue_comment_records="$(
+              gh api "repos/$REPO/issues/$pr_number/comments?per_page=100" --paginate --slurp \
+                | jq -c --arg bot "$REVIEW_BOT_EVENT_LOGIN" --arg head "$head_sha" --arg prefix "$head_prefix" '
+                    def regular_heading:
+                      ascii_downcase
+                      | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review(?:[[:space:]]*:|[[:space:]]|$)|^[[:space:]]*(?:#{1,6}[[:space:]]+)?review result(?:[[:space:]]*:|[[:space:]]|$)");
+                    def security_heading:
+                      ascii_downcase
+                      | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?security(?:[[:space:]-]+)review(?:[[:space:]]*:|[[:space:]]|$)");
+                    def exact_head:
+                      test("(?im)\\*{0,2}reviewed commit:\\*{0,2}[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60");
+                    def stock_clean_envelope:
+                      test("(?is)^[[:space:]]*#{1,6}[^\\r\\n]*codex[[:space:]]+review[[:space:]]*\\r?\\n[[:space:]]*\\r?\\n[[:space:]]*here are some automated review suggestions for this pull request\\.[[:space:]]*\\r?\\n[[:space:]]*\\r?\\n[[:space:]]*\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*\\r?\\n[[:space:]]*<details>");
+                    [.[][]
+                     | select((.user.login // "") == $bot)
+                     | (.body // "") as $body
+                     | select($body | regular_heading)
+                     | select(($body | security_heading) | not)
+                     | select($body | exact_head)
+                     | {at: (.updated_at // .created_at),
+                        id: ("issue-comment-" + (.id | tostring)),
+                        source: "issue_comment",
+                        clean: ($body | stock_clean_envelope)}]'
+            )"
+            jq -cn --argjson reviews "$review_records" --argjson issue_comments "$issue_comment_records" '
+              {deliveries: ($reviews + $issue_comments),
                review_ids: [$reviews[].id]}'
           }
 
-          active_regular_finding_count() {
+          regular_review_thread_summary() {
             local review_ids="$1"
             # shellcheck disable=SC2016 # GraphQL expands these variables, not the shell.
             gh api graphql --paginate \
@@ -240,16 +341,19 @@ jobs:
               -F number="$pr_number" \
               | jq -rs --argjson review_ids "$review_ids" --arg bot "$REVIEW_BOT_LOGIN" --arg head "$head_sha" '
                   [.[]
-                   | .data.repository.pullRequest.reviewThreads.nodes[]?
-                   | select(.isResolved | not)
-                   | select(.isOutdated | not)
-                   | .comments.nodes[]?
+                   | .data.repository.pullRequest.reviewThreads.nodes[]? as $thread
+                   | $thread.comments.nodes[]?
                    | select((.author.login // "") == $bot)
                    | select(.replyTo == null)
                    | select((((.pullRequestReview.databaseId // -1) | tostring) as $review_id
                        | ($review_ids | index($review_id))) != null)
-                   | select((.commit.oid // .originalCommit.oid // "") == $head)]
-                  | length'
+                   | select((.commit.oid // .originalCommit.oid // "") == $head)
+                   | {id: (.pullRequestReview.databaseId | tostring),
+                      active: (($thread.isResolved | not) and ($thread.isOutdated | not))}]
+                  | group_by(.id)
+                  | map({id: .[0].id,
+                         active_count: ([.[] | select(.active)] | length),
+                         total_count: length})'
           }
 
           shared_open_head_count() {
@@ -264,32 +368,66 @@ jobs:
           }
 
           read_gate_snapshot() {
-            local evidence verdict review_ids finding_count base_changed_at
+            local evidence deliveries reviews review_ids thread_summary verdict_selection verdict finding_count base_changed_at latest_finding_at issue_comment_at
             evidence="$(regular_evidence)"
-            verdict="$(jq -c '.verdict' <<< "$evidence")"
+            deliveries="$(jq -c '.deliveries' <<< "$evidence")"
+            reviews="$(jq -c '[.deliveries[] | select(.source == "review")]' <<< "$evidence")"
             review_ids="$(jq -c '.review_ids' <<< "$evidence")"
-            finding_count="$(active_regular_finding_count "$review_ids")"
+            thread_summary="$(regular_review_thread_summary "$review_ids")"
+            verdict_selection="$(
+              issue_comment_at="$(latest_regular_issue_comment_at)"
+              jq -cn --argjson deliveries "$deliveries" --argjson reviews "$reviews" --argjson thread_summary "$thread_summary" --arg issue_comment_at "$issue_comment_at" '
+                ($thread_summary | map(select(.total_count > 0) | .id)) as $finding_ids
+                | (([$deliveries[] | select(.clean | not) | .at]
+                    + [$reviews[]
+                       | select(.id as $id | ($finding_ids | index($id)) != null)
+                       | .at]
+                    + (if $issue_comment_at == "" then [] else [$issue_comment_at] end))
+                   | max // "") as $latest_finding_at
+                | ($deliveries | sort_by(.at) | last) as $latest_delivery
+                | {verdict:
+                     (if $latest_delivery != null
+                           and $latest_delivery.source == "review"
+                           and $latest_delivery.clean
+                           and (($finding_ids | index($latest_delivery.id)) == null)
+                           and $latest_delivery.at > $latest_finding_at
+                      then $latest_delivery
+                      else null
+                      end),
+                   latest_finding_at: $latest_finding_at}'
+            )"
+            verdict="$(jq -c '.verdict' <<< "$verdict_selection")"
+            latest_finding_at="$(jq -r '.latest_finding_at' <<< "$verdict_selection")"
+            finding_count="$(jq '[.[].active_count] | add // 0' <<< "$thread_summary")"
             base_changed_at="$(latest_base_change_at)"
             jq -cn \
               --argjson verdict "$verdict" \
               --argjson finding_count "$finding_count" \
               --arg base_changed_at "$base_changed_at" \
+              --arg latest_finding_at "$latest_finding_at" \
               '{verdict: $verdict,
                 finding_count: $finding_count,
-                base_changed_at: $base_changed_at}'
+                base_changed_at: $base_changed_at,
+                latest_finding_at: $latest_finding_at}'
           }
 
           require_clean_regular_snapshot() {
             local gate_snapshot="$1"
-            local verdict verdict_at finding_count base_changed_at
+            local verdict verdict_at finding_count base_changed_at latest_finding_at
             verdict="$(jq -c '.verdict' <<< "$gate_snapshot")"
+            latest_finding_at="$(jq -r '.latest_finding_at // empty' <<< "$gate_snapshot")"
+            finding_count="$(jq -r '.finding_count' <<< "$gate_snapshot")"
             if [[ "$verdict" == "null" ]]; then
+              if [[ -n "$latest_finding_at" ]]; then
+                stamp_review_gate pending "Waiting for fresh clean Codex review on $head_prefix"
+                echo "A findings-bearing regular review needs a newer clean review."
+                exit 0
+              fi
               stamp_review_gate pending "Waiting for @codex review on $head_prefix"
               echo "No affirmative regular Codex verdict covers the exact head."
               exit 0
             fi
             verdict_at="$(jq -r '.at // empty' <<< "$verdict")"
-            finding_count="$(jq -r '.finding_count' <<< "$gate_snapshot")"
             base_changed_at="$(jq -r '.base_changed_at' <<< "$gate_snapshot")"
             if [[ -z "$verdict_at" || "$finding_count" -gt 0 ]]; then
               stamp_review_gate pending "Codex reported findings on $head_prefix"

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -5,8 +5,6 @@ on:
     types: [opened, reopened, synchronize, ready_for_review, auto_merge_enabled]
   pull_request_review:
     types: [submitted, edited, dismissed]
-  issue_comment:
-    types: [created, edited, deleted]
   pull_request_review_comment:
     types: [created, edited, deleted]
   workflow_dispatch:
@@ -16,16 +14,15 @@ on:
         required: true
         type: string
 
-# A newly delivered regular-review result or finding must replace a stale
-# evaluator before it can stamp success. Base-change invalidation has its own
-# workflow and intentionally does not share this concurrency group.
+# Base invalidation uses this same per-PR lock with cancellation enabled. Review
+# events queue instead of cancelling that invalidation, so a retarget cannot be
+# dropped between its final marker check and a status write.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || inputs.pull_request || github.ref }}
-  cancel-in-progress: true
+  group: review-gate-${{ github.event.pull_request.number || inputs.pull_request || github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
-  issues: read
   pull-requests: write
   statuses: write
 
@@ -34,7 +31,6 @@ jobs:
     name: evaluate-review
     if: >-
       github.event_name == 'workflow_dispatch'
-      || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null)
       || github.event.pull_request.number != null
     runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
     steps:
@@ -43,7 +39,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           INPUT_PR: ${{ inputs.pull_request }}
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
-          EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           EVENT_NAME: ${{ github.event_name }}
           REPO: ${{ github.repository }}
           REVIEW_BOT: chatgpt-codex-connector[bot]
@@ -68,8 +64,6 @@ jobs:
               exit 1
             fi
             pr_number="$INPUT_PR"
-          elif [[ -n "${EVENT_ISSUE_NUMBER:-}" ]]; then
-            pr_number="$EVENT_ISSUE_NUMBER"
           else
             pr_number="$EVENT_PR_NUMBER"
           fi
@@ -81,6 +75,31 @@ jobs:
 
           review_owner="$(printf '%s' "$REPO" | cut -d/ -f1)"
           review_repo="$(printf '%s' "$REPO" | cut -d/ -f2)"
+          event_head_sha="${EVENT_HEAD_SHA:-}"
+          if [[ -n "$event_head_sha" && ! "$event_head_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "The review event did not provide a valid pull request head SHA."
+            exit 1
+          fi
+
+          stamp_status_for_sha() {
+            local target_sha="$1"
+            local context="$2"
+            local state="$3"
+            local description="$4"
+            gh api "repos/$REPO/statuses/$target_sha" --silent \
+              -f state="$state" \
+              -f context="$context" \
+              -f description="$description" \
+              -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
+          }
+
+          # PR-review event payloads carry the exact head. Revoke its prior
+          # success before the first fallible API lookup; issue comments are not
+          # evidence and do not trigger this workflow.
+          if [[ -n "$event_head_sha" ]]; then
+            stamp_status_for_sha "$event_head_sha" "$REVIEW_GATE_CONTEXT" pending \
+              "Review state changed; evaluating regular Codex review"
+          fi
 
           read_pr_snapshot() {
             # shellcheck disable=SC2016 # GraphQL expands these variables, not the shell.
@@ -110,17 +129,17 @@ jobs:
             echo "Could not resolve the pull request state for PR #$pr_number."
             exit 1
           fi
+          if [[ -n "$event_head_sha" && "$event_head_sha" != "$head_sha" ]]; then
+            echo "The event head changed before evaluation; the newer PR event will re-evaluate it."
+            exit 0
+          fi
           head_prefix="$(printf '%.10s' "$head_sha")"
 
           stamp_status() {
             local context="$1"
             local state="$2"
             local description="$3"
-            gh api "repos/$REPO/statuses/$head_sha" --silent \
-              -f state="$state" \
-              -f context="$context" \
-              -f description="$description" \
-              -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
+            stamp_status_for_sha "$head_sha" "$context" "$state" "$description"
           }
 
           stamp_review_gate() {
@@ -168,38 +187,14 @@ jobs:
           }
 
           # This function deliberately returns regular-review evidence only.
-          # Security-review results and availability notices are never selected,
-          # counted, or used in any review-gate decision.
+          # It reads only submitted PR reviews, never issue comments; security
+          # review results and availability notices cannot qualify or block it.
           regular_evidence() {
-            local issue_records review_records
-            issue_records="$(
-              gh api "repos/$REPO/issues/$pr_number/comments?per_page=100" --paginate --slurp \
-                | jq -c --arg bot "$REVIEW_BOT" --arg head "$head_sha" --arg prefix "$head_prefix" '
-                    def regular_heading:
-                      ascii_downcase
-                      | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review(?:[[:space:]]*:|[[:space:]]|$)|^[[:space:]]*(?:#{1,6}[[:space:]]+)?review result(?:[[:space:]]*:|[[:space:]]|$)");
-                    def security_heading:
-                      ascii_downcase
-                      | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?security(?:[[:space:]-]+)review(?:[[:space:]]*:|[[:space:]]|$)");
-                    def exact_head:
-                      test("(?im)\\*{0,2}reviewed commit:\\*{0,2}[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60");
-                    def clean_result:
-                      ascii_downcase
-                      | test("didn.t find( any)?( major)? issues|did not find( any)?( major)? issues|no (major |blocking )?(issues|findings)( found)?|found no (major |blocking )?(issues|findings)");
-                    [.[][]
-                     | select((.user.login // "") == $bot)
-                     | (.body // "") as $body
-                     | select($body | regular_heading)
-                     | select(($body | security_heading) | not)
-                     | select($body | exact_head)
-                     | {at: (.updated_at // .created_at),
-                        kind: (if ($body | clean_result) then "clean" else "findings" end),
-                        source: "issue", id: (.id | tostring)}]'
-            )"
+            local review_records
             review_records="$(
               # shellcheck disable=SC2016 # GraphQL expands these variables, not the shell.
               gh api graphql --paginate \
-                -f query='query($owner: String!, $name: String!, $number: Int!, $endCursor: String) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { reviews(first: 100, after: $endCursor) { nodes { databaseId state submittedAt updatedAt body author { login } } pageInfo { hasNextPage endCursor } } } } }' \
+                -f query='query($owner: String!, $name: String!, $number: Int!, $endCursor: String) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { reviews(first: 100, after: $endCursor) { nodes { databaseId state submittedAt updatedAt body author { login } commit { oid } } pageInfo { hasNextPage endCursor } } } } }' \
                 -F owner="$review_owner" \
                 -F name="$review_repo" \
                 -F number="$pr_number" \
@@ -212,23 +207,26 @@ jobs:
                       | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?security(?:[[:space:]-]+)review(?:[[:space:]]*:|[[:space:]]|$)");
                     def exact_head:
                       test("(?im)\\*{0,2}reviewed commit:\\*{0,2}[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60");
-                    def clean_result:
-                      ascii_downcase
-                      | test("didn.t find( any)?( major)? issues|did not find( any)?( major)? issues|no (major |blocking )?(issues|findings)( found)?|found no (major |blocking )?(issues|findings)");
+                    # The connector stock review envelope has no body-only
+                    # findings. Textual "no major/blocking issues" claims are
+                    # intentionally not accepted as a clean verdict.
+                    def stock_clean_envelope:
+                      test("(?is)^[[:space:]]*#{1,6}[^\\r\\n]*codex[[:space:]]+review[[:space:]]*\\r?\\n[[:space:]]*\\r?\\n[[:space:]]*here are some automated review suggestions for this pull request\\.[[:space:]]*\\r?\\n[[:space:]]*\\r?\\n[[:space:]]*\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*\\r?\\n[[:space:]]*<details>");
                     [.[]
                      | .data.repository.pullRequest.reviews.nodes[]?
                      | select((.author.login // "") == $bot)
                      | select((.state // "") != "DISMISSED")
+                     | select((.commit.oid // "") == $head)
                      | (.body // "") as $body
                      | select($body | regular_heading)
                      | select(($body | security_heading) | not)
                      | select($body | exact_head)
+                     | select($body | stock_clean_envelope)
                      | {at: (.updatedAt // .submittedAt),
-                        kind: (if ($body | clean_result) then "clean" else "findings" end),
-                        source: "review", id: (.databaseId | tostring)}]'
+                        id: (.databaseId | tostring)}]'
             )"
-            jq -cn --argjson issues "$issue_records" --argjson reviews "$review_records" '
-              {verdict: (([$issues[], $reviews[]] | sort_by(.at) | last) // null),
+            jq -cn --argjson reviews "$review_records" '
+              {verdict: (($reviews | sort_by(.at) | last) // null),
                review_ids: [$reviews[].id]}'
           }
 
@@ -254,39 +252,36 @@ jobs:
                   | length'
           }
 
-          latest_finding_gate_at() {
-            gh api "repos/$REPO/commits/$head_sha/statuses?per_page=100" --paginate --slurp \
-              | jq -r --arg context "$REVIEW_GATE_CONTEXT" '
-                  [.[][]
-                   | select(.context == $context)
-                   | select(.state == "pending")
-                   | select((.description // "") | startswith("Codex reported findings on "))
-                   | .updated_at]
-                  | max // empty'
+          shared_open_head_count() {
+            # Commit statuses are keyed by SHA, not PR number. A shared open
+            # head is therefore fail-closed rather than borrowing another PR's
+            # clean status or review evidence.
+            gh api "repos/$REPO/pulls?state=open&per_page=100" --paginate \
+              | jq -rs --arg head "$head_sha" '
+                  [.[][] | select((.head.sha // "") == $head) | .number]
+                  | unique
+                  | length'
           }
 
           read_gate_snapshot() {
-            local evidence verdict review_ids finding_count finding_gate_at base_changed_at
+            local evidence verdict review_ids finding_count base_changed_at
             evidence="$(regular_evidence)"
             verdict="$(jq -c '.verdict' <<< "$evidence")"
             review_ids="$(jq -c '.review_ids' <<< "$evidence")"
             finding_count="$(active_regular_finding_count "$review_ids")"
-            finding_gate_at="$(latest_finding_gate_at)"
             base_changed_at="$(latest_base_change_at)"
             jq -cn \
               --argjson verdict "$verdict" \
               --argjson finding_count "$finding_count" \
-              --arg finding_gate_at "$finding_gate_at" \
               --arg base_changed_at "$base_changed_at" \
               '{verdict: $verdict,
                 finding_count: $finding_count,
-                finding_gate_at: $finding_gate_at,
                 base_changed_at: $base_changed_at}'
           }
 
           require_clean_regular_snapshot() {
             local gate_snapshot="$1"
-            local verdict verdict_at verdict_kind finding_count finding_gate_at base_changed_at
+            local verdict verdict_at finding_count base_changed_at
             verdict="$(jq -c '.verdict' <<< "$gate_snapshot")"
             if [[ "$verdict" == "null" ]]; then
               stamp_review_gate pending "Waiting for @codex review on $head_prefix"
@@ -294,19 +289,12 @@ jobs:
               exit 0
             fi
             verdict_at="$(jq -r '.at // empty' <<< "$verdict")"
-            verdict_kind="$(jq -r '.kind // empty' <<< "$verdict")"
             finding_count="$(jq -r '.finding_count' <<< "$gate_snapshot")"
-            finding_gate_at="$(jq -r '.finding_gate_at' <<< "$gate_snapshot")"
             base_changed_at="$(jq -r '.base_changed_at' <<< "$gate_snapshot")"
-            if [[ -z "$verdict_at" || "$verdict_kind" != "clean" || "$finding_count" -gt 0 ]]; then
+            if [[ -z "$verdict_at" || "$finding_count" -gt 0 ]]; then
               stamp_review_gate pending "Codex reported findings on $head_prefix"
               echo "Codex reported $finding_count active regular-review finding(s) on the exact head."
               echo "Fix them, push a new head, and tag @codex review again."
-              exit 0
-            fi
-            if [[ -n "$finding_gate_at" && ( "$finding_gate_at" == "$verdict_at" || "$finding_gate_at" > "$verdict_at" ) ]]; then
-              stamp_review_gate pending "Waiting for newer clean Codex review on $head_prefix"
-              echo "A prior regular finding requires a newer affirmative clean review."
               exit 0
             fi
             if [[ -n "$base_changed_at" && ( "$base_changed_at" == "$verdict_at" || "$base_changed_at" > "$verdict_at" ) ]]; then
@@ -328,14 +316,20 @@ jobs:
             stamp_review_gate pending "Waiting for pull request to leave draft"
             exit 0
           fi
+          shared_head_count="$(shared_open_head_count)"
+          if [[ "$shared_head_count" != "1" ]]; then
+            stamp_review_gate pending "Current head is shared by multiple open pull requests"
+            echo "Refusing to share regular-review evidence across $shared_head_count open PRs."
+            exit 0
+          fi
           if base_change_marker_exists; then
             stamp_review_gate pending "Base changed; push a new head before @codex review"
             echo "The base-change marker requires a fresh PR head and regular review."
             exit 0
           fi
 
-          # Clear any stale success before reads. Later review/comment events cancel
-          # this run and start a fresh evaluator rather than queue behind it.
+          # The event head was revoked before its first API read. Revoke the
+          # resolved head as well for manual dispatches and stale event payloads.
           stamp_review_gate pending "Evaluating regular Codex review on $head_prefix"
           gate_snapshot="$(read_gate_snapshot)"
           require_clean_regular_snapshot "$gate_snapshot"
@@ -389,6 +383,12 @@ jobs:
           if base_change_marker_exists; then
             stamp_review_gate pending "Base changed; push a new head before @codex review"
             echo "A base-change marker arrived during final revalidation."
+            exit 0
+          fi
+          final_shared_head_count="$(shared_open_head_count)"
+          if [[ "$final_shared_head_count" != "1" ]]; then
+            stamp_review_gate pending "Current head is shared by multiple open pull requests"
+            echo "A second open PR shares this head; the gate was not marked successful."
             exit 0
           fi
 

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -175,11 +175,11 @@ jobs:
 
           base_change_marker_exists() {
             gh api "repos/$REPO/commits/$head_sha/statuses?per_page=100" --paginate --slurp \
-              | jq -e --arg context "$REVIEW_BASE_CONTEXT" --arg description "$base_marker_description" '
+              | jq -e --arg context "$REVIEW_BASE_CONTEXT" --arg prefix "Base changed for PR #$pr_number at base " '
                   any(.[][];
                     (.context == $context)
                     and (.state == "pending")
-                    and ((.description // "") == $description))' \
+                    and ((.description // "") | startswith($prefix)))' \
               >/dev/null
           }
 

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -138,6 +138,9 @@ jobs:
               echo "Could not resolve a pull request node ID to disable automatic merge."
               exit 1
             fi
+            # Revoke any old green gate before a transient GraphQL/API failure
+            # can leave an already-armed PR eligible to merge automatically.
+            stamp_review_gate pending "Disarming automatic merge on $head_prefix"
             # shellcheck disable=SC2016 # GraphQL expands this variable, not the shell.
             gh api graphql \
               -f query='mutation($pullRequestId: ID!) { disablePullRequestAutoMerge(input: {pullRequestId: $pullRequestId}) { pullRequest { id } } }' \

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -205,8 +205,12 @@ jobs:
                   [.[][]
                    | select(.context == $context)
                    | select(.state == "pending")
-                   | select((.description // "") | startswith("Regular issue-comment invalidated;"))
-                   | .updated_at]
+                   | (.description // "") as $description
+                   | select($description | startswith("Regular issue-comment invalidated"))
+                   | if ($description | test("^Regular issue-comment invalidated at [0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z;"))
+                     then ($description | capture("^Regular issue-comment invalidated at (?<at>[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z);").at)
+                     else .updated_at
+                     end]
                   | max // empty'
           }
 

--- a/.github/workflows/review-regular-comment.yml
+++ b/.github/workflows/review-regular-comment.yml
@@ -13,6 +13,7 @@ concurrency:
 
 permissions:
   actions: write
+  contents: read
   issues: read
   pull-requests: read
   statuses: write
@@ -25,7 +26,6 @@ jobs:
       regular: ${{ steps.classify.outputs.regular }}
       clean: ${{ steps.classify.outputs.clean }}
       head_sha: ${{ steps.classify.outputs.head_sha }}
-      workflow_ref: ${{ steps.classify.outputs.workflow_ref }}
     runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
     steps:
       - id: classify
@@ -59,13 +59,39 @@ jobs:
             echo "The issue-comment event did not provide a pull request number."
             exit 1
           fi
+          if [[ "$EVENT_COMMENT_AUTHOR" != "$REVIEW_BOT_EVENT_LOGIN" ]]; then
+            echo "Ignoring a comment from another author."
+            exit 0
+          fi
+          body_could_be_regular_comment() {
+            local comment_body="$1"
+            printf '%s' "$comment_body" \
+              | jq -e -R -s '
+                  def regular_heading:
+                    ascii_downcase
+                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review(?:[[:space:]]*:|[[:space:]]|$)|^[[:space:]]*(?:#{1,6}[[:space:]]+)?review result(?:[[:space:]]*:|[[:space:]]|$)");
+                  def security_heading:
+                    ascii_downcase
+                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?security(?:[[:space:]-]+)review(?:[[:space:]]*:|[[:space:]]|$)");
+                  def availability_notice:
+                    ascii_downcase
+                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?(?:review|review[[:space:]]+result)(?:[[:space:]]*:|[[:space:]]|$)[[:space:]]*(?:you have reached[^\\r\\n]*(?:usage[[:space:]]+limits?|quota)|(?:codex[[:space:]]+)?(?:review[[:space:]]+)?(?:is[[:space:]]+)?(?:currently[[:space:]]+)?(?:unavailable|at[[:space:]]+capacity|rate[[:space:]-]*limited)|(?:could not|unable to)[[:space:]]+(?:start|complete|perform)[[:space:]]+(?:the[[:space:]]+)?(?:codex[[:space:]]+)?review|[^\\r\\n]*try again later)");
+                  select(regular_heading)
+                  | select(security_heading | not)
+                  | select(availability_notice | not)' >/dev/null
+          }
+          if ! body_could_be_regular_comment "$EVENT_COMMENT_BODY" \
+            && ! body_could_be_regular_comment "$EVENT_PREVIOUS_COMMENT_BODY"; then
+            echo "Ignoring a non-regular issue comment before the pull request lookup."
+            exit 0
+          fi
           pr_state="$(
             gh api "repos/$REPO/pulls/$PR_NUMBER" \
-              | jq -er '[.head.sha, .base.ref] | @tsv'
+              | jq -er '.head.sha'
           )"
-          IFS=$'\t' read -r head_sha workflow_ref <<< "$pr_state"
-          if [[ ! "$head_sha" =~ ^[0-9a-f]{40}$ || -z "$workflow_ref" ]]; then
-            echo "Could not resolve the current pull request head and trusted base ref."
+          head_sha="$pr_state"
+          if [[ ! "$head_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Could not resolve the current pull request head."
             exit 1
           fi
           head_prefix="${head_sha:0:10}"
@@ -118,10 +144,6 @@ jobs:
                   | select(stock_clean_issue_comment_envelope)' >/dev/null
           }
 
-          if [[ "$EVENT_COMMENT_AUTHOR" != "$REVIEW_BOT_EVENT_LOGIN" ]]; then
-            echo "Ignoring a comment from another author."
-            exit 0
-          fi
           if ! body_is_regular_comment "$EVENT_COMMENT_BODY" \
             && ! body_is_regular_comment "$EVENT_PREVIOUS_COMMENT_BODY"; then
             echo "Ignoring a non-regular issue comment."
@@ -130,7 +152,6 @@ jobs:
           {
             echo "regular=true"
             echo "head_sha=$head_sha"
-            echo "workflow_ref=$workflow_ref"
           } >> "$GITHUB_OUTPUT"
           if body_is_clean_comment "$EVENT_COMMENT_BODY"; then
             echo "clean=true" >> "$GITHUB_OUTPUT"
@@ -154,7 +175,7 @@ jobs:
           REPO: ${{ github.repository }}
           REVIEW_COMMENT_CONTEXT: review-gate-regular-comment
           REVIEW_GATE_CONTEXT: review-gate
-          WORKFLOW_REF: ${{ needs.classify.outputs.workflow_ref }}
+          WORKFLOW_REF: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
           export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"

--- a/.github/workflows/review-regular-comment.yml
+++ b/.github/workflows/review-regular-comment.yml
@@ -25,6 +25,7 @@ jobs:
       regular: ${{ steps.classify.outputs.regular }}
       clean: ${{ steps.classify.outputs.clean }}
       head_sha: ${{ steps.classify.outputs.head_sha }}
+      head_repository: ${{ steps.classify.outputs.head_repository }}
       workflow_ref: ${{ steps.classify.outputs.workflow_ref }}
     runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
     steps:
@@ -61,11 +62,11 @@ jobs:
           fi
           pr_state="$(
             gh api "repos/$REPO/pulls/$PR_NUMBER" \
-              | jq -er '[.head.sha, .base.ref] | @tsv'
+              | jq -er '[.head.sha, .head.ref, .head.repo.full_name] | @tsv'
           )"
-          IFS=$'\t' read -r head_sha workflow_ref <<< "$pr_state"
-          if [[ ! "$head_sha" =~ ^[0-9a-f]{40}$ || -z "$workflow_ref" ]]; then
-            echo "Could not resolve the current pull request head and base ref."
+          IFS=$'\t' read -r head_sha workflow_ref head_repository <<< "$pr_state"
+          if [[ ! "$head_sha" =~ ^[0-9a-f]{40}$ || -z "$workflow_ref" || -z "$head_repository" ]]; then
+            echo "Could not resolve the current pull request head and source ref."
             exit 1
           fi
           head_prefix="${head_sha:0:10}"
@@ -130,6 +131,7 @@ jobs:
           {
             echo "regular=true"
             echo "head_sha=$head_sha"
+            echo "head_repository=$head_repository"
             echo "workflow_ref=$workflow_ref"
           } >> "$GITHUB_OUTPUT"
           if body_is_clean_comment "$EVENT_COMMENT_BODY"; then
@@ -139,7 +141,9 @@ jobs:
   invalidate:
     name: invalidate-on-regular-comment
     needs: classify
-    if: needs.classify.outputs.regular == 'true'
+    if: >-
+      needs.classify.outputs.regular == 'true'
+      && needs.classify.outputs.head_repository == github.repository
     concurrency:
       group: review-gate-${{ github.event.issue.number }}
       cancel-in-progress: true

--- a/.github/workflows/review-regular-comment.yml
+++ b/.github/workflows/review-regular-comment.yml
@@ -4,9 +4,9 @@ on:
   issue_comment:
     types: [created, edited, deleted]
 
-# Isolate every comment event from the evaluator's lock. Security and unrelated
-# comments can never cancel a run that is disarming automatic merge or reading
-# regular-review evidence.
+# Classify every comment independently. Only a confirmed regular verdict enters
+# the evaluator's per-PR lock, so security and availability notices cannot
+# cancel or delay a normal review evaluation.
 concurrency:
   group: review-gate-comment-event-${{ github.event.comment.id }}
   cancel-in-progress: false
@@ -18,12 +18,18 @@ permissions:
   statuses: write
 
 jobs:
-  invalidate:
-    name: invalidate-on-regular-comment
+  classify:
+    name: classify-regular-comment
     if: github.event.issue.pull_request != null
+    outputs:
+      regular: ${{ steps.classify.outputs.regular }}
+      clean: ${{ steps.classify.outputs.clean }}
+      head_sha: ${{ steps.classify.outputs.head_sha }}
+      workflow_ref: ${{ steps.classify.outputs.workflow_ref }}
     runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
     steps:
-      - name: Dispatch only regular Codex issue-comment verdicts
+      - id: classify
+        name: Classify regular Codex issue-comment verdicts
         env:
           EVENT_COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
           EVENT_COMMENT_BODY: ${{ github.event.comment.body }}
@@ -45,13 +51,21 @@ jobs:
             echo "jq is required to classify issue comments."
             exit 1
           }
+          {
+            echo "regular=false"
+            echo "clean=false"
+          } >> "$GITHUB_OUTPUT"
           if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
             echo "The issue-comment event did not provide a pull request number."
             exit 1
           fi
-          head_sha="$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')"
-          if [[ ! "$head_sha" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "Could not resolve the current pull request head."
+          pr_state="$(
+            gh api "repos/$REPO/pulls/$PR_NUMBER" \
+              | jq -er '[.head.sha, .base.ref] | @tsv'
+          )"
+          IFS=$'\t' read -r head_sha workflow_ref <<< "$pr_state"
+          if [[ ! "$head_sha" =~ ^[0-9a-f]{40}$ || -z "$workflow_ref" ]]; then
+            echo "Could not resolve the current pull request head and base ref."
             exit 1
           fi
           head_prefix="${head_sha:0:10}"
@@ -92,15 +106,16 @@ jobs:
                     | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?(?:review|review[[:space:]]+result)(?:[[:space:]]*:|[[:space:]]|$)[[:space:]]*(?:you have reached[^\\r\\n]*(?:usage[[:space:]]+limits?|quota)|(?:codex[[:space:]]+)?(?:review[[:space:]]+)?(?:is[[:space:]]+)?(?:currently[[:space:]]+)?(?:unavailable|at[[:space:]]+capacity|rate[[:space:]-]*limited)|(?:could not|unable to)[[:space:]]+(?:start|complete|perform)[[:space:]]+(?:the[[:space:]]+)?(?:codex[[:space:]]+)?review|[^\\r\\n]*try again later)");
                   def exact_head:
                     test("(?im)\\*{0,2}reviewed commit:\\*{0,2}[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60");
-                  def stock_clean_envelope:
-                    test("(?is)^[[:space:]]*#{1,6}[^\\r\\n]*codex[[:space:]]+review[[:space:]]*\\r?\\n[[:space:]]*\\r?\\n[[:space:]]*here are some automated review suggestions for this pull request\\.[[:space:]]*\\r?\\n[[:space:]]*\\r?\\n[[:space:]]*\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*\\r?\\n[[:space:]]*<details>")
-                    or test("(?is)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review:[[:space:]]*didn.t find any major issues\\.[^\\r\\n]*(?:\\r?\\n[[:space:]]*)+\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*(?:\\r?\\n[[:space:]]*)+<details>[[:space:]]*<summary>[^\\r\\n]*codex[[:space:]]+in[[:space:]]+github")
+                  # A top-level issue comment has no review-thread metadata, so
+                  # only an explicit clean verdict can preserve the gate.
+                  def stock_clean_issue_comment_envelope:
+                    test("(?is)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review:[[:space:]]*didn.t find any major issues\\.[^\\r\\n]*(?:\\r?\\n[[:space:]]*)+\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*(?:\\r?\\n[[:space:]]*)+<details>[[:space:]]*<summary>[^\\r\\n]*codex[[:space:]]+in[[:space:]]+github")
                     or test("(?is)^[[:space:]]*#{1,6}[^\\r\\n]*(?:codex[[:space:]]+review|review result):[[:space:]]*(?:didn.t find any issues|no issues found)\\.[[:space:]]*(?:\\r?\\n[[:space:]]*)*\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*$");
                   select(regular_heading)
                   | select(security_heading | not)
                   | select(availability_notice | not)
                   | select(exact_head)
-                  | select(stock_clean_envelope)' >/dev/null
+                  | select(stock_clean_issue_comment_envelope)' >/dev/null
           }
 
           if [[ "$EVENT_COMMENT_AUTHOR" != "$REVIEW_BOT_EVENT_LOGIN" ]]; then
@@ -112,23 +127,55 @@ jobs:
             echo "Ignoring a non-regular issue comment."
             exit 0
           fi
+          {
+            echo "regular=true"
+            echo "head_sha=$head_sha"
+            echo "workflow_ref=$workflow_ref"
+          } >> "$GITHUB_OUTPUT"
+          if body_is_clean_comment "$EVENT_COMMENT_BODY"; then
+            echo "clean=true" >> "$GITHUB_OUTPUT"
+          fi
 
+  invalidate:
+    name: invalidate-on-regular-comment
+    needs: classify
+    if: needs.classify.outputs.regular == 'true'
+    concurrency:
+      group: review-gate-${{ github.event.issue.number }}
+      cancel-in-progress: true
+    runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
+    steps:
+      - name: Revoke the regular gate under its per-PR lock
+        env:
+          CLEAN: ${{ needs.classify.outputs.clean }}
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ needs.classify.outputs.head_sha }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          REVIEW_COMMENT_CONTEXT: review-gate-regular-comment
+          REVIEW_GATE_CONTEXT: review-gate
+          WORKFLOW_REF: ${{ needs.classify.outputs.workflow_ref }}
+        run: |
+          set -euo pipefail
+          export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ || ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ || -z "$WORKFLOW_REF" ]]; then
+            echo "The regular issue-comment event did not provide a dispatchable pull request state." >&2
+            exit 1
+          fi
           stamp_pending() {
             local context="$1"
             local description="$2"
-            gh api "repos/$REPO/statuses/$head_sha" --silent \
+            gh api "repos/$REPO/statuses/$HEAD_SHA" --silent \
               -f state=pending \
               -f context="$context" \
               -f description="$description" \
               -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
           }
-
-          # Revoke the gate first. If the marker or follow-up dispatch fails,
-          # the current head remains fail closed instead of retaining success.
           stamp_pending "$REVIEW_GATE_CONTEXT" "Regular issue-comment verdict; evaluating review"
-          if ! body_is_clean_comment "$EVENT_COMMENT_BODY"; then
+          if [[ "$CLEAN" != "true" ]]; then
             stamp_pending "$REVIEW_COMMENT_CONTEXT" \
               "Regular issue-comment invalidated; require a newer clean normal verdict"
           fi
-          gh workflow run review-gate.yml --repo "$REPO" -f pull_request="$PR_NUMBER"
+          gh workflow run review-gate.yml --repo "$REPO" --ref "$WORKFLOW_REF" \
+            -f pull_request="$PR_NUMBER"
           echo "Dispatched regular-comment evaluation for PR #$PR_NUMBER."

--- a/.github/workflows/review-regular-comment.yml
+++ b/.github/workflows/review-regular-comment.yml
@@ -1,0 +1,126 @@
+name: Invalidate Review Gate on Regular Comment
+
+on:
+  issue_comment:
+    types: [created, edited, deleted]
+
+# Isolate every comment event from the evaluator's lock. Security and unrelated
+# comments can never cancel a run that is disarming automatic merge or reading
+# regular-review evidence.
+concurrency:
+  group: review-gate-comment-event-${{ github.event.comment.id }}
+  cancel-in-progress: false
+
+permissions:
+  actions: write
+  issues: read
+  pull-requests: read
+  statuses: write
+
+jobs:
+  invalidate:
+    name: invalidate-on-regular-comment
+    if: github.event.issue.pull_request != null
+    runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
+    steps:
+      - name: Dispatch only regular Codex issue-comment verdicts
+        env:
+          EVENT_COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_COMMENT_BODY: ${{ github.event.comment.body }}
+          EVENT_PREVIOUS_COMMENT_BODY: ${{ github.event.changes.body.from }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          REVIEW_BOT_EVENT_LOGIN: chatgpt-codex-connector[bot]
+          REVIEW_COMMENT_CONTEXT: review-gate-regular-comment
+          REVIEW_GATE_CONTEXT: review-gate
+        run: |
+          set -euo pipefail
+          export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+          command -v gh >/dev/null 2>&1 || {
+            echo "GitHub CLI (gh) is required."
+            exit 1
+          }
+          command -v jq >/dev/null || {
+            echo "jq is required to classify issue comments."
+            exit 1
+          }
+          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+            echo "The issue-comment event did not provide a pull request number."
+            exit 1
+          fi
+          head_sha="$(gh api "repos/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')"
+          if [[ ! "$head_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Could not resolve the current pull request head."
+            exit 1
+          fi
+          head_prefix="${head_sha:0:10}"
+
+          body_is_regular_comment() {
+            local comment_body="$1"
+            printf '%s' "$comment_body" \
+              | jq -e -R -s --arg head "$head_sha" --arg prefix "$head_prefix" '
+                  def regular_heading:
+                    ascii_downcase
+                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review(?:[[:space:]]*:|[[:space:]]|$)|^[[:space:]]*(?:#{1,6}[[:space:]]+)?review result(?:[[:space:]]*:|[[:space:]]|$)");
+                  def security_heading:
+                    ascii_downcase
+                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?security(?:[[:space:]-]+)review(?:[[:space:]]*:|[[:space:]]|$)");
+                  def exact_head:
+                    test("(?im)\\*{0,2}reviewed commit:\\*{0,2}[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60");
+                  select(regular_heading)
+                  | select(security_heading | not)
+                  | select(exact_head)' >/dev/null
+          }
+
+          body_is_clean_comment() {
+            local comment_body="$1"
+            printf '%s' "$comment_body" \
+              | jq -e -R -s --arg head "$head_sha" --arg prefix "$head_prefix" '
+                  def regular_heading:
+                    ascii_downcase
+                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review(?:[[:space:]]*:|[[:space:]]|$)|^[[:space:]]*(?:#{1,6}[[:space:]]+)?review result(?:[[:space:]]*:|[[:space:]]|$)");
+                  def security_heading:
+                    ascii_downcase
+                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?security(?:[[:space:]-]+)review(?:[[:space:]]*:|[[:space:]]|$)");
+                  def exact_head:
+                    test("(?im)\\*{0,2}reviewed commit:\\*{0,2}[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60");
+                  def stock_clean_envelope:
+                    test("(?is)^[[:space:]]*#{1,6}[^\\r\\n]*codex[[:space:]]+review[[:space:]]*\\r?\\n[[:space:]]*\\r?\\n[[:space:]]*here are some automated review suggestions for this pull request\\.[[:space:]]*\\r?\\n[[:space:]]*\\r?\\n[[:space:]]*\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*\\r?\\n[[:space:]]*<details>")
+                    or test("(?is)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review:[[:space:]]*didn.t find any major issues\\.[^\\r\\n]*(?:\\r?\\n[[:space:]]*)+\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*(?:\\r?\\n[[:space:]]*)+<details>[[:space:]]*<summary>[^\\r\\n]*codex[[:space:]]+in[[:space:]]+github")
+                    or test("(?is)^[[:space:]]*#{1,6}[^\\r\\n]*(?:codex[[:space:]]+review|review result):[[:space:]]*(?:didn.t find any issues|no issues found)\\.[[:space:]]*(?:\\r?\\n[[:space:]]*)*\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*$");
+                  select(regular_heading)
+                  | select(security_heading | not)
+                  | select(exact_head)
+                  | select(stock_clean_envelope)' >/dev/null
+          }
+
+          if [[ "$EVENT_COMMENT_AUTHOR" != "$REVIEW_BOT_EVENT_LOGIN" ]]; then
+            echo "Ignoring a comment from another author."
+            exit 0
+          fi
+          if ! body_is_regular_comment "$EVENT_COMMENT_BODY" \
+            && ! body_is_regular_comment "$EVENT_PREVIOUS_COMMENT_BODY"; then
+            echo "Ignoring a non-regular issue comment."
+            exit 0
+          fi
+
+          stamp_pending() {
+            local context="$1"
+            local description="$2"
+            gh api "repos/$REPO/statuses/$head_sha" --silent \
+              -f state=pending \
+              -f context="$context" \
+              -f description="$description" \
+              -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
+          }
+
+          # Revoke the gate first. If the marker or follow-up dispatch fails,
+          # the current head remains fail closed instead of retaining success.
+          stamp_pending "$REVIEW_GATE_CONTEXT" "Regular issue-comment verdict; evaluating review"
+          if ! body_is_clean_comment "$EVENT_COMMENT_BODY"; then
+            stamp_pending "$REVIEW_COMMENT_CONTEXT" \
+              "Regular issue-comment invalidated; require a newer clean normal verdict"
+          fi
+          gh workflow run review-gate.yml --repo "$REPO" -f pull_request="$PR_NUMBER"
+          echo "Dispatched regular-comment evaluation for PR #$PR_NUMBER."

--- a/.github/workflows/review-regular-comment.yml
+++ b/.github/workflows/review-regular-comment.yml
@@ -166,6 +166,10 @@ jobs:
       - name: Revoke the regular gate under its per-PR lock
         env:
           CLEAN: ${{ needs.classify.outputs.clean }}
+          EVENT_ACTION: ${{ github.event.action }}
+          EVENT_COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          EVENT_COMMENT_BODY: ${{ github.event.comment.body }}
+          EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ needs.classify.outputs.head_sha }}
           PR_NUMBER: ${{ github.event.issue.number }}
@@ -176,9 +180,27 @@ jobs:
         run: |
           set -euo pipefail
           export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
-          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ || ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ || -z "$WORKFLOW_REF" ]]; then
+          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ || ! "$EVENT_COMMENT_ID" =~ ^[1-9][0-9]*$ || ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ || -z "$WORKFLOW_REF" ]]; then
             echo "The regular issue-comment event did not provide a dispatchable pull request state." >&2
             exit 1
+          fi
+          if [[ "$EVENT_ACTION" == "deleted" ]]; then
+            if gh api "repos/$REPO/issues/comments/$EVENT_COMMENT_ID" --silent >/dev/null 2>&1; then
+              echo "Ignoring a stale deleted-comment delivery for comment $EVENT_COMMENT_ID."
+              exit 0
+            fi
+          else
+            if ! current_comment="$(gh api "repos/$REPO/issues/comments/$EVENT_COMMENT_ID" 2>/dev/null)"; then
+              echo "Ignoring a stale comment delivery for missing comment $EVENT_COMMENT_ID."
+              exit 0
+            fi
+            current_comment_state="$(jq -er '[.user.login, ((.body // "") | @base64)] | @tsv' <<< "$current_comment")"
+            IFS=$'\t' read -r current_author current_body_b64 <<< "$current_comment_state"
+            event_body_b64="$(jq -rn --arg body "$EVENT_COMMENT_BODY" '$body | @base64')"
+            if [[ "$current_author" != "$EVENT_COMMENT_AUTHOR" || "$current_body_b64" != "$event_body_b64" ]]; then
+              echo "Ignoring a stale comment delivery superseded by a newer edit."
+              exit 0
+            fi
           fi
           stamp_pending() {
             local context="$1"

--- a/.github/workflows/review-regular-comment.yml
+++ b/.github/workflows/review-regular-comment.yml
@@ -170,6 +170,7 @@ jobs:
           EVENT_COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
           EVENT_COMMENT_BODY: ${{ github.event.comment.body }}
           EVENT_COMMENT_ID: ${{ github.event.comment.id }}
+          EVENT_COMMENT_UPDATED_AT: ${{ github.event.comment.updated_at }}
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ needs.classify.outputs.head_sha }}
           PR_NUMBER: ${{ github.event.issue.number }}
@@ -180,10 +181,11 @@ jobs:
         run: |
           set -euo pipefail
           export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
-          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ || ! "$EVENT_COMMENT_ID" =~ ^[1-9][0-9]*$ || ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ || -z "$WORKFLOW_REF" ]]; then
+          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ || ! "$EVENT_COMMENT_ID" =~ ^[1-9][0-9]*$ || ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ || -z "$WORKFLOW_REF" || -z "$EVENT_COMMENT_UPDATED_AT" ]]; then
             echo "The regular issue-comment event did not provide a dispatchable pull request state." >&2
             exit 1
           fi
+          current_comment_at="$EVENT_COMMENT_UPDATED_AT"
           if [[ "$EVENT_ACTION" == "deleted" ]]; then
             if gh api "repos/$REPO/issues/comments/$EVENT_COMMENT_ID" --silent >/dev/null 2>&1; then
               echo "Ignoring a stale deleted-comment delivery for comment $EVENT_COMMENT_ID."
@@ -196,11 +198,16 @@ jobs:
             fi
             current_comment_state="$(jq -er '[.user.login, ((.body // "") | @base64)] | @tsv' <<< "$current_comment")"
             IFS=$'\t' read -r current_author current_body_b64 <<< "$current_comment_state"
+            current_comment_at="$(jq -er '.updated_at // .created_at' <<< "$current_comment")"
             event_body_b64="$(jq -rn --arg body "$EVENT_COMMENT_BODY" '$body | @base64')"
             if [[ "$current_author" != "$EVENT_COMMENT_AUTHOR" || "$current_body_b64" != "$event_body_b64" ]]; then
               echo "Ignoring a stale comment delivery superseded by a newer edit."
               exit 0
             fi
+          fi
+          if [[ ! "$current_comment_at" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; then
+            echo "Could not resolve the current regular-comment timestamp." >&2
+            exit 1
           fi
           stamp_pending() {
             local context="$1"
@@ -214,7 +221,7 @@ jobs:
           stamp_pending "$REVIEW_GATE_CONTEXT" "Regular issue-comment verdict; evaluating review"
           if [[ "$CLEAN" != "true" ]]; then
             stamp_pending "$REVIEW_COMMENT_CONTEXT" \
-              "Regular issue-comment invalidated; require a newer clean normal verdict"
+              "Regular issue-comment invalidated at $current_comment_at; require a newer clean normal verdict"
           fi
           if ! gh api \
             "repos/$REPO/contents/.github/workflows/review-gate.yml?ref=$WORKFLOW_REF" \

--- a/.github/workflows/review-regular-comment.yml
+++ b/.github/workflows/review-regular-comment.yml
@@ -25,7 +25,6 @@ jobs:
       regular: ${{ steps.classify.outputs.regular }}
       clean: ${{ steps.classify.outputs.clean }}
       head_sha: ${{ steps.classify.outputs.head_sha }}
-      head_repository: ${{ steps.classify.outputs.head_repository }}
       workflow_ref: ${{ steps.classify.outputs.workflow_ref }}
     runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
     steps:
@@ -62,11 +61,11 @@ jobs:
           fi
           pr_state="$(
             gh api "repos/$REPO/pulls/$PR_NUMBER" \
-              | jq -er '[.head.sha, .head.ref, .head.repo.full_name] | @tsv'
+              | jq -er '[.head.sha, .base.ref] | @tsv'
           )"
-          IFS=$'\t' read -r head_sha workflow_ref head_repository <<< "$pr_state"
-          if [[ ! "$head_sha" =~ ^[0-9a-f]{40}$ || -z "$workflow_ref" || -z "$head_repository" ]]; then
-            echo "Could not resolve the current pull request head and source ref."
+          IFS=$'\t' read -r head_sha workflow_ref <<< "$pr_state"
+          if [[ ! "$head_sha" =~ ^[0-9a-f]{40}$ || -z "$workflow_ref" ]]; then
+            echo "Could not resolve the current pull request head and trusted base ref."
             exit 1
           fi
           head_prefix="${head_sha:0:10}"
@@ -131,7 +130,6 @@ jobs:
           {
             echo "regular=true"
             echo "head_sha=$head_sha"
-            echo "head_repository=$head_repository"
             echo "workflow_ref=$workflow_ref"
           } >> "$GITHUB_OUTPUT"
           if body_is_clean_comment "$EVENT_COMMENT_BODY"; then
@@ -141,9 +139,7 @@ jobs:
   invalidate:
     name: invalidate-on-regular-comment
     needs: classify
-    if: >-
-      needs.classify.outputs.regular == 'true'
-      && needs.classify.outputs.head_repository == github.repository
+    if: needs.classify.outputs.regular == 'true'
     concurrency:
       group: review-gate-${{ github.event.issue.number }}
       cancel-in-progress: true
@@ -179,6 +175,12 @@ jobs:
           if [[ "$CLEAN" != "true" ]]; then
             stamp_pending "$REVIEW_COMMENT_CONTEXT" \
               "Regular issue-comment invalidated; require a newer clean normal verdict"
+          fi
+          if ! gh api \
+            "repos/$REPO/contents/.github/workflows/review-gate.yml?ref=$WORKFLOW_REF" \
+            --silent >/dev/null 2>&1; then
+            echo "Trusted review-gate evaluator is not installed on $WORKFLOW_REF; leaving the required gate pending."
+            exit 0
           fi
           gh workflow run review-gate.yml --repo "$REPO" --ref "$WORKFLOW_REF" \
             -f pull_request="$PR_NUMBER"

--- a/.github/workflows/review-regular-comment.yml
+++ b/.github/workflows/review-regular-comment.yml
@@ -66,10 +66,14 @@ jobs:
                   def security_heading:
                     ascii_downcase
                     | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?security(?:[[:space:]-]+)review(?:[[:space:]]*:|[[:space:]]|$)");
+                  def availability_notice:
+                    ascii_downcase
+                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?(?:review|review[[:space:]]+result)(?:[[:space:]]*:|[[:space:]]|$)[[:space:]]*(?:you have reached[^\\r\\n]*(?:usage[[:space:]]+limits?|quota)|(?:codex[[:space:]]+)?(?:review[[:space:]]+)?(?:is[[:space:]]+)?(?:currently[[:space:]]+)?(?:unavailable|at[[:space:]]+capacity|rate[[:space:]-]*limited)|(?:could not|unable to)[[:space:]]+(?:start|complete|perform)[[:space:]]+(?:the[[:space:]]+)?(?:codex[[:space:]]+)?review|[^\\r\\n]*try again later)");
                   def exact_head:
                     test("(?im)\\*{0,2}reviewed commit:\\*{0,2}[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60");
                   select(regular_heading)
                   | select(security_heading | not)
+                  | select(availability_notice | not)
                   | select(exact_head)' >/dev/null
           }
 
@@ -83,6 +87,9 @@ jobs:
                   def security_heading:
                     ascii_downcase
                     | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?security(?:[[:space:]-]+)review(?:[[:space:]]*:|[[:space:]]|$)");
+                  def availability_notice:
+                    ascii_downcase
+                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?(?:review|review[[:space:]]+result)(?:[[:space:]]*:|[[:space:]]|$)[[:space:]]*(?:you have reached[^\\r\\n]*(?:usage[[:space:]]+limits?|quota)|(?:codex[[:space:]]+)?(?:review[[:space:]]+)?(?:is[[:space:]]+)?(?:currently[[:space:]]+)?(?:unavailable|at[[:space:]]+capacity|rate[[:space:]-]*limited)|(?:could not|unable to)[[:space:]]+(?:start|complete|perform)[[:space:]]+(?:the[[:space:]]+)?(?:codex[[:space:]]+)?review|[^\\r\\n]*try again later)");
                   def exact_head:
                     test("(?im)\\*{0,2}reviewed commit:\\*{0,2}[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60");
                   def stock_clean_envelope:
@@ -91,6 +98,7 @@ jobs:
                     or test("(?is)^[[:space:]]*#{1,6}[^\\r\\n]*(?:codex[[:space:]]+review|review result):[[:space:]]*(?:didn.t find any issues|no issues found)\\.[[:space:]]*(?:\\r?\\n[[:space:]]*)*\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*$");
                   select(regular_heading)
                   | select(security_heading | not)
+                  | select(availability_notice | not)
                   | select(exact_head)
                   | select(stock_clean_envelope)' >/dev/null
           }

--- a/.github/workflows/review-regular-comment.yml
+++ b/.github/workflows/review-regular-comment.yml
@@ -4,12 +4,9 @@ on:
   issue_comment:
     types: [created, edited, deleted]
 
-# Classify every comment independently. Only a confirmed regular verdict enters
-# the evaluator's per-PR lock, so security and availability notices cannot
-# cancel or delay a normal review evaluation.
-concurrency:
-  group: review-gate-comment-event-${{ github.event.comment.id }}
-  cancel-in-progress: false
+# Run every comment delivery independently so rapid edits cannot replace a
+# queued state transition. Only a confirmed regular verdict enters the
+# evaluator's per-PR lock below.
 
 permissions:
   actions: write

--- a/.github/workflows/review-regular-review.yml
+++ b/.github/workflows/review-regular-review.yml
@@ -103,11 +103,25 @@ jobs:
             echo "review_invalidated=true" >> "$GITHUB_OUTPUT"
           fi
 
+  fork_signal:
+    name: fork-regular-review-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}-${{ github.event.review.id }}-${{ needs.route.outputs.review_invalidated }}
+    needs: route
+    if: >-
+      needs.route.outputs.regular == 'true'
+      && github.event.pull_request.head.repo.full_name != github.repository
+    # Fork review workflows receive read-only tokens. This job executes no PR
+    # code and carries only a strictly parsed handoff to the trusted follow-up.
+    permissions: {}
+    runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
+    steps:
+      - name: Record a trusted fork-review handoff
+        run: ':'
+
   invalidate:
     name: invalidate-regular-review
     needs: route
     # GitHub downgrades pull_request_review tokens for forks to read-only.
-    # The trusted scheduled audit reconciles those fork verdicts instead.
+    # fork_signal hands those regular events to a default-branch workflow_run.
     if: >-
       needs.route.outputs.regular == 'true'
       && github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/review-regular-review.yml
+++ b/.github/workflows/review-regular-review.yml
@@ -105,9 +105,7 @@ jobs:
   invalidate:
     name: invalidate-regular-review
     needs: route
-    if: >-
-      needs.route.outputs.regular == 'true'
-      && github.event.pull_request.head.repo.full_name == github.repository
+    if: needs.route.outputs.regular == 'true'
     concurrency:
       group: review-gate-${{ github.event.pull_request.number }}
       cancel-in-progress: true
@@ -122,10 +120,7 @@ jobs:
           REVIEW_GATE_CONTEXT: review-gate
           REVIEW_INVALIDATED: ${{ needs.route.outputs.review_invalidated }}
           REVIEW_REVIEW_CONTEXT: review-gate-regular-review
-          # The evaluator is introduced by this PR, so dispatch its verified
-          # same-repository head rather than a base branch that may not yet
-          # contain a workflow_dispatch trigger.
-          WORKFLOW_REF: ${{ github.event.pull_request.head.ref }}
+          WORKFLOW_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           set -euo pipefail
           export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
@@ -147,6 +142,12 @@ jobs:
           if [[ "$REVIEW_INVALIDATED" == "true" ]]; then
             stamp_pending "$REVIEW_REVIEW_CONTEXT" \
               "Regular review invalidated; require a newer normal review"
+          fi
+          if ! gh api \
+            "repos/$REPO/contents/.github/workflows/review-gate.yml?ref=$WORKFLOW_REF" \
+            --silent >/dev/null 2>&1; then
+            echo "Trusted review-gate evaluator is not installed on $WORKFLOW_REF; leaving the required gate pending."
+            exit 0
           fi
           gh workflow run review-gate.yml --repo "$REPO" --ref "$WORKFLOW_REF" \
             -f pull_request="$PR_NUMBER"

--- a/.github/workflows/review-regular-review.yml
+++ b/.github/workflows/review-regular-review.yml
@@ -1,0 +1,104 @@
+name: Route Regular Codex Review Events
+
+on:
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+
+# Each review has its own lightweight router. A security or unrelated review
+# therefore cannot cancel the evaluator responsible for the regular gate.
+concurrency:
+  group: review-gate-review-event-${{ github.event.review.id }}
+  cancel-in-progress: false
+
+permissions:
+  actions: write
+  statuses: write
+
+jobs:
+  route:
+    name: route-regular-review
+    if: github.event.pull_request.number != null
+    runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
+    steps:
+      - name: Dispatch only regular Codex review events
+        env:
+          EVENT_ACTION: ${{ github.event.action }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_REVIEW_AUTHOR: ${{ github.event.review.user.login }}
+          EVENT_REVIEW_BODY: ${{ github.event.review.body }}
+          EVENT_PREVIOUS_REVIEW_BODY: ${{ github.event.changes.body.from }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          REVIEW_BOT_EVENT_LOGIN: chatgpt-codex-connector[bot]
+          REVIEW_GATE_CONTEXT: review-gate
+          REVIEW_REVIEW_CONTEXT: review-gate-regular-review
+        run: |
+          set -euo pipefail
+          export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+          command -v gh >/dev/null 2>&1 || {
+            echo "GitHub CLI (gh) is required."
+            exit 1
+          }
+          command -v jq >/dev/null || {
+            echo "jq is required to classify review events."
+            exit 1
+          }
+          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ || ! "$EVENT_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "The review event did not provide a valid pull request state."
+            exit 1
+          fi
+
+          body_is_regular_review() {
+            local review_body="$1"
+            printf '%s' "$review_body" \
+              | jq -e -R -s '
+                  def regular_heading:
+                    ascii_downcase
+                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review(?:[[:space:]]*:|[[:space:]]|$)|^[[:space:]]*(?:#{1,6}[[:space:]]+)?review result(?:[[:space:]]*:|[[:space:]]|$)");
+                  def security_heading:
+                    ascii_downcase
+                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?security(?:[[:space:]-]+)review(?:[[:space:]]*:|[[:space:]]|$)");
+                  select(regular_heading)
+                  | select(security_heading | not)' >/dev/null
+          }
+
+          if [[ "$EVENT_REVIEW_AUTHOR" != "$REVIEW_BOT_EVENT_LOGIN" ]]; then
+            echo "Ignoring a review from another author."
+            exit 0
+          fi
+          current_is_regular=false
+          previous_is_regular=false
+          if body_is_regular_review "$EVENT_REVIEW_BODY"; then
+            current_is_regular=true
+          fi
+          if body_is_regular_review "$EVENT_PREVIOUS_REVIEW_BODY"; then
+            previous_is_regular=true
+          fi
+          if [[ "$current_is_regular" != "true" && "$previous_is_regular" != "true" ]]; then
+            echo "Ignoring a non-regular pull request review."
+            exit 0
+          fi
+
+          stamp_pending() {
+            local context="$1"
+            local description="$2"
+            gh api "repos/$REPO/statuses/$EVENT_HEAD_SHA" --silent \
+              -f state=pending \
+              -f context="$context" \
+              -f description="$description" \
+              -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
+          }
+
+          # Security-only reviews never reach this point. A normal review that
+          # is dismissed or reclassified is itself a normal-gate invalidation,
+          # not a security-review blocker; a newer normal verdict is required.
+          stamp_pending "$REVIEW_GATE_CONTEXT" \
+            "Review state changed; evaluating regular Codex review"
+          if [[ "$EVENT_ACTION" == "dismissed" \
+            || ( "$previous_is_regular" == "true" && "$current_is_regular" != "true" ) ]]; then
+            stamp_pending "$REVIEW_REVIEW_CONTEXT" \
+              "Regular review invalidated; require a newer normal review"
+          fi
+          gh workflow run review-gate.yml --repo "$REPO" -f pull_request="$PR_NUMBER"
+          echo "Dispatched regular-review evaluation for PR #$PR_NUMBER."

--- a/.github/workflows/review-regular-review.yml
+++ b/.github/workflows/review-regular-review.yml
@@ -105,7 +105,9 @@ jobs:
   invalidate:
     name: invalidate-regular-review
     needs: route
-    if: needs.route.outputs.regular == 'true'
+    if: >-
+      needs.route.outputs.regular == 'true'
+      && github.event.pull_request.head.repo.full_name == github.repository
     concurrency:
       group: review-gate-${{ github.event.pull_request.number }}
       cancel-in-progress: true
@@ -120,7 +122,10 @@ jobs:
           REVIEW_GATE_CONTEXT: review-gate
           REVIEW_INVALIDATED: ${{ needs.route.outputs.review_invalidated }}
           REVIEW_REVIEW_CONTEXT: review-gate-regular-review
-          WORKFLOW_REF: ${{ github.event.pull_request.base.ref }}
+          # The evaluator is introduced by this PR, so dispatch its verified
+          # same-repository head rather than a base branch that may not yet
+          # contain a workflow_dispatch trigger.
+          WORKFLOW_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           set -euo pipefail
           export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"

--- a/.github/workflows/review-regular-review.yml
+++ b/.github/workflows/review-regular-review.yml
@@ -24,6 +24,7 @@ jobs:
         env:
           EVENT_ACTION: ${{ github.event.action }}
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_REVIEW_COMMIT_SHA: ${{ github.event.review.commit_id }}
           EVENT_REVIEW_AUTHOR: ${{ github.event.review.user.login }}
           EVENT_REVIEW_BODY: ${{ github.event.review.body }}
           EVENT_PREVIOUS_REVIEW_BODY: ${{ github.event.changes.body.from }}
@@ -44,7 +45,7 @@ jobs:
             echo "jq is required to classify review events."
             exit 1
           }
-          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ || ! "$EVENT_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ || ! "$EVENT_HEAD_SHA" =~ ^[0-9a-f]{40}$ || ! "$EVENT_REVIEW_COMMIT_SHA" =~ ^[0-9a-f]{40}$ ]]; then
             echo "The review event did not provide a valid pull request state."
             exit 1
           fi
@@ -59,12 +60,20 @@ jobs:
                   def security_heading:
                     ascii_downcase
                     | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?security(?:[[:space:]-]+)review(?:[[:space:]]*:|[[:space:]]|$)");
+                  def availability_notice:
+                    ascii_downcase
+                    | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?(?:review|review[[:space:]]+result)(?:[[:space:]]*:|[[:space:]]|$)[[:space:]]*(?:you have reached[^\\r\\n]*(?:usage[[:space:]]+limits?|quota)|(?:codex[[:space:]]+)?(?:review[[:space:]]+)?(?:is[[:space:]]+)?(?:currently[[:space:]]+)?(?:unavailable|at[[:space:]]+capacity|rate[[:space:]-]*limited)|(?:could not|unable to)[[:space:]]+(?:start|complete|perform)[[:space:]]+(?:the[[:space:]]+)?(?:codex[[:space:]]+)?review|[^\\r\\n]*try again later)");
                   select(regular_heading)
-                  | select(security_heading | not)' >/dev/null
+                  | select(security_heading | not)
+                  | select(availability_notice | not)' >/dev/null
           }
 
           if [[ "$EVENT_REVIEW_AUTHOR" != "$REVIEW_BOT_EVENT_LOGIN" ]]; then
             echo "Ignoring a review from another author."
+            exit 0
+          fi
+          if [[ "$EVENT_REVIEW_COMMIT_SHA" != "$EVENT_HEAD_SHA" ]]; then
+            echo "Ignoring a review attached to an older pull request head."
             exit 0
           fi
           current_is_regular=false

--- a/.github/workflows/review-regular-review.yml
+++ b/.github/workflows/review-regular-review.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   actions: write
   contents: read
+  pull-requests: read
   statuses: write
 
 jobs:
@@ -130,20 +131,40 @@ jobs:
     steps:
       - name: Revoke the regular gate under its per-PR lock
         env:
+          EVENT_ACTION: ${{ github.event.action }}
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_REVIEW_AUTHOR: ${{ github.event.review.user.login }}
+          EVENT_REVIEW_BODY: ${{ github.event.review.body }}
+          EVENT_REVIEW_COMMIT_SHA: ${{ github.event.review.commit_id }}
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
           REVIEW_GATE_CONTEXT: review-gate
           REVIEW_INVALIDATED: ${{ needs.route.outputs.review_invalidated }}
+          REVIEW_ID: ${{ github.event.review.id }}
           REVIEW_REVIEW_CONTEXT: review-gate-regular-review
           WORKFLOW_REF: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
           export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
-          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ || ! "$EVENT_HEAD_SHA" =~ ^[0-9a-f]{40}$ || -z "$WORKFLOW_REF" ]]; then
+          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ || ! "$REVIEW_ID" =~ ^[1-9][0-9]*$ || ! "$EVENT_HEAD_SHA" =~ ^[0-9a-f]{40}$ || ! "$EVENT_REVIEW_COMMIT_SHA" =~ ^[0-9a-f]{40}$ || -z "$WORKFLOW_REF" ]]; then
             echo "The regular-review event did not provide a dispatchable pull request state." >&2
             exit 1
+          fi
+          if ! current_review="$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" 2>/dev/null)"; then
+            echo "Ignoring a stale delivery for missing review $REVIEW_ID."
+            exit 0
+          fi
+          current_review_state="$(jq -er '[.user.login, .commit_id, .state, ((.body // "") | @base64)] | @tsv' <<< "$current_review")"
+          IFS=$'\t' read -r current_author current_commit current_state current_body_b64 <<< "$current_review_state"
+          event_body_b64="$(jq -rn --arg body "$EVENT_REVIEW_BODY" '$body | @base64')"
+          if [[ "$current_author" != "$EVENT_REVIEW_AUTHOR" \
+            || "$current_commit" != "$EVENT_REVIEW_COMMIT_SHA" \
+            || "$current_body_b64" != "$event_body_b64" \
+            || ( "$EVENT_ACTION" == "dismissed" && "$current_state" != "DISMISSED" ) \
+            || ( "$EVENT_ACTION" != "dismissed" && "$current_state" == "DISMISSED" ) ]]; then
+            echo "Ignoring a stale review delivery superseded by newer review state."
+            exit 0
           fi
           stamp_pending() {
             local context="$1"

--- a/.github/workflows/review-regular-review.yml
+++ b/.github/workflows/review-regular-review.yml
@@ -18,9 +18,13 @@ jobs:
   route:
     name: route-regular-review
     if: github.event.pull_request.number != null
+    outputs:
+      regular: ${{ steps.classify.outputs.regular }}
+      review_invalidated: ${{ steps.classify.outputs.review_invalidated }}
     runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
     steps:
-      - name: Dispatch only regular Codex review events
+      - id: classify
+        name: Classify regular Codex review events
         env:
           EVENT_ACTION: ${{ github.event.action }}
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -45,6 +49,10 @@ jobs:
             echo "jq is required to classify review events."
             exit 1
           }
+          {
+            echo "regular=false"
+            echo "review_invalidated=false"
+          } >> "$GITHUB_OUTPUT"
           if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ || ! "$EVENT_HEAD_SHA" =~ ^[0-9a-f]{40}$ || ! "$EVENT_REVIEW_COMMIT_SHA" =~ ^[0-9a-f]{40}$ ]]; then
             echo "The review event did not provide a valid pull request state."
             exit 1
@@ -88,7 +96,38 @@ jobs:
             echo "Ignoring a non-regular pull request review."
             exit 0
           fi
+          echo "regular=true" >> "$GITHUB_OUTPUT"
+          if [[ "$EVENT_ACTION" == "dismissed" \
+            || ( "$previous_is_regular" == "true" && "$current_is_regular" != "true" ) ]]; then
+            echo "review_invalidated=true" >> "$GITHUB_OUTPUT"
+          fi
 
+  invalidate:
+    name: invalidate-regular-review
+    needs: route
+    if: needs.route.outputs.regular == 'true'
+    concurrency:
+      group: review-gate-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
+    steps:
+      - name: Revoke the regular gate under its per-PR lock
+        env:
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          REVIEW_GATE_CONTEXT: review-gate
+          REVIEW_INVALIDATED: ${{ needs.route.outputs.review_invalidated }}
+          REVIEW_REVIEW_CONTEXT: review-gate-regular-review
+          WORKFLOW_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+          export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ || ! "$EVENT_HEAD_SHA" =~ ^[0-9a-f]{40}$ || -z "$WORKFLOW_REF" ]]; then
+            echo "The regular-review event did not provide a dispatchable pull request state." >&2
+            exit 1
+          fi
           stamp_pending() {
             local context="$1"
             local description="$2"
@@ -98,16 +137,12 @@ jobs:
               -f description="$description" \
               -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
           }
-
-          # Security-only reviews never reach this point. A normal review that
-          # is dismissed or reclassified is itself a normal-gate invalidation,
-          # not a security-review blocker; a newer normal verdict is required.
           stamp_pending "$REVIEW_GATE_CONTEXT" \
             "Review state changed; evaluating regular Codex review"
-          if [[ "$EVENT_ACTION" == "dismissed" \
-            || ( "$previous_is_regular" == "true" && "$current_is_regular" != "true" ) ]]; then
+          if [[ "$REVIEW_INVALIDATED" == "true" ]]; then
             stamp_pending "$REVIEW_REVIEW_CONTEXT" \
               "Regular review invalidated; require a newer normal review"
           fi
-          gh workflow run review-gate.yml --repo "$REPO" -f pull_request="$PR_NUMBER"
+          gh workflow run review-gate.yml --repo "$REPO" --ref "$WORKFLOW_REF" \
+            -f pull_request="$PR_NUMBER"
           echo "Dispatched regular-review evaluation for PR #$PR_NUMBER."

--- a/.github/workflows/review-regular-review.yml
+++ b/.github/workflows/review-regular-review.yml
@@ -4,11 +4,9 @@ on:
   pull_request_review:
     types: [submitted, edited, dismissed]
 
-# Each review has its own lightweight router. A security or unrelated review
-# therefore cannot cancel the evaluator responsible for the regular gate.
-concurrency:
-  group: review-gate-review-event-${{ github.event.review.id }}
-  cancel-in-progress: false
+# Run every review delivery independently so rapid edits cannot replace a
+# queued state transition. Only a confirmed regular review enters the
+# evaluator's per-PR lock below.
 
 permissions:
   actions: write

--- a/.github/workflows/review-regular-review.yml
+++ b/.github/workflows/review-regular-review.yml
@@ -12,6 +12,7 @@ concurrency:
 
 permissions:
   actions: write
+  contents: read
   statuses: write
 
 jobs:
@@ -105,7 +106,11 @@ jobs:
   invalidate:
     name: invalidate-regular-review
     needs: route
-    if: needs.route.outputs.regular == 'true'
+    # GitHub downgrades pull_request_review tokens for forks to read-only.
+    # The trusted scheduled audit reconciles those fork verdicts instead.
+    if: >-
+      needs.route.outputs.regular == 'true'
+      && github.event.pull_request.head.repo.full_name == github.repository
     concurrency:
       group: review-gate-${{ github.event.pull_request.number }}
       cancel-in-progress: true
@@ -120,7 +125,7 @@ jobs:
           REVIEW_GATE_CONTEXT: review-gate
           REVIEW_INVALIDATED: ${{ needs.route.outputs.review_invalidated }}
           REVIEW_REVIEW_CONTEXT: review-gate-regular-review
-          WORKFLOW_REF: ${{ github.event.pull_request.base.ref }}
+          WORKFLOW_REF: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
           export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -72,11 +72,12 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
 
     assert "cancel-in-progress: true" in review_gate
     assert "group: review-gate-" in review_gate
-    assert "types: [opened, reopened, synchronize, ready_for_review]" in review_gate
     assert (
         "types: [opened, reopened, synchronize, ready_for_review, auto_merge_enabled]"
-        not in review_gate
+        in review_gate
     )
+    assert "baseRefName" in review_gate
+    assert "Retarget to the repository default branch before review" in review_gate
     assert "pull_request_review:" not in review_gate
     assert "issue_comment:" not in review_gate
     assert "REVIEW_BASE_CONTEXT: review-gate-base-change" in review_gate
@@ -238,7 +239,8 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "--auto" not in base_change
     assert "pulls?state=open" in base_advance
     assert "BASE_PUSHED_AT" in base_advance
-    assert "commits/$event_head_sha/statuses" in base_advance
+    assert "commits/$event_head_sha/statuses" not in base_advance
+    assert ".created_at | fromdateiso8601" in base_advance
     assert "created_at | fromdateiso8601" in base_advance
     assert "mktemp" in base_advance
     assert "event_head_sha" in base_advance
@@ -283,6 +285,7 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "evidence_marker" in audit
     assert "is_reconciliation_pending" in audit
     assert "Reconcile every head through the trusted default-branch workflow" in audit
+    assert "didn.t find any major issues" in audit
     assert "issue_comment:" not in audit
     assert "pulls?state=open" in rollout
     assert "allow_auto_merge" in rollout

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -81,6 +81,8 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "stock_clean_envelope" in review_gate
     assert "didn.t find any major issues" in review_gate
     assert "codex[[:space:]]+in[[:space:]]+github" in review_gate
+    assert "def availability_notice:" in review_gate
+    assert "availability_notice) | not" in review_gate
     assert 'source == "issue_comment"' in review_gate
     assert "total_count" in review_gate
     assert "latest_regular_issue_comment_at" in review_gate
@@ -101,6 +103,10 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "body_is_regular_review" in regular_review
     assert "def security_heading:" in regular_review
     assert "security_heading | not" in regular_review
+    assert "EVENT_REVIEW_COMMIT_SHA" in regular_review
+    assert "def availability_notice:" in regular_review
+    assert "availability_notice | not" in regular_review
+    assert "Ignoring a review attached to an older pull request head" in regular_review
     assert "REVIEW_REVIEW_CONTEXT: review-gate-regular-review" in regular_review
     assert "Regular review invalidated; require a newer normal review" in regular_review
     assert "gh workflow run review-gate.yml" in regular_review
@@ -115,6 +121,8 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "body_is_clean_comment" in regular_comment
     assert "def security_heading:" in regular_comment
     assert "security_heading | not" in regular_comment
+    assert "def availability_notice:" in regular_comment
+    assert "availability_notice | not" in regular_comment
     assert "REVIEW_COMMENT_CONTEXT: review-gate-regular-comment" in regular_comment
     assert "gh workflow run review-gate.yml" in regular_comment
     assert "gh pr merge" not in regular_review + regular_comment
@@ -134,6 +142,9 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "gh pr merge" not in base_change
     assert "--auto" not in base_change
     assert "pulls?state=open" in base_advance
+    assert "event_head_sha" in base_advance
+    assert "EVENT_HEAD_SHA" in base_advance
+    assert "gained a new head after the base advance" in base_advance
     assert "group: review-gate-base-advance-" in base_advance
     assert "cancel-in-progress: true" in base_advance
     assert "review-gate-base-change" in base_advance
@@ -145,12 +156,15 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "*/5 * * * *" in audit
     assert "matrix.pr_number" in audit
     assert "actions: write" in audit
+    assert "statuses: read" in audit
     assert "group: review-gate-audit-${{ matrix.pr_number }}" in audit
     assert "reviewThreads" in audit
     assert "review result" in audit
     assert "gh workflow run review-gate.yml" in audit
     assert "def security_heading:" in audit
     assert "security_heading) | not" in audit
+    assert "def availability_notice:" in audit
+    assert "availability_notice) | not" in audit
     assert "issue_comment:" not in audit
     assert "pulls?state=open" in rollout
     assert "actions: write" in rollout

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -116,15 +116,11 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "REVIEW_REVIEW_CONTEXT: review-gate-regular-review" in regular_review
     assert "Regular review invalidated; require a newer normal review" in regular_review
     assert "needs: route" in regular_review
-    assert "needs.route.outputs.regular == 'true'" in regular_review
+    assert "if: needs.route.outputs.regular == 'true'" in regular_review
+    assert "WORKFLOW_REF: ${{ github.event.pull_request.base.ref }}" in regular_review
+    assert "Trusted review-gate evaluator is not installed" in regular_review
     assert (
-        "github.event.pull_request.head.repo.full_name == github.repository"
-        in regular_review
-    )
-    assert "WORKFLOW_REF: ${{ github.event.pull_request.head.ref }}" in regular_review
-    assert (
-        "group: review-gate-${{ github.event.pull_request.number }}"
-        in regular_review
+        "group: review-gate-${{ github.event.pull_request.number }}" in regular_review
     )
     assert '--ref "$WORKFLOW_REF"' in regular_review
     assert "gh workflow run review-gate.yml" in regular_review
@@ -144,24 +140,17 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "REVIEW_COMMENT_CONTEXT: review-gate-regular-comment" in regular_comment
     assert "name: classify-regular-comment" in regular_comment
     assert "needs: classify" in regular_comment
-    assert "needs.classify.outputs.regular == 'true'" in regular_comment
-    assert (
-        "needs.classify.outputs.head_repository == github.repository"
-        in regular_comment
-    )
-    assert "[.head.sha, .head.ref, .head.repo.full_name]" in regular_comment
+    assert "if: needs.classify.outputs.regular == 'true'" in regular_comment
+    assert "[.head.sha, .base.ref]" in regular_comment
     assert "group: review-gate-${{ github.event.issue.number }}" in regular_comment
     assert "stock_clean_issue_comment_envelope" in regular_comment
     assert '--ref "$WORKFLOW_REF"' in regular_comment
     assert "gh workflow run review-gate.yml" in regular_comment
+    assert "Trusted review-gate evaluator is not installed" in regular_comment
     assert "gh pr merge" not in regular_review + regular_comment
     assert "--auto" not in regular_review + regular_comment
     assert "github.event.changes.base != null" in base_change
-    assert (
-        "github.event.pull_request.head.repo.full_name == github.repository"
-        in base_change
-    )
-    assert "WORKFLOW_REF: ${{ github.event.pull_request.head.ref }}" in base_change
+    assert "WORKFLOW_REF: ${{ github.event.pull_request.base.ref }}" in base_change
     assert "EVENT_BASE_SHA" in base_change
     assert "REVIEW_GATE_CONTEXT: review-gate" in base_change
     assert "review-gate-base-change" in base_change
@@ -174,6 +163,7 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "cancel_active_gate_runs" in base_change
     assert "gh workflow run review-gate.yml" in base_change
     assert '--ref "$WORKFLOW_REF"' in base_change
+    assert "Trusted review-gate evaluator is not installed" in base_change
     assert "gh pr merge" not in base_change
     assert "--auto" not in base_change
     assert "pulls?state=open" in base_advance
@@ -184,7 +174,6 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "mktemp" in base_advance
     assert "event_head_sha" in base_advance
     assert "EVENT_HEAD_SHA" in base_advance
-    assert "select(.head.repo.full_name == $repo)" in base_advance
     assert "gained a new head after the base advance" in base_advance
     assert "group: review-gate-base-advance-" in base_advance
     assert "cancel-in-progress: true" in base_advance
@@ -193,18 +182,19 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "((.auto_merge != null) | tostring)" in base_advance
     assert "cancel_active_gate_runs" in base_advance
     assert "gh workflow run review-gate.yml" in base_advance
-    assert '--ref "$head_ref"' in base_advance
+    assert '--ref "$current_base"' in base_advance
+    assert "Trusted review-gate evaluator is not installed" in base_advance
     assert "schedule:" in audit
     assert "*/5 * * * *" in audit
     assert "matrix.pr_number" in audit
     assert "actions: write" in audit
-    assert "statuses: read" in audit
+    assert "statuses: write" in audit
     assert "group: review-gate-${{ matrix.pr_number }}" in audit
     assert "reviewThreads" in audit
     assert "review result" in audit
     assert "gh workflow run review-gate.yml" in audit
     assert '--ref "$workflow_ref"' in audit
-    assert "head_repository" in audit
+    assert "Trusted review-gate evaluator is not installed" in audit
     assert "def security_heading:" in audit
     assert "security_heading) | not" in audit
     assert "def availability_notice:" in audit

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -73,11 +73,15 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "review-gate-base-change" in base_change
     assert "Base changed; push a new head before @codex review" in base_change
     assert 'stamp_status "$REVIEW_GATE_CONTEXT"' in base_change
+    assert base_change.count('stamp_status "$REVIEW_GATE_CONTEXT"') == 2
     assert "gh pr merge" not in base_change
     assert "--auto" not in base_change
     assert "pulls?state=open" in rollout
     assert "Disarming automatic merge; waiting for @codex review" in rollout
     assert "disablePullRequestAutoMerge" in rollout
+    assert rollout.index("Disarming automatic merge; waiting") < rollout.index(
+        '"$auto_merge_enabled" != "true"'
+    )
     assert "gh pr merge" not in rollout
     assert "--auto" not in rollout
 

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -76,7 +76,9 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "REVIEW_REVIEW_CONTEXT: review-gate-regular-review" in review_gate
     assert "REVIEW_BOT_EVENT_LOGIN: chatgpt-codex-connector[bot]" in review_gate
     assert "Dedicated routers classify review and" in review_gate
-    assert "Exact-head regular PR reviews and explicit clean regular issue" in review_gate
+    assert (
+        "Exact-head regular PR reviews and explicit clean regular issue" in review_gate
+    )
     assert "updatedAt" in review_gate
     assert "stock_clean_envelope" in review_gate
     assert "stock_clean_issue_comment_envelope" in review_gate
@@ -115,7 +117,10 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "Regular review invalidated; require a newer normal review" in regular_review
     assert "needs: route" in regular_review
     assert "if: needs.route.outputs.regular == 'true'" in regular_review
-    assert "group: review-gate-${{ github.event.pull_request.number }}" in regular_review
+    assert (
+        "group: review-gate-${{ github.event.pull_request.number }}"
+        in regular_review
+    )
     assert '--ref "$WORKFLOW_REF"' in regular_review
     assert "gh workflow run review-gate.yml" in regular_review
 

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -56,14 +56,19 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
         ROOT / ".github" / "workflows" / "review-base-change.yml"
     ).read_text()
     rollout = (ROOT / ".github" / "workflows" / "review-gate-rollout.yml").read_text()
+    base_advance = (
+        ROOT / ".github" / "workflows" / "review-base-advance.yml"
+    ).read_text()
+    audit = (ROOT / ".github" / "workflows" / "review-gate-audit.yml").read_text()
 
-    assert "cancel-in-progress: true" in review_gate
+    assert "cancel-in-progress: false" in review_gate
+    assert "group: review-gate-" in review_gate
     assert "REVIEW_BASE_CONTEXT: review-gate-base-change" in review_gate
-    assert (
-        "Security-review results and availability notices are never selected"
-        in review_gate
-    )
+    assert "never issue comments; security" in review_gate
+    assert "issue_comment:" not in review_gate
     assert "updatedAt" in review_gate
+    assert "stock_clean_envelope" in review_gate
+    assert "shared_open_head_count" in review_gate
     assert "final_gate_snapshot" in review_gate
     assert "Disarming automatic merge on" in review_gate
     assert "gh pr merge" not in review_gate
@@ -74,14 +79,27 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "Base changed; push a new head before @codex review" in base_change
     assert 'stamp_status "$REVIEW_GATE_CONTEXT"' in base_change
     assert base_change.count('stamp_status "$REVIEW_GATE_CONTEXT"') == 2
+    assert "group: review-gate-" in base_change
+    assert "cancel-in-progress: true" in base_change
     assert "gh pr merge" not in base_change
     assert "--auto" not in base_change
+    assert "pulls?state=open" in base_advance
+    assert "group: review-gate-" in base_advance
+    assert "cancel-in-progress: true" in base_advance
+    assert "review-gate-base-change" in base_advance
+    assert "schedule:" in audit
+    assert "reviewThreads" in audit
+    assert "Active regular Codex findings require a fresh review" in audit
+    assert "def security_heading:" in audit
+    assert "security_heading) | not" in audit
+    assert "issue_comment:" not in audit
     assert "pulls?state=open" in rollout
+    assert "actions: write" in rollout
     assert "Disarming automatic merge; waiting for @codex review" in rollout
     assert "disablePullRequestAutoMerge" in rollout
-    assert rollout.index("Disarming automatic merge; waiting") < rollout.index(
-        '"$auto_merge_enabled" != "true"'
-    )
+    assert "cancel-legacy-auto-merge-runs" in rollout
+    assert "active_gate_runs" in rollout
+    assert "group: review-gate-" in rollout
     assert "gh pr merge" not in rollout
     assert "--auto" not in rollout
 

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -55,6 +55,9 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     regular_review = (
         ROOT / ".github" / "workflows" / "review-regular-review.yml"
     ).read_text()
+    fork_regular_review = (
+        ROOT / ".github" / "workflows" / "review-fork-regular-review.yml"
+    ).read_text()
     regular_comment = (
         ROOT / ".github" / "workflows" / "review-regular-comment.yml"
     ).read_text()
@@ -123,6 +126,14 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
         in regular_review
     )
     assert (
+        "github.event.pull_request.head.repo.full_name != github.repository"
+        in regular_review
+    )
+    assert (
+        "fork-regular-review-${{ github.event.pull_request.number }}" in regular_review
+    )
+    assert "permissions: {}" in regular_review
+    assert (
         "GitHub downgrades pull_request_review tokens for forks to read-only"
         in regular_review
     )
@@ -136,6 +147,32 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     )
     assert '--ref "$WORKFLOW_REF"' in regular_review
     assert "gh workflow run review-gate.yml" in regular_review
+    assert "name: Reconcile Fork Regular Codex Review Events" in fork_regular_review
+    assert "workflow_run:" in fork_regular_review
+    assert 'workflows: ["Route Regular Codex Review Events"]' in fork_regular_review
+    assert "github.event.workflow_run.conclusion == 'success'" in fork_regular_review
+    assert (
+        "github.event.workflow_run.event == 'pull_request_review'"
+        in fork_regular_review
+    )
+    assert (
+        "review-gate-fork-review-${{ github.event.workflow_run.id }}"
+        in fork_regular_review
+    )
+    assert "fork-regular-review-(?<pr>" in fork_regular_review
+    assert "source_pr_number" in fork_regular_review
+    assert "actions/runs/$SOURCE_RUN_ID" in fork_regular_review
+    assert '"$source_pr_number" == "$pr_number"' in fork_regular_review
+    assert '"$head_repository" != "$REPO"' in fork_regular_review
+    assert "repos/$REPO/pulls/$pr_number/reviews/$review_id" in fork_regular_review
+    assert "REVIEW_BOT_EVENT_LOGIN: chatgpt-codex-connector[bot]" in fork_regular_review
+    assert (
+        "Regular review invalidated; require a newer normal review"
+        in fork_regular_review
+    )
+    assert "gh workflow run review-gate.yml" in fork_regular_review
+    assert '--ref "$WORKFLOW_REF"' in fork_regular_review
+    assert "actions/checkout" not in fork_regular_review
 
     assert "name: Invalidate Review Gate on Regular Comment" in regular_comment
     assert "issue_comment:" in regular_comment
@@ -165,8 +202,8 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert '--ref "$WORKFLOW_REF"' in regular_comment
     assert "gh workflow run review-gate.yml" in regular_comment
     assert "Trusted review-gate evaluator is not installed" in regular_comment
-    assert "gh pr merge" not in regular_review + regular_comment
-    assert "--auto" not in regular_review + regular_comment
+    assert "gh pr merge" not in regular_review + fork_regular_review + regular_comment
+    assert "--auto" not in regular_review + fork_regular_review + regular_comment
     assert "github.event.changes.base != null" in base_change
     assert "WORKFLOW_REF: ${{ github.event.repository.default_branch }}" in base_change
     assert "contents: read" in base_change
@@ -234,6 +271,7 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "Reconcile every head through the trusted default-branch workflow" in audit
     assert "issue_comment:" not in audit
     assert "pulls?state=open" in rollout
+    assert "review-fork-regular-review.yml" in rollout
     assert "actions: write" in rollout
     assert "Disarming automatic merge; waiting for @codex review" in rollout
     assert "disablePullRequestAutoMerge" in rollout

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -72,6 +72,11 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
 
     assert "cancel-in-progress: true" in review_gate
     assert "group: review-gate-" in review_gate
+    assert "types: [opened, reopened, synchronize, ready_for_review]" in review_gate
+    assert (
+        "types: [opened, reopened, synchronize, ready_for_review, auto_merge_enabled]"
+        not in review_gate
+    )
     assert "pull_request_review:" not in review_gate
     assert "issue_comment:" not in review_gate
     assert "REVIEW_BASE_CONTEXT: review-gate-base-change" in review_gate
@@ -276,6 +281,8 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "Reconcile every head through the trusted default-branch workflow" in audit
     assert "issue_comment:" not in audit
     assert "pulls?state=open" in rollout
+    assert "allow_auto_merge" in rollout
+    assert "Repository auto-merge must be disabled" in rollout
     assert "review-fork-regular-review.yml" in rollout
     assert "actions: write" in rollout
     assert "Disarming automatic merge; waiting for @codex review" in rollout
@@ -284,13 +291,19 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "cancel-legacy-auto-merge-runs" in rollout
     assert 'gh run cancel "$run_id" --repo "$REPO" || true' in rollout
     assert "active_gate_runs" in rollout
-    assert '.event == "workflow_dispatch"' in rollout
-    assert '.event == "issue_comment"' in rollout
+    assert '.event == "workflow_dispatch"' not in rollout
+    assert '.event == "issue_comment"' not in rollout
+    assert rollout.index("stamp_pending") < rollout.index("active_gate_runs")
+    assert "Refresh the PR after cancellation" in rollout
     assert "group: review-gate-" in rollout
     assert "review-regular-review.yml" in rollout
     assert "review-regular-comment.yml" in rollout
     assert "gh pr merge" not in rollout
     assert "--auto" not in rollout
+    assert "issues/comments/$EVENT_COMMENT_ID" in regular_comment
+    assert "superseded by a newer edit" in regular_comment
+    assert "pulls/$PR_NUMBER/reviews/$REVIEW_ID" in regular_review
+    assert "superseded by newer review state" in regular_review
 
 
 def test_github_actions_use_immutable_refs_with_semantic_comments() -> None:

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -238,9 +238,8 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "--auto" not in base_change
     assert "pulls?state=open" in base_advance
     assert "BASE_PUSHED_AT" in base_advance
-    assert "snapshot_before_base_push" in base_advance
-    assert "pull_requests" in base_advance
-    assert "--slurpfile prs" in base_advance
+    assert "commits/$event_head_sha/statuses" in base_advance
+    assert "created_at | fromdateiso8601" in base_advance
     assert "mktemp" in base_advance
     assert "event_head_sha" in base_advance
     assert "EVENT_HEAD_SHA" in base_advance
@@ -256,6 +255,7 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert '--ref "$WORKFLOW_REF"' in base_advance
     assert "contents: read" in base_advance
     assert "Trusted review-gate evaluator is not installed" in base_advance
+    assert "startswith($prefix)" in review_gate
     assert "push:\n    branches: [main]" in base_advance
     assert "schedule:" in audit
     assert "*/5 * * * *" in audit
@@ -287,6 +287,10 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "pulls?state=open" in rollout
     assert "allow_auto_merge" in rollout
     assert "Repository auto-merge must be disabled" in rollout
+    assert "disarm-open-prs:" in rollout
+    assert "needs: discover" in rollout
+    assert "verify-repository-policy:" in rollout
+    assert "if: always()" in rollout
     assert "review-fork-regular-review.yml" in rollout
     assert "actions: write" in rollout
     assert "Disarming automatic merge; waiting for @codex review" in rollout

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -160,6 +160,8 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "BASE_PUSHED_AT" in base_advance
     assert "snapshot_before_base_push" in base_advance
     assert "pull_requests" in base_advance
+    assert "--slurpfile prs" in base_advance
+    assert "mktemp" in base_advance
     assert "event_head_sha" in base_advance
     assert "EVENT_HEAD_SHA" in base_advance
     assert "gained a new head after the base advance" in base_advance

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -161,17 +161,21 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
         "github.event.workflow_run.event == 'pull_request_review'"
         in fork_regular_review
     )
-    assert (
-        "review-gate-fork-review-${{ github.event.workflow_run.id }}"
-        in fork_regular_review
+    assert "group: review-gate-${{ needs.route.outputs.pr_number }}" in (
+        fork_regular_review
     )
+    assert "cancel-in-progress: true" in fork_regular_review
     assert "fork-regular-review-(?<pr>" in fork_regular_review
     assert "source_pr_number" in fork_regular_review
     assert "actions/runs/$SOURCE_RUN_ID" in fork_regular_review
     assert '"$source_pr_number" == "$pr_number"' in fork_regular_review
     assert '"$head_repository" != "$REPO"' in fork_regular_review
-    assert "repos/$REPO/pulls/$pr_number/reviews/$review_id" in fork_regular_review
+    assert "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" in fork_regular_review
     assert "REVIEW_BOT_EVENT_LOGIN: chatgpt-codex-connector[bot]" in fork_regular_review
+    assert "body_is_regular_review" in fork_regular_review
+    assert "security_heading | not" in fork_regular_review
+    assert "availability_notice | not" in fork_regular_review
+    assert 'review_state" != "DISMISSED"' in fork_regular_review
     assert (
         "Regular review invalidated; require a newer normal review"
         in fork_regular_review

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -100,6 +100,8 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "latest_regular_issue_comment_at" in review_gate
     assert "latest_regular_review_invalidation_at" in review_gate
     assert "latest_finding_at" in review_gate
+    assert "base_change_marker_exists" in review_gate
+    assert "Regular review invalidated at $latest_finding_at" in review_gate
     assert "shared_open_head_count" in review_gate
     assert "shared_open_head_owner" in review_gate
     assert "$pr.state" in review_gate
@@ -226,7 +228,7 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
         "group: review-gate-base-change-${{ github.event.pull_request.number }}"
         in base_change
     )
-    assert "Base changed; request a fresh @codex review" in base_change
+    assert "Base changed; push a new head before @codex review" in base_change
     assert "Base changed for PR #$PR_NUMBER at base $EVENT_BASE_SHA" in base_change
     assert 'stamp_status "$REVIEW_GATE_CONTEXT"' in base_change
     assert base_change.count('stamp_status "$REVIEW_GATE_CONTEXT"') == 2
@@ -244,13 +246,14 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
         base_advance
     )
     assert "base_advanced_at" in base_advance
-    assert "request a fresh @codex review" in base_advance
+    assert "push a new head before @codex review" in base_advance
     assert "mktemp" in base_advance
     assert "event_head_sha" in base_advance
     assert "EVENT_HEAD_SHA" in base_advance
+    assert "EVENT_BASE_SHA" in base_advance
     assert ".[]\n                | select(.base.ref == $base)" in base_advance
     assert "group: review-gate-base-advance-" in base_advance
-    assert "cancel-in-progress: true" in base_advance
+    assert "cancel-in-progress: false" in base_advance
     assert "review-gate-base-change" in base_advance
     assert "disablePullRequestAutoMerge" in base_advance
     assert "((.auto_merge != null) | tostring)" in base_advance
@@ -261,7 +264,8 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "contents: read" in base_advance
     assert "Trusted review-gate evaluator is not installed" in base_advance
     assert "startswith($prefix)" in review_gate
-    assert "push:\n    branches: [main]" in base_advance
+    assert "push:\n  workflow_dispatch:" in base_advance
+    assert "github.event.repository.default_branch" in base_advance
     assert "schedule:" in audit
     assert "*/5 * * * *" in audit
     assert "matrix.pr_number" in audit

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -96,6 +96,8 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "$pr.state" in review_gate
     assert '"$pr_state" != "OPEN"' in review_gate
     assert "final_gate_snapshot" in review_gate
+    assert "evidence_marker" in review_gate
+    assert "; evidence $evidence_marker" in review_gate
     assert "Disarming automatic merge on" in review_gate
     assert "gh pr merge" not in review_gate
     assert "--auto" not in review_gate
@@ -203,6 +205,7 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert '--ref "$WORKFLOW_REF"' in base_advance
     assert "contents: read" in base_advance
     assert "Trusted review-gate evaluator is not installed" in base_advance
+    assert "push:\n    branches: [main]" in base_advance
     assert "schedule:" in audit
     assert "*/5 * * * *" in audit
     assert "matrix.pr_number" in audit
@@ -221,11 +224,14 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "security_heading) | not" in audit
     assert "def availability_notice:" in audit
     assert "availability_notice) | not" in audit
-    assert "latest_regular_comment_at" in audit
-    assert "latest_regular_review_at" in audit
-    assert "Keep dismissed normal reviews in the timestamp" in audit
-    assert "head.repo.full_name" in audit
-    assert "Fork review routers cannot write at all" in audit
+    assert "current_regular_comment_records" in audit
+    assert "current_regular_review_records" in audit
+    assert "databaseId state submittedAt updatedAt" in audit
+    assert 'select((.state // "") != "DISMISSED")' in audit
+    assert 'select((.pullRequestReview.state // "") != "DISMISSED")' in audit
+    assert "evidence_marker" in audit
+    assert "is_reconciliation_pending" in audit
+    assert "Reconcile every head through the trusted default-branch workflow" in audit
     assert "issue_comment:" not in audit
     assert "pulls?state=open" in rollout
     assert "actions: write" in rollout

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -49,6 +49,30 @@ def test_github_validation_runs_hacs_and_hassfest() -> None:
     )
 
 
+def test_review_gate_uses_only_regular_review_evidence() -> None:
+    """Keep manual shipping independent from security-review availability."""
+    review_gate = (ROOT / ".github" / "workflows" / "review-gate.yml").read_text()
+    base_change = (
+        ROOT / ".github" / "workflows" / "review-base-change.yml"
+    ).read_text()
+
+    assert "cancel-in-progress: true" in review_gate
+    assert "REVIEW_BASE_CONTEXT: review-gate-base-change" in review_gate
+    assert (
+        "Security-review results and availability notices are never selected"
+        in review_gate
+    )
+    assert "updatedAt" in review_gate
+    assert "final_gate_snapshot" in review_gate
+    assert "gh pr merge" not in review_gate
+    assert "--auto" not in review_gate
+    assert "github.event.changes.base != null" in base_change
+    assert "review-gate-base-change" in base_change
+    assert "Base changed; push a new head before @codex review" in base_change
+    assert "gh pr merge" not in base_change
+    assert "--auto" not in base_change
+
+
 def test_github_actions_use_immutable_refs_with_semantic_comments() -> None:
     """Pin external actions while documenting the corresponding upstream ref."""
     for path in (ROOT / ".github" / "workflows").glob("*.yml"):

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -241,6 +241,10 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "BASE_PUSHED_AT" in base_advance
     assert "commits/$event_head_sha/statuses" not in base_advance
     assert ".created_at | fromdateiso8601" in base_advance
+    assert ".commit.committer.date | fromdateiso8601" in base_advance
+    assert "gained a new head after the base advance; leaving it reviewable" in (
+        base_advance
+    )
     assert "created_at | fromdateiso8601" in base_advance
     assert "mktemp" in base_advance
     assert "event_head_sha" in base_advance

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -116,8 +116,18 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "REVIEW_REVIEW_CONTEXT: review-gate-regular-review" in regular_review
     assert "Regular review invalidated; require a newer normal review" in regular_review
     assert "needs: route" in regular_review
-    assert "if: needs.route.outputs.regular == 'true'" in regular_review
-    assert "WORKFLOW_REF: ${{ github.event.pull_request.base.ref }}" in regular_review
+    assert (
+        "github.event.pull_request.head.repo.full_name == github.repository"
+        in regular_review
+    )
+    assert (
+        "GitHub downgrades pull_request_review tokens for forks to read-only"
+        in regular_review
+    )
+    assert "contents: read" in regular_review
+    assert (
+        "WORKFLOW_REF: ${{ github.event.repository.default_branch }}" in regular_review
+    )
     assert "Trusted review-gate evaluator is not installed" in regular_review
     assert (
         "group: review-gate-${{ github.event.pull_request.number }}" in regular_review
@@ -131,6 +141,8 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "cancel-in-progress: false" in regular_comment
     assert "REVIEW_BOT_EVENT_LOGIN: chatgpt-codex-connector[bot]" in regular_comment
     assert "EVENT_PREVIOUS_COMMENT_BODY" in regular_comment
+    assert "body_could_be_regular_comment" in regular_comment
+    assert "before the pull request lookup" in regular_comment
     assert "body_is_regular_comment" in regular_comment
     assert "body_is_clean_comment" in regular_comment
     assert "def security_heading:" in regular_comment
@@ -141,7 +153,11 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "name: classify-regular-comment" in regular_comment
     assert "needs: classify" in regular_comment
     assert "if: needs.classify.outputs.regular == 'true'" in regular_comment
-    assert "[.head.sha, .base.ref]" in regular_comment
+    assert "| jq -er '.head.sha'" in regular_comment
+    assert (
+        "WORKFLOW_REF: ${{ github.event.repository.default_branch }}" in regular_comment
+    )
+    assert "contents: read" in regular_comment
     assert "group: review-gate-${{ github.event.issue.number }}" in regular_comment
     assert "stock_clean_issue_comment_envelope" in regular_comment
     assert '--ref "$WORKFLOW_REF"' in regular_comment
@@ -150,7 +166,8 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "gh pr merge" not in regular_review + regular_comment
     assert "--auto" not in regular_review + regular_comment
     assert "github.event.changes.base != null" in base_change
-    assert "WORKFLOW_REF: ${{ github.event.pull_request.base.ref }}" in base_change
+    assert "WORKFLOW_REF: ${{ github.event.repository.default_branch }}" in base_change
+    assert "contents: read" in base_change
     assert "EVENT_BASE_SHA" in base_change
     assert "REVIEW_GATE_CONTEXT: review-gate" in base_change
     assert "review-gate-base-change" in base_change
@@ -182,23 +199,33 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "((.auto_merge != null) | tostring)" in base_advance
     assert "cancel_active_gate_runs" in base_advance
     assert "gh workflow run review-gate.yml" in base_advance
-    assert '--ref "$current_base"' in base_advance
+    assert "WORKFLOW_REF: ${{ github.event.repository.default_branch }}" in base_advance
+    assert '--ref "$WORKFLOW_REF"' in base_advance
+    assert "contents: read" in base_advance
     assert "Trusted review-gate evaluator is not installed" in base_advance
     assert "schedule:" in audit
     assert "*/5 * * * *" in audit
     assert "matrix.pr_number" in audit
     assert "actions: write" in audit
+    assert "contents: read" in audit
+    assert "issues: read" in audit
     assert "statuses: write" in audit
     assert "group: review-gate-${{ matrix.pr_number }}" in audit
     assert "reviewThreads" in audit
     assert "review result" in audit
     assert "gh workflow run review-gate.yml" in audit
-    assert '--ref "$workflow_ref"' in audit
+    assert "WORKFLOW_REF: ${{ github.event.repository.default_branch }}" in audit
+    assert '--ref "$WORKFLOW_REF"' in audit
     assert "Trusted review-gate evaluator is not installed" in audit
     assert "def security_heading:" in audit
     assert "security_heading) | not" in audit
     assert "def availability_notice:" in audit
     assert "availability_notice) | not" in audit
+    assert "latest_regular_comment_at" in audit
+    assert "latest_regular_review_at" in audit
+    assert "Keep dismissed normal reviews in the timestamp" in audit
+    assert "head.repo.full_name" in audit
+    assert "Fork review routers cannot write at all" in audit
     assert "issue_comment:" not in audit
     assert "pulls?state=open" in rollout
     assert "actions: write" in rollout

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -226,7 +226,7 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
         "group: review-gate-base-change-${{ github.event.pull_request.number }}"
         in base_change
     )
-    assert "Base changed; push a new head before @codex review" in base_change
+    assert "Base changed; request a fresh @codex review" in base_change
     assert "Base changed for PR #$PR_NUMBER at base $EVENT_BASE_SHA" in base_change
     assert 'stamp_status "$REVIEW_GATE_CONTEXT"' in base_change
     assert base_change.count('stamp_status "$REVIEW_GATE_CONTEXT"') == 2
@@ -240,16 +240,15 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "pulls?state=open" in base_advance
     assert "BASE_PUSHED_AT" in base_advance
     assert "commits/$event_head_sha/statuses" not in base_advance
-    assert ".created_at | fromdateiso8601" in base_advance
-    assert ".commit.committer.date | fromdateiso8601" in base_advance
-    assert "gained a new head after the base advance; leaving it reviewable" in (
+    assert "Over-invalidate rather than trusting contributor-controlled commit" in (
         base_advance
     )
-    assert "created_at | fromdateiso8601" in base_advance
+    assert "base_advanced_at" in base_advance
+    assert "request a fresh @codex review" in base_advance
     assert "mktemp" in base_advance
     assert "event_head_sha" in base_advance
     assert "EVENT_HEAD_SHA" in base_advance
-    assert "gained a new head after the base advance" in base_advance
+    assert ".[]\n                | select(.base.ref == $base)" in base_advance
     assert "group: review-gate-base-advance-" in base_advance
     assert "cancel-in-progress: true" in base_advance
     assert "review-gate-base-change" in base_advance

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -55,6 +55,7 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     base_change = (
         ROOT / ".github" / "workflows" / "review-base-change.yml"
     ).read_text()
+    rollout = (ROOT / ".github" / "workflows" / "review-gate-rollout.yml").read_text()
 
     assert "cancel-in-progress: true" in review_gate
     assert "REVIEW_BASE_CONTEXT: review-gate-base-change" in review_gate
@@ -64,13 +65,21 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     )
     assert "updatedAt" in review_gate
     assert "final_gate_snapshot" in review_gate
+    assert "Disarming automatic merge on" in review_gate
     assert "gh pr merge" not in review_gate
     assert "--auto" not in review_gate
     assert "github.event.changes.base != null" in base_change
+    assert "REVIEW_GATE_CONTEXT: review-gate" in base_change
     assert "review-gate-base-change" in base_change
     assert "Base changed; push a new head before @codex review" in base_change
+    assert 'stamp_status "$REVIEW_GATE_CONTEXT"' in base_change
     assert "gh pr merge" not in base_change
     assert "--auto" not in base_change
+    assert "pulls?state=open" in rollout
+    assert "Disarming automatic merge; waiting for @codex review" in rollout
+    assert "disablePullRequestAutoMerge" in rollout
+    assert "gh pr merge" not in rollout
+    assert "--auto" not in rollout
 
 
 def test_github_actions_use_immutable_refs_with_semantic_comments() -> None:

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -116,7 +116,12 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "REVIEW_REVIEW_CONTEXT: review-gate-regular-review" in regular_review
     assert "Regular review invalidated; require a newer normal review" in regular_review
     assert "needs: route" in regular_review
-    assert "if: needs.route.outputs.regular == 'true'" in regular_review
+    assert "needs.route.outputs.regular == 'true'" in regular_review
+    assert (
+        "github.event.pull_request.head.repo.full_name == github.repository"
+        in regular_review
+    )
+    assert "WORKFLOW_REF: ${{ github.event.pull_request.head.ref }}" in regular_review
     assert (
         "group: review-gate-${{ github.event.pull_request.number }}"
         in regular_review
@@ -139,7 +144,12 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "REVIEW_COMMENT_CONTEXT: review-gate-regular-comment" in regular_comment
     assert "name: classify-regular-comment" in regular_comment
     assert "needs: classify" in regular_comment
-    assert "if: needs.classify.outputs.regular == 'true'" in regular_comment
+    assert "needs.classify.outputs.regular == 'true'" in regular_comment
+    assert (
+        "needs.classify.outputs.head_repository == github.repository"
+        in regular_comment
+    )
+    assert "[.head.sha, .head.ref, .head.repo.full_name]" in regular_comment
     assert "group: review-gate-${{ github.event.issue.number }}" in regular_comment
     assert "stock_clean_issue_comment_envelope" in regular_comment
     assert '--ref "$WORKFLOW_REF"' in regular_comment
@@ -147,6 +157,11 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "gh pr merge" not in regular_review + regular_comment
     assert "--auto" not in regular_review + regular_comment
     assert "github.event.changes.base != null" in base_change
+    assert (
+        "github.event.pull_request.head.repo.full_name == github.repository"
+        in base_change
+    )
+    assert "WORKFLOW_REF: ${{ github.event.pull_request.head.ref }}" in base_change
     assert "EVENT_BASE_SHA" in base_change
     assert "REVIEW_GATE_CONTEXT: review-gate" in base_change
     assert "review-gate-base-change" in base_change
@@ -169,6 +184,7 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "mktemp" in base_advance
     assert "event_head_sha" in base_advance
     assert "EVENT_HEAD_SHA" in base_advance
+    assert "select(.head.repo.full_name == $repo)" in base_advance
     assert "gained a new head after the base advance" in base_advance
     assert "group: review-gate-base-advance-" in base_advance
     assert "cancel-in-progress: true" in base_advance
@@ -177,7 +193,7 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "((.auto_merge != null) | tostring)" in base_advance
     assert "cancel_active_gate_runs" in base_advance
     assert "gh workflow run review-gate.yml" in base_advance
-    assert '--ref "$current_base"' in base_advance
+    assert '--ref "$head_ref"' in base_advance
     assert "schedule:" in audit
     assert "*/5 * * * *" in audit
     assert "matrix.pr_number" in audit
@@ -188,6 +204,7 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "review result" in audit
     assert "gh workflow run review-gate.yml" in audit
     assert '--ref "$workflow_ref"' in audit
+    assert "head_repository" in audit
     assert "def security_heading:" in audit
     assert "security_heading) | not" in audit
     assert "def availability_notice:" in audit

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -52,6 +52,12 @@ def test_github_validation_runs_hacs_and_hassfest() -> None:
 def test_review_gate_uses_only_regular_review_evidence() -> None:
     """Keep manual shipping independent from security-review availability."""
     review_gate = (ROOT / ".github" / "workflows" / "review-gate.yml").read_text()
+    regular_review = (
+        ROOT / ".github" / "workflows" / "review-regular-review.yml"
+    ).read_text()
+    regular_comment = (
+        ROOT / ".github" / "workflows" / "review-regular-comment.yml"
+    ).read_text()
     base_change = (
         ROOT / ".github" / "workflows" / "review-base-change.yml"
     ).read_text()
@@ -63,37 +69,67 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
 
     assert "cancel-in-progress: true" in review_gate
     assert "group: review-gate-" in review_gate
-    assert "github.event.issue.number" in review_gate
+    assert "pull_request_review:" not in review_gate
+    assert "issue_comment:" not in review_gate
     assert "REVIEW_BASE_CONTEXT: review-gate-base-change" in review_gate
     assert "REVIEW_COMMENT_CONTEXT: review-gate-regular-comment" in review_gate
-    assert "issue_comment:" in review_gate
-    assert "EVENT_COMMENT_AUTHOR" in review_gate
-    assert "EVENT_REVIEW_AUTHOR" in review_gate
+    assert "REVIEW_REVIEW_CONTEXT: review-gate-regular-review" in review_gate
     assert "REVIEW_BOT_EVENT_LOGIN: chatgpt-codex-connector[bot]" in review_gate
-    assert '"$EVENT_COMMENT_AUTHOR" != "$REVIEW_BOT_EVENT_LOGIN"' in review_gate
-    assert "event_pull_request_review_is_regular" in review_gate
-    assert "security review cannot momentarily block" in review_gate
-    assert "Submitted PR reviews are the only qualifying clean evidence." in review_gate
-    assert "Security-review messages and all other" in review_gate
+    assert "Dedicated routers classify review and" in review_gate
+    assert "Exact-head regular PR reviews and explicit clean regular issue" in review_gate
     assert "updatedAt" in review_gate
     assert "stock_clean_envelope" in review_gate
-    assert 'source == "review"' in review_gate
+    assert "didn.t find any major issues" in review_gate
+    assert "codex[[:space:]]+in[[:space:]]+github" in review_gate
+    assert 'source == "issue_comment"' in review_gate
     assert "total_count" in review_gate
     assert "latest_regular_issue_comment_at" in review_gate
+    assert "latest_regular_review_invalidation_at" in review_gate
     assert "latest_finding_at" in review_gate
     assert "shared_open_head_count" in review_gate
     assert "final_gate_snapshot" in review_gate
     assert "Disarming automatic merge on" in review_gate
     assert "gh pr merge" not in review_gate
     assert "--auto" not in review_gate
+
+    assert "name: Route Regular Codex Review Events" in regular_review
+    assert "pull_request_review:" in regular_review
+    assert "review-gate-review-event-${{ github.event.review.id }}" in regular_review
+    assert "cancel-in-progress: false" in regular_review
+    assert "REVIEW_BOT_EVENT_LOGIN: chatgpt-codex-connector[bot]" in regular_review
+    assert "EVENT_PREVIOUS_REVIEW_BODY" in regular_review
+    assert "body_is_regular_review" in regular_review
+    assert "def security_heading:" in regular_review
+    assert "security_heading | not" in regular_review
+    assert "REVIEW_REVIEW_CONTEXT: review-gate-regular-review" in regular_review
+    assert "Regular review invalidated; require a newer normal review" in regular_review
+    assert "gh workflow run review-gate.yml" in regular_review
+
+    assert "name: Invalidate Review Gate on Regular Comment" in regular_comment
+    assert "issue_comment:" in regular_comment
+    assert "review-gate-comment-event-${{ github.event.comment.id }}" in regular_comment
+    assert "cancel-in-progress: false" in regular_comment
+    assert "REVIEW_BOT_EVENT_LOGIN: chatgpt-codex-connector[bot]" in regular_comment
+    assert "EVENT_PREVIOUS_COMMENT_BODY" in regular_comment
+    assert "body_is_regular_comment" in regular_comment
+    assert "body_is_clean_comment" in regular_comment
+    assert "def security_heading:" in regular_comment
+    assert "security_heading | not" in regular_comment
+    assert "REVIEW_COMMENT_CONTEXT: review-gate-regular-comment" in regular_comment
+    assert "gh workflow run review-gate.yml" in regular_comment
+    assert "gh pr merge" not in regular_review + regular_comment
+    assert "--auto" not in regular_review + regular_comment
     assert "github.event.changes.base != null" in base_change
+    assert "EVENT_BASE_SHA" in base_change
     assert "REVIEW_GATE_CONTEXT: review-gate" in base_change
     assert "review-gate-base-change" in base_change
     assert "group: review-gate-base-change-" in base_change
     assert "Base changed; push a new head before @codex review" in base_change
+    assert "Base changed for PR #$PR_NUMBER at base $EVENT_BASE_SHA" in base_change
     assert 'stamp_status "$REVIEW_GATE_CONTEXT"' in base_change
     assert base_change.count('stamp_status "$REVIEW_GATE_CONTEXT"') == 2
     assert "cancel-in-progress: true" in base_change
+    assert "cancel_active_gate_runs" in base_change
     assert "gh workflow run review-gate.yml" in base_change
     assert "gh pr merge" not in base_change
     assert "--auto" not in base_change
@@ -103,14 +139,16 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "review-gate-base-change" in base_advance
     assert "disablePullRequestAutoMerge" in base_advance
     assert "((.auto_merge != null) | tostring)" in base_advance
+    assert "cancel_active_gate_runs" in base_advance
     assert "gh workflow run review-gate.yml" in base_advance
     assert "schedule:" in audit
     assert "*/5 * * * *" in audit
     assert "matrix.pr_number" in audit
-    assert "group: review-gate-${{ matrix.pr_number }}" in audit
+    assert "actions: write" in audit
+    assert "group: review-gate-audit-${{ matrix.pr_number }}" in audit
     assert "reviewThreads" in audit
     assert "review result" in audit
-    assert "Active regular Codex findings require a fresh review" in audit
+    assert "gh workflow run review-gate.yml" in audit
     assert "def security_heading:" in audit
     assert "security_heading) | not" in audit
     assert "issue_comment:" not in audit
@@ -122,7 +160,10 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "cancel-legacy-auto-merge-runs" in rollout
     assert "active_gate_runs" in rollout
     assert '.event == "workflow_dispatch"' in rollout
+    assert '.event == "issue_comment"' in rollout
     assert "group: review-gate-" in rollout
+    assert "review-regular-review.yml" in rollout
+    assert "review-regular-comment.yml" in rollout
     assert "gh pr merge" not in rollout
     assert "--auto" not in rollout
 

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -107,8 +107,9 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
 
     assert "name: Route Regular Codex Review Events" in regular_review
     assert "pull_request_review:" in regular_review
-    assert "review-gate-review-event-${{ github.event.review.id }}" in regular_review
-    assert "cancel-in-progress: false" in regular_review
+    assert "Run every review delivery independently" in regular_review
+    assert "review-gate-review-event-" not in regular_review
+    assert "cancel-in-progress: false" not in regular_review
     assert "REVIEW_BOT_EVENT_LOGIN: chatgpt-codex-connector[bot]" in regular_review
     assert "EVENT_PREVIOUS_REVIEW_BODY" in regular_review
     assert "body_is_regular_review" in regular_review
@@ -176,8 +177,9 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
 
     assert "name: Invalidate Review Gate on Regular Comment" in regular_comment
     assert "issue_comment:" in regular_comment
-    assert "review-gate-comment-event-${{ github.event.comment.id }}" in regular_comment
-    assert "cancel-in-progress: false" in regular_comment
+    assert "Run every comment delivery independently" in regular_comment
+    assert "review-gate-comment-event-" not in regular_comment
+    assert "cancel-in-progress: false" not in regular_comment
     assert "REVIEW_BOT_EVENT_LOGIN: chatgpt-codex-connector[bot]" in regular_comment
     assert "EVENT_PREVIOUS_COMMENT_BODY" in regular_comment
     assert "body_could_be_regular_comment" in regular_comment
@@ -210,7 +212,10 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "EVENT_BASE_SHA" in base_change
     assert "REVIEW_GATE_CONTEXT: review-gate" in base_change
     assert "review-gate-base-change" in base_change
-    assert "group: review-gate-${{ github.event.pull_request.number }}" in base_change
+    assert (
+        "group: review-gate-base-change-${{ github.event.pull_request.number }}"
+        in base_change
+    )
     assert "Base changed; push a new head before @codex review" in base_change
     assert "Base changed for PR #$PR_NUMBER at base $EVENT_BASE_SHA" in base_change
     assert 'stamp_status "$REVIEW_GATE_CONTEXT"' in base_change

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -79,6 +79,7 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "Exact-head regular PR reviews and explicit clean regular issue" in review_gate
     assert "updatedAt" in review_gate
     assert "stock_clean_envelope" in review_gate
+    assert "stock_clean_issue_comment_envelope" in review_gate
     assert "didn.t find any major issues" in review_gate
     assert "codex[[:space:]]+in[[:space:]]+github" in review_gate
     assert "def availability_notice:" in review_gate
@@ -89,6 +90,9 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "latest_regular_review_invalidation_at" in review_gate
     assert "latest_finding_at" in review_gate
     assert "shared_open_head_count" in review_gate
+    assert "shared_open_head_owner" in review_gate
+    assert "$pr.state" in review_gate
+    assert '"$pr_state" != "OPEN"' in review_gate
     assert "final_gate_snapshot" in review_gate
     assert "Disarming automatic merge on" in review_gate
     assert "gh pr merge" not in review_gate
@@ -109,6 +113,10 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "Ignoring a review attached to an older pull request head" in regular_review
     assert "REVIEW_REVIEW_CONTEXT: review-gate-regular-review" in regular_review
     assert "Regular review invalidated; require a newer normal review" in regular_review
+    assert "needs: route" in regular_review
+    assert "if: needs.route.outputs.regular == 'true'" in regular_review
+    assert "group: review-gate-${{ github.event.pull_request.number }}" in regular_review
+    assert '--ref "$WORKFLOW_REF"' in regular_review
     assert "gh workflow run review-gate.yml" in regular_review
 
     assert "name: Invalidate Review Gate on Regular Comment" in regular_comment
@@ -124,6 +132,12 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "def availability_notice:" in regular_comment
     assert "availability_notice | not" in regular_comment
     assert "REVIEW_COMMENT_CONTEXT: review-gate-regular-comment" in regular_comment
+    assert "name: classify-regular-comment" in regular_comment
+    assert "needs: classify" in regular_comment
+    assert "if: needs.classify.outputs.regular == 'true'" in regular_comment
+    assert "group: review-gate-${{ github.event.issue.number }}" in regular_comment
+    assert "stock_clean_issue_comment_envelope" in regular_comment
+    assert '--ref "$WORKFLOW_REF"' in regular_comment
     assert "gh workflow run review-gate.yml" in regular_comment
     assert "gh pr merge" not in regular_review + regular_comment
     assert "--auto" not in regular_review + regular_comment
@@ -131,7 +145,7 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "EVENT_BASE_SHA" in base_change
     assert "REVIEW_GATE_CONTEXT: review-gate" in base_change
     assert "review-gate-base-change" in base_change
-    assert "group: review-gate-base-change-" in base_change
+    assert "group: review-gate-${{ github.event.pull_request.number }}" in base_change
     assert "Base changed; push a new head before @codex review" in base_change
     assert "Base changed for PR #$PR_NUMBER at base $EVENT_BASE_SHA" in base_change
     assert 'stamp_status "$REVIEW_GATE_CONTEXT"' in base_change
@@ -139,9 +153,13 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "cancel-in-progress: true" in base_change
     assert "cancel_active_gate_runs" in base_change
     assert "gh workflow run review-gate.yml" in base_change
+    assert '--ref "$WORKFLOW_REF"' in base_change
     assert "gh pr merge" not in base_change
     assert "--auto" not in base_change
     assert "pulls?state=open" in base_advance
+    assert "BASE_PUSHED_AT" in base_advance
+    assert "snapshot_before_base_push" in base_advance
+    assert "pull_requests" in base_advance
     assert "event_head_sha" in base_advance
     assert "EVENT_HEAD_SHA" in base_advance
     assert "gained a new head after the base advance" in base_advance
@@ -152,15 +170,17 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "((.auto_merge != null) | tostring)" in base_advance
     assert "cancel_active_gate_runs" in base_advance
     assert "gh workflow run review-gate.yml" in base_advance
+    assert '--ref "$current_base"' in base_advance
     assert "schedule:" in audit
     assert "*/5 * * * *" in audit
     assert "matrix.pr_number" in audit
     assert "actions: write" in audit
     assert "statuses: read" in audit
-    assert "group: review-gate-audit-${{ matrix.pr_number }}" in audit
+    assert "group: review-gate-${{ matrix.pr_number }}" in audit
     assert "reviewThreads" in audit
     assert "review result" in audit
     assert "gh workflow run review-gate.yml" in audit
+    assert '--ref "$workflow_ref"' in audit
     assert "def security_heading:" in audit
     assert "security_heading) | not" in audit
     assert "def availability_notice:" in audit
@@ -172,6 +192,7 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "disablePullRequestAutoMerge" in rollout
     assert "((.auto_merge != null) | tostring)" in rollout
     assert "cancel-legacy-auto-merge-runs" in rollout
+    assert 'gh run cancel "$run_id" --repo "$REPO" || true' in rollout
     assert "active_gate_runs" in rollout
     assert '.event == "workflow_dispatch"' in rollout
     assert '.event == "issue_comment"' in rollout

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -61,13 +61,26 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     ).read_text()
     audit = (ROOT / ".github" / "workflows" / "review-gate-audit.yml").read_text()
 
-    assert "cancel-in-progress: false" in review_gate
+    assert "cancel-in-progress: true" in review_gate
     assert "group: review-gate-" in review_gate
+    assert "github.event.issue.number" in review_gate
     assert "REVIEW_BASE_CONTEXT: review-gate-base-change" in review_gate
-    assert "never issue comments; security" in review_gate
-    assert "issue_comment:" not in review_gate
+    assert "REVIEW_COMMENT_CONTEXT: review-gate-regular-comment" in review_gate
+    assert "issue_comment:" in review_gate
+    assert "EVENT_COMMENT_AUTHOR" in review_gate
+    assert "EVENT_REVIEW_AUTHOR" in review_gate
+    assert "REVIEW_BOT_EVENT_LOGIN: chatgpt-codex-connector[bot]" in review_gate
+    assert '"$EVENT_COMMENT_AUTHOR" != "$REVIEW_BOT_EVENT_LOGIN"' in review_gate
+    assert "event_pull_request_review_is_regular" in review_gate
+    assert "security review cannot momentarily block" in review_gate
+    assert "Submitted PR reviews are the only qualifying clean evidence." in review_gate
+    assert "Security-review messages and all other" in review_gate
     assert "updatedAt" in review_gate
     assert "stock_clean_envelope" in review_gate
+    assert 'source == "review"' in review_gate
+    assert "total_count" in review_gate
+    assert "latest_regular_issue_comment_at" in review_gate
+    assert "latest_finding_at" in review_gate
     assert "shared_open_head_count" in review_gate
     assert "final_gate_snapshot" in review_gate
     assert "Disarming automatic merge on" in review_gate
@@ -76,19 +89,27 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "github.event.changes.base != null" in base_change
     assert "REVIEW_GATE_CONTEXT: review-gate" in base_change
     assert "review-gate-base-change" in base_change
+    assert "group: review-gate-base-change-" in base_change
     assert "Base changed; push a new head before @codex review" in base_change
     assert 'stamp_status "$REVIEW_GATE_CONTEXT"' in base_change
     assert base_change.count('stamp_status "$REVIEW_GATE_CONTEXT"') == 2
-    assert "group: review-gate-" in base_change
     assert "cancel-in-progress: true" in base_change
+    assert "gh workflow run review-gate.yml" in base_change
     assert "gh pr merge" not in base_change
     assert "--auto" not in base_change
     assert "pulls?state=open" in base_advance
-    assert "group: review-gate-" in base_advance
+    assert "group: review-gate-base-advance-" in base_advance
     assert "cancel-in-progress: true" in base_advance
     assert "review-gate-base-change" in base_advance
+    assert "disablePullRequestAutoMerge" in base_advance
+    assert "((.auto_merge != null) | tostring)" in base_advance
+    assert "gh workflow run review-gate.yml" in base_advance
     assert "schedule:" in audit
+    assert "*/5 * * * *" in audit
+    assert "matrix.pr_number" in audit
+    assert "group: review-gate-${{ matrix.pr_number }}" in audit
     assert "reviewThreads" in audit
+    assert "review result" in audit
     assert "Active regular Codex findings require a fresh review" in audit
     assert "def security_heading:" in audit
     assert "security_heading) | not" in audit
@@ -97,8 +118,10 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "actions: write" in rollout
     assert "Disarming automatic merge; waiting for @codex review" in rollout
     assert "disablePullRequestAutoMerge" in rollout
+    assert "((.auto_merge != null) | tostring)" in rollout
     assert "cancel-legacy-auto-merge-runs" in rollout
     assert "active_gate_runs" in rollout
+    assert '.event == "workflow_dispatch"' in rollout
     assert "group: review-gate-" in rollout
     assert "gh pr merge" not in rollout
     assert "--auto" not in rollout

--- a/tests/test_slam_history.py
+++ b/tests/test_slam_history.py
@@ -190,16 +190,16 @@ async def test_history_collector_captures_stable_complete_revision(hass) -> None
             side_effect=lambda listener: listeners.append(listener) or remove_listener
         ),
     )
-    history = SimpleNamespace(async_add=AsyncMock())
+    history_added = asyncio.Event()
+    history = SimpleNamespace(
+        async_add=AsyncMock(side_effect=lambda *_args: history_added.set())
+    )
     task = asyncio.create_task(
         async_collect_slam_history(hass, slam_map, history, lambda: None)
     )
     try:
         with patch("custom_components.matic_robot.slam_history.MAP_SETTLE_SECONDS", 0):
-            for _index in range(20):
-                if history.async_add.await_count:
-                    break
-                await asyncio.sleep(0)
+            await asyncio.wait_for(history_added.wait(), timeout=1)
         history.async_add.assert_awaited_once()
     finally:
         task.cancel()


### PR DESCRIPTION
Strengthens the manual review gate so ordinary `@codex review` evidence is evaluated separately from security-review status or availability notices. Base retargets now persist an invalidation marker, and the gate revalidates the PR immediately before stamping success. Automatic and deferred merge remain disabled; the workflows never perform a merge.

Validated with the targeted packaging policy test, Ruff, formatting, the public-tree privacy check, and actionlint.