### PR TITLE
Restore eager room handoffs with stop-fence ownership

### DIFF
--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -917,6 +917,38 @@ async def _async_run_room(
                         hass, entity_id, room, cancel_event
                     )
                     if outcome is RoomRunOutcome.HANDOFF_CANDIDATE:
+                        next_dispatch = (
+                            await prefetch_next() if prefetch_next is not None else None
+                        )
+                        if next_dispatch is not None:
+                            # Eager handoff: the next room is commanded during
+                            # the observed return so the robot can pivot
+                            # without docking.  Prefetch refuses ownership
+                            # while an OEM stop settles or the run is being
+                            # cancelled, and the current room still needs
+                            # native verification; an unverified room stops
+                            # the started next room without history credit.
+                            await manager.async_mark_verifying(
+                                serial_number, call.data["plan_id"], room
+                            )
+                            completion_verified = await _async_verify_room_completion(
+                                session_history,
+                                history_baseline,
+                                room,
+                                dispatched_at,
+                                hass=hass,
+                                entity_id=entity_id,
+                                cancel_event=cancel_event,
+                                attempts=HANDOFF_HISTORY_ATTEMPTS,
+                                allow_active_cleaning=True,
+                            )
+                            if not completion_verified:
+                                await _async_cleanup_managed_motion(
+                                    managed_user_command,
+                                    motion_token,
+                                    dispatch_attempted=True,
+                                )
+                            break
                         session_active = await _async_active_session_state(
                             active_session
                         )
@@ -934,11 +966,10 @@ async def _async_run_room(
                                 cancel_event=cancel_event,
                             )
                             if completion_verified and prefetch_next is not None:
-                                # Handoff is intentionally sequential.  The
-                                # next room may be prepared only after the
-                                # current native session is verified, avoiding
-                                # duplicate/queued rooms when OEM STOP or
-                                # return transitions are still settling.
+                                # The eager dispatch above was unavailable;
+                                # retry once the session is verified so a
+                                # cleared stop fence or transient dispatch
+                                # error does not end the run early.
                                 await prefetch_next()
                             break
                         if session_active is None:
@@ -1902,6 +1933,7 @@ async def _async_execute_rooms(
                         or not manager.managed_motion_is_current(
                             serial_number, motion_token
                         )
+                        or _stop_is_pending(manager, serial_number)
                     ):
                         return None
                     if existing := prepared_dispatches.get(candidate.room_id):

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -277,9 +277,12 @@ Room history advances only after the managed runner positively matches the end
 of the commanded room. Returning, idle, or docked state alone is not completion:
 a low-charge return is suspended and waits for the robot's automatic resume;
 an unexplained stop receives no credit. The private protocol does not yet expose
-a verified refill-specific signal. After a verified room completion, the
-runner can send the next room before the robot reaches the dock; only the final
-room returns all the way to the dock.
+a verified refill-specific signal. When the runner observes a commanded room's
+normal return, it sends the next room immediately so the robot can pivot without
+docking, then verifies the finished room against native history while the next
+room runs. An unverified room stops that started next room and receives no
+credit, and no next room is prepared while a native stop countdown settles; only
+the final room returns all the way to the dock.
 
 Motion commands are serialized per robot. An independent Home Assistant clean,
 custom-area clean, stop, or dock revokes the managed plan before that command is

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -2653,10 +2653,10 @@ async def test_active_session_can_resume_then_end_unverified() -> None:
 
 
 @pytest.mark.parametrize("use_session_reader", [False, True])
-async def test_room_prefetch_verifies_current_history_while_next_room_starts(
+async def test_room_handoff_retries_prefetch_once_completion_is_verified(
     hass, use_session_reader: bool
 ) -> None:
-    """A return dispatches the next room before current history settles."""
+    """An unavailable eager dispatch is retried after verified completion."""
     room = _room("Kitchen", "room-kitchen")
     next_room = _room("Study", "room-study")
     manager = SimpleNamespace(
@@ -2706,7 +2706,14 @@ async def test_room_prefetch_verifies_current_history_while_next_room_starts(
             ),
         )
 
-    async def prefetch() -> _PreparedRoomDispatch:
+    prefetch_calls = 0
+
+    async def prefetch() -> _PreparedRoomDispatch | None:
+        # The eager dispatch at the observed return is unavailable once.
+        nonlocal prefetch_calls
+        prefetch_calls += 1
+        if prefetch_calls == 1:
+            return None
         hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Study"})
         return _PreparedRoomDispatch(next_room, frozenset(), dt_util.utcnow())
 
@@ -2727,14 +2734,91 @@ async def test_room_prefetch_verifies_current_history_while_next_room_starts(
     )
 
     assert completed is True
+    assert prefetch_calls == 2
     manager.async_mark_verifying.assert_awaited_once()
     manager.async_mark_completed.assert_awaited_once()
     sender.assert_not_awaited()
 
 
-async def test_room_prefetch_does_not_start_next_task_when_completion_is_unverified(
+async def test_room_handoff_dispatches_next_room_before_history_settles(hass) -> None:
+    """The next room is commanded at the observed return, before verification."""
+    room = _room("Kitchen", "room-kitchen")
+    next_room = _room("Study", "room-study")
+    manager = SimpleNamespace(
+        async_mark_started=AsyncMock(),
+        async_mark_completed=AsyncMock(),
+        async_mark_ended_unverified=AsyncMock(),
+        async_mark_verifying=AsyncMock(),
+        async_mark_failed=AsyncMock(),
+        async_mark_interrupted=AsyncMock(),
+        async_mark_suspended=AsyncMock(),
+        async_mark_resumed=AsyncMock(),
+    )
+
+    async def send_command(_call) -> None:
+        hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Kitchen"})
+
+        async def finish_room() -> None:
+            await asyncio.sleep(0)
+            hass.states.async_set(
+                "vacuum.matic",
+                "returning",
+                {"current_area": "Kitchen", "low_charge": False},
+            )
+
+        hass.async_create_task(finish_room(), eager_start=True)
+
+    hass.services.async_register("vacuum", "send_command", send_command)
+    prefetched = False
+
+    async def history() -> tuple[CleaningSessionRecord, ...]:
+        # The native record settles only after the next room is underway.
+        if not prefetched:
+            return ()
+        ended = dt_util.utcnow()
+        return (
+            CleaningSessionRecord(
+                b"kitchen",
+                CleaningSession(
+                    (ended - timedelta(seconds=5)).isoformat(),
+                    ended.isoformat(),
+                    5,
+                    ("Kitchen",),
+                    (("Kitchen", 5),),
+                    True,
+                ),
+            ),
+        )
+
+    async def prefetch() -> _PreparedRoomDispatch:
+        nonlocal prefetched
+        prefetched = True
+        hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Study"})
+        return _PreparedRoomDispatch(next_room, frozenset(), dt_util.utcnow())
+
+    sender = AsyncMock()
+    completed = await _async_run_room(
+        hass,
+        _call(hass),
+        manager,
+        "vacuum.matic",
+        "serial",
+        room,
+        session_history=history,
+        managed_user_command=sender,
+        prefetch_next=prefetch,
+    )
+
+    assert completed is True
+    assert prefetched is True
+    manager.async_mark_completed.assert_awaited_once()
+    sender.assert_not_awaited()
+
+
+async def test_room_unverified_eager_handoff_stops_the_started_next_room(
     hass,
 ) -> None:
+    """An unverified current room stops its eagerly dispatched next room."""
     room = _room("Kitchen", "room-kitchen")
     next_room = _room("Study", "room-study")
     manager = SimpleNamespace(
@@ -2783,7 +2867,7 @@ async def test_room_prefetch_does_not_start_next_task_when_completion_is_unverif
         )
 
     assert completed is False
-    sender.assert_not_awaited()
+    sender.assert_awaited_once_with(7, UserCommand.STOP)
     manager.async_mark_ended_unverified.assert_awaited_once()
     manager.async_mark_completed.assert_not_awaited()
 
@@ -3521,6 +3605,44 @@ async def test_execute_rooms_skips_prefetch_after_stop_request(hass) -> None:
         )
 
     managed_command.assert_not_awaited()
+
+
+async def test_execute_rooms_skips_prefetch_while_stop_fence_pending(hass) -> None:
+    """No next room may be prepared while an OEM stop countdown settles."""
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    rooms = [
+        _room("Kitchen", "room-kitchen"),
+        _room("Study", "room-study"),
+    ]
+    fake_hass = SimpleNamespace(
+        services=SimpleNamespace(async_call=AsyncMock()),
+        states=SimpleNamespace(
+            get=MagicMock(return_value=SimpleNamespace(state="returning"))
+        ),
+    )
+
+    async def run_room(*_args, **kwargs) -> bool:
+        manager.mark_stop_pending("serial")
+        assert await kwargs["prefetch_next"]() is None
+        return False
+
+    with patch(
+        "custom_components.matic_robot.services._async_run_room",
+        side_effect=run_room,
+    ) as run:
+        await _async_execute_rooms(
+            fake_hass,
+            _call(fake_hass),
+            manager,
+            "vacuum.matic",
+            "serial",
+            rooms,
+            intelligent=False,
+        )
+
+    run.assert_awaited_once()
+    fake_hass.services.async_call.assert_not_awaited()
 
 
 async def test_execute_rooms_stops_after_unverified_room(hass) -> None:


### PR DESCRIPTION
## Summary

Since 0.3.5 made room-to-room handoff sequential, the robot docks and idles for minutes between managed plan rooms while Home Assistant waits for the native session to close and its history record to verify. This restores the pre-0.3.5 no-dock transitions using the ownership machinery 0.3.5 itself introduced.

- At an observed normal return (`HANDOFF_CANDIDATE`), the next room is dispatched immediately so the robot pivots without docking.
- `prefetch_next` now refuses ownership while an OEM stop countdown settles (`_stop_is_pending`), alongside the existing cancellation, finish-current-room, and motion-generation guards. This is the fence that did not exist in 0.3.4 and whose absence motivated the sequential change.
- The finished room is verified against native history concurrently (`HANDOFF_HISTORY_ATTEMPTS`, `allow_active_cleaning`). An unverified room STOPs the eagerly started next room and ends the plan without history credit; the STOP sets the stop fence so firmware owns the graceful return.
- The sequential verify-then-dispatch path is preserved as the fallback whenever eager dispatch is unavailable, including a post-verify retry so a cleared fence or transient dispatch error does not end the run early.

## Rotation safety invariants preserved

- History credit still requires the strict native single-room record (mode status 2, exact dispatch identity, positive duration).
- Unverified, failed, cancelled, and interrupted rooms remain uncredited but keep their last-opportunity ordering.
- No next room is prepared while a native stop settles; DOCK after cleanup remains suppressed while the fence is pending.

## Testing

- New: eager dispatch before history settles; unverified eager handoff stops the started next room; prefetch refused while the stop fence is pending; unavailable eager dispatch retried after verified completion (both session-reader paths).
- 1009 tests pass at 100.00% coverage; Ruff check/format, strict MyPy, and the public-tree privacy scan pass.