### PR TITLE
Add a visible Matic referral callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ relays.
 **[Documentation](docs/README.md)** — Installation, local pairing, cleaning
 plans, automation, privacy, and troubleshooting.
 
+> **Buying a Matic?** If you are already planning to buy one, you can use the
+> [maintainer's Matic referral link](https://referrals.maticrobots.com/maticrobots/u/dbaef97f?sub=maticrobots).
+> Under Matic's current referral program, you receive an Annual Bag Pass and the
+> maintainer receives $100 in Matic store credit. Using the link is optional and
+> does not affect this independent integration. Referral benefits may change.
+
 ## Status
 
 Home Assistant 2026.7 is the tested baseline and the minimum version accepted by


### PR DESCRIPTION
## Summary

- add an optional Matic referral callout near the top of the README
- disclose the Annual Bag Pass for buyers and the maintainer's $100 store-credit benefit
- keep the referral separate from integration behavior and state that participation is optional

## Why

Make the referral easy to see in GitHub and HACS while preserving the project's independent status and clearly disclosing the maintainer benefit.

## Validation

- `.venv/bin/python scripts/check_public_tree.py`
- `git diff --check`
- confirmed the HTTPS referral URL returns HTTP 200