### PR TITLE
Release 0.3.6: Matic Cues and OTA analysis

### DIFF
--- a/custom_components/matic_robot/manifest.json
+++ b/custom_components/matic_robot/manifest.json
@@ -24,7 +24,7 @@
     "numpy==2.3.2",
     "protobuf>=6"
   ],
-  "version": "0.3.5",
+  "version": "0.3.6",
   "zeroconf": [
     "_matic_hermes._tcp.local."
   ]

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,8 @@ the integration so instructions and behavior stay aligned with each release.
   discovery, passkey, room-mapping, firmware, and Bluetooth constraints.
 - [Firmware compatibility](firmware-compatibility.md) — Track observed robot
   versions, validation status, regressions, and newly discovered capabilities.
+- [Release notes — 0.3.6](release-notes-0.3.6.md) — Local Matic Cues and
+  automatic, privacy-safe OTA analysis
 - [Release notes — 0.3.5](release-notes-0.3.5.md) — Safer managed-plan stops,
   presence automation, and Map Studio recovery
 - [Release notes — 0.3.4](release-notes-0.3.4.md) — Reliable retained-device

--- a/docs/release-notes-0.3.6.md
+++ b/docs/release-notes-0.3.6.md
@@ -1,0 +1,54 @@
+# Release notes — 0.3.6
+
+Released: 2026-08-15
+
+## Summary
+
+0.3.6 brings Matic Cues to Home Assistant's local automation surface and adds
+automatic, privacy-safe analysis whenever the robot reports a new firmware or
+protocol version.
+
+## Matic Cues for local automations
+
+- A **Matic Cues** switch controls the robot's Cues setting. Voice and gesture
+  lifecycle sensors, a following-person binary sensor, and the **Matic Cues**
+  event entity expose automation-safe state between regular coordinator polls.
+- The integration reports only lifecycle stages and reviewed intent
+  classifications such as clean, pause, dock, navigate, and follow. It never
+  retains or publishes audio, transcripts, images, video, person identity, or
+  pointing coordinates. Recording-related classifications deliberately remain
+  `unknown`.
+- The live state subscription retries with bounded backoff and safely replaces a
+  failed Hermes channel. It is cancelled cleanly when the Home Assistant config
+  entry unloads, so a reload cannot leave a background Cues task behind.
+
+## Automatic firmware and protocol analysis
+
+- When a newly observed firmware or protocol version is recorded, the
+  integration automatically compares its allowlisted local Hermes endpoints
+  with the prior snapshot. The **Firmware snapshot** action remains available
+  for a deliberate repeat.
+- The analyzer records only bounded protobuf field-number and wire-type shapes
+  from explicitly approved message paths. It never stores payload values,
+  transcripts, media, coordinates, or raw protobuf data.
+- A new structural shape emits a quiet diagnostic result for advanced
+  automations and does not create a Repair or a persistent notification.
+  Repairs remain limited to endpoint availability or transport regressions.
+
+This release adds no robot motion command and keeps integration traffic,
+snapshots, analysis, and automation data local to Home Assistant.
+
+## Verification
+
+The release candidate is gated by the full Python suite at 100% coverage,
+Ruff, strict MyPy, the public-tree privacy gate, release archive inspection,
+a fresh-install import check, browser tests, HACS, Hassfest, and a clean
+exact-head regular review. The v172.9 / protocol 25 Cues lifecycle and
+value-free OTA shape sweep were also verified on a real robot.
+
+## Upgrading from 0.3.5
+
+Install 0.3.6 through HACS and restart Home Assistant. Existing entries,
+credentials, plans, custom areas, maps, cleaning history, and firmware
+snapshots are preserved. Cues remains controlled by its existing robot setting;
+review Matic's Cues privacy information before enabling it.

--- a/docs/release-notes-0.3.6.md
+++ b/docs/release-notes-0.3.6.md
@@ -28,9 +28,11 @@ protocol version.
   integration automatically compares its allowlisted local Hermes endpoints
   with the prior snapshot. The **Firmware snapshot** action remains available
   for a deliberate repeat.
-- The analyzer records only bounded protobuf field-number and wire-type shapes
-  from explicitly approved message paths. It never stores payload values,
-  transcripts, media, coordinates, or raw protobuf data.
+- Each snapshot retains endpoint reachability/status plus each key and value's
+  byte length and SHA-256 fingerprint. For explicitly approved message paths,
+  it additionally records bounded protobuf field-number and wire-type shapes.
+  It never stores payload values, transcripts, media, coordinates, or raw
+  protobuf data.
 - A new structural shape emits a quiet diagnostic result for advanced
   automations and does not create a Repair or a persistent notification.
   Repairs remain limited to endpoint availability or transport regressions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "matic-home-assistant"
-version = "0.3.5"
+version = "0.3.6"
 description = "Unofficial local-only Home Assistant integration for Matic robot vacuums"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -28,7 +28,7 @@ def test_release_versions_and_links_are_consistent() -> None:
     hacs = json.loads((ROOT / "hacs.json").read_text())
     project = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]
 
-    assert manifest["version"] == "0.3.5"
+    assert manifest["version"] == "0.3.6"
     assert project["version"] == manifest["version"]
     assert hacs["homeassistant"] == "2026.7.0"
     assert manifest["documentation"].startswith("https://github.com/")


### PR DESCRIPTION
## Release

- Bump the integration and package metadata to `0.3.6`.
- Publish user-facing notes for the already merged local Matic Cues and automatic, privacy-safe OTA analysis work.
- Keep OTA structural candidates silent for regular users; only availability or transport regressions create a Repair.

## Validation

- `pytest --cov=custom_components/matic_robot --cov-report=term-missing` — 1,007 passed, 100% coverage
- Ruff, formatting, strict MyPy, and the public-tree privacy gate
- Built wheel and source archive; artifact parity and fresh-install import passed
- 46 Playwright browser tests
- Repository-level auto-merge disabled; no open PR has an auto-merge request