### PR TITLE
Add switchable Claude/Codex review provider

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,68 @@
+name: Claude Review
+
+# Runs only when the repository variable REVIEW_PROVIDER is "claude"; the
+# review-gate workflows read the same variable to decide which bot identity
+# satisfies the gate, so switching providers is one variable flip with the
+# Codex flow as the unset default.
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  review:
+    name: claude-review
+    if: >-
+      vars.REVIEW_PROVIDER == 'claude'
+      && github.event.pull_request.draft == false
+    runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+      - uses: anthropics/claude-code-action@5ee796a55f92566ecd7e39d70dd613abcbea0d7c # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: >-
+            --allowedTools "Read,Grep,Glob,LS,Bash(gh pr diff:*),Bash(gh pr
+            view:*),Bash(gh api:*)"
+          prompt: |
+            You are this repository's regular review gate. Review pull request
+            #${{ github.event.pull_request.number }} of
+            ${{ github.repository }} at exactly head commit
+            ${{ github.event.pull_request.head.sha }}.
+
+            Read the full diff with `gh pr diff`, open any file you need, and
+            hold the change to this repository's bar (CLAUDE.md and
+            CONTRIBUTING.md): correctness bugs first; privacy (no credentials,
+            serials, addresses, captures, maps, or Home Assistant storage
+            contents); protocol safety (no command from a guessed enum or
+            payload); rotation and completion-evidence invariants; and test
+            adequacy for changed behavior. Review only — never edit files,
+            push commits, approve, or request changes.
+
+            When done, post exactly one pull request review by running:
+
+            gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews -f commit_id=${{ github.event.pull_request.head.sha }} -f event=COMMENT -f body="$BODY"
+
+            If the change has no blocking findings, $BODY must be exactly the
+            following two lines and nothing else before or after:
+
+            ## Review result: No issues found.
+
+            **Reviewed commit:** `${{ github.event.pull_request.head.sha }}`
+
+            If there are blocking findings, $BODY must start with the heading
+            `## Review result: findings`, followed by the line
+            **Reviewed commit:** `${{ github.event.pull_request.head.sha }}`
+            and then a numbered list giving file:line, the defect, and a
+            concrete failure scenario for every finding. If you cannot
+            complete the review, post nothing.

--- a/.github/workflows/review-fork-regular-review.yml
+++ b/.github/workflows/review-fork-regular-review.yml
@@ -93,7 +93,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ needs.route.outputs.pr_number }}
           REPO: ${{ github.repository }}
-          REVIEW_BOT_EVENT_LOGIN: chatgpt-codex-connector[bot]
+          REVIEW_BOT_EVENT_LOGIN: ${{ vars.REVIEW_PROVIDER == 'claude' && 'claude[bot]' || 'chatgpt-codex-connector[bot]' }}
           REVIEW_GATE_CONTEXT: review-gate
           REVIEW_ID: ${{ needs.route.outputs.review_id }}
           REVIEW_REVIEW_CONTEXT: review-gate-regular-review

--- a/.github/workflows/review-gate-audit.yml
+++ b/.github/workflows/review-gate-audit.yml
@@ -63,8 +63,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ matrix.pr_number }}
           REPO: ${{ github.repository }}
-          REVIEW_BOT_LOGIN: chatgpt-codex-connector
-          REVIEW_BOT_EVENT_LOGIN: chatgpt-codex-connector[bot]
+          REVIEW_BOT_LOGIN: ${{ vars.REVIEW_PROVIDER == 'claude' && 'claude' || 'chatgpt-codex-connector' }}
+          REVIEW_BOT_EVENT_LOGIN: ${{ vars.REVIEW_PROVIDER == 'claude' && 'claude[bot]' || 'chatgpt-codex-connector[bot]' }}
           REVIEW_GATE_CONTEXT: review-gate
           WORKFLOW_REF: ${{ github.event.repository.default_branch }}
         run: |

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -43,9 +43,9 @@ jobs:
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           REPO: ${{ github.repository }}
-          REVIEW_BOT: chatgpt-codex-connector[bot]
-          REVIEW_BOT_LOGIN: chatgpt-codex-connector
-          REVIEW_BOT_EVENT_LOGIN: chatgpt-codex-connector[bot]
+          REVIEW_BOT: ${{ vars.REVIEW_PROVIDER == 'claude' && 'claude[bot]' || 'chatgpt-codex-connector[bot]' }}
+          REVIEW_BOT_LOGIN: ${{ vars.REVIEW_PROVIDER == 'claude' && 'claude' || 'chatgpt-codex-connector' }}
+          REVIEW_BOT_EVENT_LOGIN: ${{ vars.REVIEW_PROVIDER == 'claude' && 'claude[bot]' || 'chatgpt-codex-connector[bot]' }}
           REVIEW_GATE_CONTEXT: review-gate
           REVIEW_BASE_CONTEXT: review-gate-base-change
           REVIEW_COMMENT_CONTEXT: review-gate-regular-comment

--- a/.github/workflows/review-regular-comment.yml
+++ b/.github/workflows/review-regular-comment.yml
@@ -34,7 +34,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
-          REVIEW_BOT_EVENT_LOGIN: chatgpt-codex-connector[bot]
+          REVIEW_BOT_EVENT_LOGIN: ${{ vars.REVIEW_PROVIDER == 'claude' && 'claude[bot]' || 'chatgpt-codex-connector[bot]' }}
           REVIEW_COMMENT_CONTEXT: review-gate-regular-comment
           REVIEW_GATE_CONTEXT: review-gate
         run: |

--- a/.github/workflows/review-regular-review.yml
+++ b/.github/workflows/review-regular-review.yml
@@ -35,7 +35,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
-          REVIEW_BOT_EVENT_LOGIN: chatgpt-codex-connector[bot]
+          REVIEW_BOT_EVENT_LOGIN: ${{ vars.REVIEW_PROVIDER == 'claude' && 'claude[bot]' || 'chatgpt-codex-connector[bot]' }}
           REVIEW_GATE_CONTEXT: review-gate
           REVIEW_REVIEW_CONTEXT: review-gate-regular-review
         run: |

--- a/custom_components/matic_robot/manifest.json
+++ b/custom_components/matic_robot/manifest.json
@@ -24,7 +24,7 @@
     "numpy==2.3.2",
     "protobuf>=6"
   ],
-  "version": "0.3.7",
+  "version": "0.3.8",
   "zeroconf": [
     "_matic_hermes._tcp.local."
   ]

--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -813,20 +813,44 @@ class CleaningPlanManager:
         await self._async_save_and_notify(serial_number)
 
     async def async_mark_completed(
-        self, serial_number: str, plan_id: str, room: CleaningRoom
+        self,
+        serial_number: str,
+        plan_id: str,
+        room: CleaningRoom,
+        *,
+        completed_at: str | None = None,
+        duration_seconds: int | None = None,
     ) -> None:
-        """Advance room history only after the room finishes."""
+        """Advance room history only after the room finishes.
+
+        Native record evidence (``completed_at``/``duration_seconds``) takes
+        precedence over wall-clock tracking so one multi-room leg mission can
+        credit each verified room with the robot's own per-room timing.
+        """
         now_value = dt_util.utcnow()
-        now = now_value.isoformat()
+        now = (
+            completed_at
+            if completed_at is not None
+            and _latest_timestamp(completed_at, now=now_value) is not None
+            else now_value.isoformat()
+        )
         record = self._room(serial_number, plan_id, room)
         active = self._robot(serial_number).get("active_plan")
-        duration = (
-            _active_elapsed_seconds(active, now_value)
-            if active is not None
-            and active.get("plan_id") == plan_id
-            and active.get("room_id") == room.room_id
-            else None
-        )
+        duration: int | None
+        if (
+            isinstance(duration_seconds, int)
+            and not isinstance(duration_seconds, bool)
+            and duration_seconds > 0
+        ):
+            duration = duration_seconds
+        else:
+            duration = (
+                _active_elapsed_seconds(active, now_value)
+                if active is not None
+                and active.get("plan_id") == plan_id
+                and active.get("room_id") == room.room_id
+                else None
+            )
         if duration is not None and duration > 0:
             samples = _stored_count(record, "duration_samples") + 1
             history = _duration_history(record)

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
 from contextlib import asynccontextmanager
 from copy import deepcopy
 from dataclasses import dataclass
@@ -109,15 +109,37 @@ class RoomRunOutcome(StrEnum):
     SUSPENDED = "suspended"
     PAUSED = "paused"
     INTERRUPTED = "interrupted"
+    ROOM_CHANGED = "room_changed"
 
 
 @dataclass(frozen=True, slots=True)
 class _PreparedRoomDispatch:
-    """Describe a next-room command issued during the prior room's return."""
+    """Describe a next-leg command issued during the prior leg's return."""
 
-    room: CleaningRoom
+    rooms: tuple[CleaningRoom, ...]
     history_baseline: frozenset[bytes] | None
     dispatched_at: datetime
+
+
+def _leg_groups(rooms: Sequence[CleaningRoom]) -> list[list[CleaningRoom]]:
+    """Group consecutive rooms sharing one mission's mode and coverage.
+
+    Firmware glides room to room inside one mission without docking, but a
+    mission carries exactly one cleaning mode and coverage pair, so a
+    settings change starts a new leg.
+    """
+    groups: list[list[CleaningRoom]] = []
+    for room in rooms:
+        previous = groups[-1][-1] if groups else None
+        if (
+            previous is not None
+            and previous.cleaning_mode == room.cleaning_mode
+            and previous.coverage_setting == room.coverage_setting
+        ):
+            groups[-1].append(room)
+        else:
+            groups.append([room])
+    return groups
 
 
 @dataclass(frozen=True, slots=True)
@@ -787,22 +809,23 @@ async def async_register_services(hass: HomeAssistant) -> None:
     )
 
 
-async def _async_dispatch_room_command(
+async def _async_dispatch_leg_command(
     hass: HomeAssistant,
     call: ServiceCall,
     entity_id: str,
-    room: CleaningRoom,
+    rooms: Sequence[CleaningRoom],
     motion_token: int | None,
     session_history: Callable[[], Awaitable[tuple[CleaningSessionRecord, ...]]] | None,
 ) -> _PreparedRoomDispatch:
-    """Issue one owned room command with its completion-history baseline."""
+    """Issue one owned leg mission with its completion-history baseline."""
+    leg = tuple(rooms)
     history_baseline = await _async_session_history_baseline(session_history)
     dispatched_at = dt_util.utcnow()
     params: dict[str, Any] = {
-        "rooms": [room.room_id],
-        "cleaning_mode": room.cleaning_mode,
-        "coverage": room.coverage_setting,
-        "ordered": False,
+        "rooms": [room.room_id for room in leg],
+        "cleaning_mode": leg[0].cleaning_mode,
+        "coverage": leg[0].coverage_setting,
+        "ordered": len(leg) > 1,
     }
     if motion_token is not None:
         params[PLAN_MOTION_TOKEN] = motion_token
@@ -817,7 +840,7 @@ async def _async_dispatch_room_command(
         blocking=True,
         context=call.context,
     )
-    return _PreparedRoomDispatch(room, history_baseline, dispatched_at)
+    return _PreparedRoomDispatch(leg, history_baseline, dispatched_at)
 
 
 async def _async_run_room(
@@ -865,16 +888,16 @@ async def _async_run_room(
     try:
         if dispatch is None:
             dispatch_attempted = True
-            dispatch = await _async_dispatch_room_command(
+            dispatch = await _async_dispatch_leg_command(
                 hass,
                 call,
                 entity_id,
-                room,
+                [room],
                 motion_token,
                 session_history,
             )
         else:
-            if dispatch.room != room:
+            if dispatch.rooms != (room,):
                 raise ValueError("prepared room dispatch does not match the room")
             dispatch_attempted = True
         history_baseline = dispatch.history_baseline
@@ -1229,6 +1252,448 @@ async def _async_run_room(
     return completion_verified
 
 
+async def _async_run_leg(
+    hass: HomeAssistant,
+    call: ServiceCall,
+    manager: CleaningPlanManager,
+    entity_id: str,
+    serial_number: str,
+    rooms: Sequence[CleaningRoom],
+    cancel_event: asyncio.Event | None = None,
+    refresh: Callable[[], Awaitable[None]] | None = None,
+    motion_token: int | None = None,
+    active_session: Callable[[], Awaitable[bool | None]] | None = None,
+    session_history: Callable[[], Awaitable[tuple[CleaningSessionRecord, ...]]]
+    | None = None,
+    confirm_room_completed: Callable[[str], None] | None = None,
+    managed_user_command: Callable[[int, UserCommand], Awaitable[None]] | None = None,
+    room_name_is_unique: bool = True,
+    prepared_dispatch: _PreparedRoomDispatch | None = None,
+    prefetch_next: Callable[[], Awaitable[_PreparedRoomDispatch | None]] | None = None,
+    finish_room_event: asyncio.Event | None = None,
+) -> bool:
+    """Run one mission leg and credit only natively verified rooms.
+
+    A leg is one native multi-room mission, so the robot glides room to room
+    without docking.  Rotation credit still comes only from the leg's single
+    native history record: each verified room is credited with the robot's
+    own per-room duration, and everything else stays due.
+    """
+    leg = list(rooms)
+    if len(leg) == 1:
+        return await _async_run_room(
+            hass,
+            call,
+            manager,
+            entity_id,
+            serial_number,
+            leg[0],
+            cancel_event,
+            refresh,
+            motion_token,
+            active_session,
+            session_history,
+            confirm_room_completed,
+            managed_user_command,
+            room_name_is_unique=room_name_is_unique,
+            prepared_dispatch=prepared_dispatch,
+            prefetch_next=prefetch_next,
+        )
+    if not room_name_is_unique:
+        raise _validation_error(
+            "Managed completion cannot distinguish duplicate mapped room names",
+            "ambiguous_room_name",
+            {"room": ", ".join(room.name for room in leg)},
+        )
+
+    def event_data(room: CleaningRoom) -> dict[str, Any]:
+        return {
+            ATTR_ENTITY_ID: entity_id,
+            "plan_id": call.data["plan_id"],
+            "room_id": room.room_id,
+            "room": room.name,
+            "cleaning_mode": room.cleaning_mode,
+            "coverage_setting": room.coverage_setting,
+        }
+
+    active_room = leg[0]
+    observed_ids = {active_room.room_id}
+    await manager.async_mark_started(serial_number, call.data["plan_id"], active_room)
+    hass.bus.async_fire(
+        f"{DOMAIN}_room_started", event_data(active_room), context=call.context
+    )
+    dispatch_attempted = False
+    stop_sent = False
+    next_dispatch: _PreparedRoomDispatch | None = None
+    evidence: dict[str, tuple[str, int]] | None = None
+    dispatch: _PreparedRoomDispatch | None = prepared_dispatch
+    try:
+        if dispatch is None:
+            dispatch_attempted = True
+            dispatch = await _async_dispatch_leg_command(
+                hass,
+                call,
+                entity_id,
+                leg,
+                motion_token,
+                session_history,
+            )
+        else:
+            if dispatch.rooms != tuple(leg):
+                raise ValueError("prepared leg dispatch does not match the leg")
+            dispatch_attempted = True
+        history_baseline = dispatch.history_baseline
+        dispatched_at = dispatch.dispatched_at
+        try:
+            start_state = await _async_wait_for_vacuum_state(
+                hass,
+                entity_id,
+                {"cleaning", "paused"},
+                call.data["start_timeout"],
+                cancel_event,
+                leg,
+            )
+        except TimeoutError as err:
+            raise RoomStartTimeoutError from err
+        if start_state == "paused":
+            await manager.async_mark_suspended(
+                serial_number, call.data["plan_id"], active_room, "paused"
+            )
+            await _async_wait_for_vacuum_state(
+                hass,
+                entity_id,
+                {"cleaning"},
+                call.data["completion_timeout"],
+                cancel_event,
+                leg,
+            )
+        await manager.async_mark_resumed(
+            serial_number, call.data["plan_id"], active_room
+        )
+        refresh_task = (
+            asyncio.create_task(_async_periodic_refresh(refresh))
+            if refresh is not None
+            else None
+        )
+        try:
+            async with asyncio.timeout(call.data["completion_timeout"]):
+                while True:
+                    outcome, changed_room = await _async_wait_for_leg_outcome(
+                        hass,
+                        entity_id,
+                        leg,
+                        active_room,
+                        cancel_event,
+                        initial_observed=True,
+                    )
+                    if outcome is RoomRunOutcome.ROOM_CHANGED:
+                        assert changed_room is not None
+                        if finish_room_event is not None and finish_room_event.is_set():
+                            # A finish-current-room stop cannot withhold the
+                            # next dispatch inside one native mission, so the
+                            # observed room boundary is where the managed STOP
+                            # honors it.
+                            await _async_cleanup_managed_motion(
+                                managed_user_command,
+                                motion_token,
+                                dispatch_attempted=True,
+                            )
+                            stop_sent = True
+                            continue
+                        active_room = changed_room
+                        observed_ids.add(active_room.room_id)
+                        await manager.async_mark_started(
+                            serial_number, call.data["plan_id"], active_room
+                        )
+                        hass.bus.async_fire(
+                            f"{DOMAIN}_room_started",
+                            event_data(active_room),
+                            context=call.context,
+                        )
+                        await manager.async_mark_resumed(
+                            serial_number, call.data["plan_id"], active_room
+                        )
+                        continue
+                    if outcome is RoomRunOutcome.HANDOFF_CANDIDATE:
+                        if prefetch_next is not None and not stop_sent:
+                            next_dispatch = await prefetch_next()
+                        await manager.async_mark_verifying(
+                            serial_number, call.data["plan_id"], active_room
+                        )
+                        evidence = await _async_verify_leg_completion(
+                            session_history,
+                            history_baseline,
+                            leg,
+                            dispatched_at,
+                            hass=hass,
+                            entity_id=entity_id,
+                            cancel_event=cancel_event,
+                            attempts=(
+                                HANDOFF_HISTORY_ATTEMPTS
+                                if next_dispatch is not None
+                                else SESSION_HISTORY_ATTEMPTS
+                            ),
+                            allow_active_cleaning=next_dispatch is not None,
+                        )
+                        break
+                    # INTERRUPTED cannot occur here: the leg loop starts only
+                    # after a confirmed in-room start, so the waiter is seeded
+                    # with that observation.
+                    suspend_reason = (
+                        "paused" if outcome is RoomRunOutcome.PAUSED else "low_charge"
+                    )
+                    await manager.async_mark_suspended(
+                        serial_number,
+                        call.data["plan_id"],
+                        active_room,
+                        suspend_reason,
+                    )
+                    await _async_wait_for_vacuum_state(
+                        hass,
+                        entity_id,
+                        {"cleaning"},
+                        call.data["completion_timeout"],
+                        cancel_event,
+                        leg,
+                    )
+                    await manager.async_mark_resumed(
+                        serial_number, call.data["plan_id"], active_room
+                    )
+        finally:
+            if refresh_task is not None:
+                refresh_task.cancel()
+                await asyncio.gather(refresh_task, return_exceptions=True)
+    except ManagedMotionReplacedError as err:
+        await manager.async_mark_cancelled(
+            serial_number, call.data["plan_id"], active_room
+        )
+        hass.bus.async_fire(
+            f"{DOMAIN}_room_cancelled", event_data(active_room), context=call.context
+        )
+        raise PlanCancelledError from err
+    except PlanCancelledError:
+        if manager.cancellation_reason(serial_number) == "config_entry_unload":
+            await _async_cleanup_managed_motion(
+                managed_user_command,
+                motion_token,
+                dispatch_attempted,
+            )
+            await manager.async_mark_interrupted(
+                serial_number,
+                call.data["plan_id"],
+                active_room,
+                "Home Assistant unloaded while cleaning this room",
+            )
+            hass.bus.async_fire(
+                f"{DOMAIN}_room_interrupted",
+                event_data(active_room),
+                context=call.context,
+            )
+        else:
+            await manager.async_mark_cancelled(
+                serial_number, call.data["plan_id"], active_room
+            )
+            hass.bus.async_fire(
+                f"{DOMAIN}_room_cancelled",
+                event_data(active_room),
+                context=call.context,
+            )
+        raise
+    except RoomTakenOverError as err:
+        await manager.async_mark_interrupted(
+            serial_number, call.data["plan_id"], active_room, str(err)
+        )
+        hass.bus.async_fire(
+            f"{DOMAIN}_room_interrupted",
+            {**event_data(active_room), "error": str(err)},
+            context=call.context,
+        )
+        raise _validation_error(
+            "The managed room was replaced by another cleaning task",
+            "room_taken_over",
+            {"room": active_room.name},
+        ) from err
+    except (TimeoutError, HomeAssistantError, MaticError) as err:
+        await _async_cleanup_managed_motion(
+            managed_user_command,
+            motion_token,
+            dispatch_attempted,
+        )
+        if isinstance(err, RoomStartTimeoutError):
+            failure_reason = "The robot did not begin cleaning before the start timeout"
+        elif isinstance(err, TimeoutError):
+            failure_reason = "The managed room exceeded its completion timeout"
+        elif isinstance(err, MaticError):
+            failure_reason = "The robot could not complete the managed room"
+        else:
+            failure_reason = str(err).strip() or "The managed room failed"
+        await manager.async_mark_failed(
+            serial_number, call.data["plan_id"], active_room, failure_reason
+        )
+        hass.bus.async_fire(
+            f"{DOMAIN}_room_failed",
+            {**event_data(active_room), "error": failure_reason},
+            context=call.context,
+        )
+        if isinstance(err, ServiceValidationError):
+            raise
+        if isinstance(err, RoomStartTimeoutError):
+            raise _validation_error(
+                f"The robot did not begin cleaning {active_room.name} before the "
+                "start timeout",
+                "plan_start_timeout",
+                {"room": active_room.name},
+            ) from err
+        if isinstance(err, MaticError):
+            raise _validation_error(
+                "The robot could not complete the managed room",
+                "robot_command_failed",
+                {"room": active_room.name},
+            ) from err
+        if isinstance(err, TimeoutError):
+            raise _validation_error(
+                f"Timed out while cleaning {active_room.name}",
+                "plan_timeout",
+                {"room": active_room.name},
+            ) from err
+        raise
+
+    credited = evidence or {}
+    for room in leg:
+        if room.room_id in credited:
+            completed_at, duration_seconds = credited[room.room_id]
+            await manager.async_mark_completed(
+                serial_number,
+                call.data["plan_id"],
+                room,
+                completed_at=completed_at,
+                duration_seconds=duration_seconds,
+            )
+            if confirm_room_completed is not None:
+                confirm_room_completed(room.name)
+            hass.bus.async_fire(
+                f"{DOMAIN}_room_completed", event_data(room), context=call.context
+            )
+        elif stop_sent and room.room_id not in observed_ids:
+            await manager.async_mark_cancelled(
+                serial_number, call.data["plan_id"], room
+            )
+            hass.bus.async_fire(
+                f"{DOMAIN}_room_cancelled", event_data(room), context=call.context
+            )
+        else:
+            await manager.async_mark_ended_unverified(
+                serial_number, call.data["plan_id"], room
+            )
+            hass.bus.async_fire(
+                f"{DOMAIN}_room_ended_unverified",
+                event_data(room),
+                context=call.context,
+            )
+    all_verified = all(room.room_id in credited for room in leg)
+    if not all_verified and next_dispatch is not None:
+        await _async_cleanup_managed_motion(
+            managed_user_command,
+            motion_token,
+            dispatch_attempted=True,
+        )
+    return all_verified
+
+
+async def _async_verify_leg_completion(
+    reader: Callable[[], Awaitable[tuple[CleaningSessionRecord, ...]]] | None,
+    baseline: frozenset[bytes] | None,
+    rooms: Sequence[CleaningRoom],
+    dispatched_at: datetime,
+    *,
+    hass: HomeAssistant | None = None,
+    entity_id: str | None = None,
+    cancel_event: asyncio.Event | None = None,
+    attempts: int = SESSION_HISTORY_ATTEMPTS,
+    allow_active_cleaning: bool = False,
+) -> dict[str, tuple[str, int]] | None:
+    """Match one new native leg record and return per-room completion evidence.
+
+    The returned mapping holds ``room_id -> (ended_at, duration_seconds)`` for
+    every leg room the record marks completed with a positive duration.  A
+    missing or ambiguous record returns ``None`` and credits nothing.
+    """
+    if reader is None or baseline is None:
+        return None
+    targets = {room.name.strip().casefold(): room.room_id for room in rooms}
+    for attempt in range(attempts):
+        _raise_if_completion_verification_was_replaced(
+            hass,
+            entity_id,
+            cancel_event,
+            allow_active_cleaning=allow_active_cleaning,
+        )
+        try:
+            records = await reader()
+        except MaticError as err:
+            _LOGGER.debug(
+                "Native Matic leg evidence unavailable (%s)", type(err).__name__
+            )
+            records = ()
+        _raise_if_completion_verification_was_replaced(
+            hass,
+            entity_id,
+            cancel_event,
+            allow_active_cleaning=allow_active_cleaning,
+        )
+        now = dt_util.utcnow()
+        matches: list[CleaningSessionRecord] = []
+        for record in records:
+            session = record.session
+            if record.key in baseline:
+                continue
+            started = dt_util.parse_datetime(session.started_at or "")
+            ended = dt_util.parse_datetime(session.ended_at or "")
+            if started is None or ended is None or started > ended:
+                continue
+            if ended < dispatched_at or started > now or ended > now:
+                continue
+            names = [name.strip().casefold() for name in session.rooms]
+            if not names or any(name not in targets for name in names):
+                continue
+            matches.append(record)
+        if len(matches) == 1:
+            session = matches[0].session
+            ended_at = session.ended_at
+            assert isinstance(ended_at, str)
+            durations = {
+                name.strip().casefold(): duration
+                for name, duration in session.room_durations
+            }
+            completed_names = {
+                name.strip().casefold() for name in session.completed_rooms
+            }
+            evidence: dict[str, tuple[str, int]] = {}
+            for name, room_id in targets.items():
+                duration = durations.get(name)
+                if (
+                    name in completed_names
+                    and isinstance(duration, int)
+                    and not isinstance(duration, bool)
+                    and duration > 0
+                ):
+                    evidence[room_id] = (ended_at, duration)
+            return evidence
+        if len(matches) > 1:
+            return None
+        if attempt + 1 < attempts:
+            if cancel_event is None:
+                await asyncio.sleep(SESSION_HISTORY_RETRY_SECONDS)
+            else:
+                try:
+                    async with asyncio.timeout(SESSION_HISTORY_RETRY_SECONDS):
+                        await cancel_event.wait()
+                except TimeoutError:
+                    continue
+                raise PlanCancelledError
+    return None
+
+
 async def _async_wait_for_room_outcome(
     hass: HomeAssistant,
     entity_id: str,
@@ -1243,19 +1708,56 @@ async def _async_wait_for_room_outcome(
     suspension so firmware may recharge and resume it.  Every other terminal
     transition is interrupted/unknown and receives no room-history credit.
     """
-    observed_room = False
-    future: asyncio.Future[RoomRunOutcome] = hass.loop.create_future()
+    outcome, _changed = await _async_wait_for_leg_outcome(
+        hass, entity_id, [room], room, cancel_event
+    )
+    return outcome
+
+
+async def _async_wait_for_leg_outcome(
+    hass: HomeAssistant,
+    entity_id: str,
+    rooms: Sequence[CleaningRoom],
+    active_room: CleaningRoom,
+    cancel_event: asyncio.Event | None = None,
+    *,
+    initial_observed: bool = False,
+) -> tuple[RoomRunOutcome, CleaningRoom | None]:
+    """Classify the next leg transition using positive room evidence.
+
+    Inside one multi-room mission the robot glides between rooms without a
+    terminal state change, so observing ``current_area`` move to another leg
+    room is itself an event.  Terminal classification matches the single-room
+    contract: completion requires an observed leg room before a normal return
+    and a low-charge return is a suspension.
+    """
+    leg = tuple(rooms)
+    observed_any = initial_observed
+    future: asyncio.Future[tuple[RoomRunOutcome, CleaningRoom | None]] = (
+        hass.loop.create_future()
+    )
 
     def classify(state: Any) -> None:
-        nonlocal observed_room
+        nonlocal observed_any
         if state is None or future.done():
             return
         current_area = state.attributes.get("current_area")
         if state.state in {"cleaning", "paused"}:
-            if _area_matches_room(current_area, room):
-                observed_room = True
+            matched = next(
+                (
+                    candidate
+                    for candidate in leg
+                    if _area_matches_room(current_area, candidate)
+                ),
+                None,
+            )
+            if matched is not None:
+                observed_any = True
+                if matched.room_id != active_room.room_id and state.state == "cleaning":
+                    future.set_result((RoomRunOutcome.ROOM_CHANGED, matched))
+                    return
             if state.state == "paused":
-                future.set_result(RoomRunOutcome.PAUSED)
+                future.set_result((RoomRunOutcome.PAUSED, None))
                 return
         if state.state == "error":
             future.set_exception(
@@ -1265,16 +1767,16 @@ async def _async_wait_for_room_outcome(
             )
         elif state.state == "returning":
             if state.attributes.get("low_charge") is True:
-                future.set_result(RoomRunOutcome.SUSPENDED)
-            elif observed_room:
-                future.set_result(RoomRunOutcome.HANDOFF_CANDIDATE)
+                future.set_result((RoomRunOutcome.SUSPENDED, None))
+            elif observed_any:
+                future.set_result((RoomRunOutcome.HANDOFF_CANDIDATE, None))
             else:
-                future.set_result(RoomRunOutcome.INTERRUPTED)
+                future.set_result((RoomRunOutcome.INTERRUPTED, None))
         elif state.state in {"docked", "idle"}:
             future.set_result(
-                RoomRunOutcome.HANDOFF_CANDIDATE
-                if observed_room
-                else RoomRunOutcome.INTERRUPTED
+                (RoomRunOutcome.HANDOFF_CANDIDATE, None)
+                if observed_any
+                else (RoomRunOutcome.INTERRUPTED, None)
             )
 
     @callback
@@ -1794,7 +2296,7 @@ async def _async_wait_for_vacuum_state(
     desired: set[str],
     timeout_seconds: int,
     cancel_event: asyncio.Event | None = None,
-    room: CleaningRoom | None = None,
+    room: CleaningRoom | Sequence[CleaningRoom] | None = None,
 ) -> str:
     """Wait for an expected state and optional target-room confirmation.
 
@@ -1806,10 +2308,17 @@ async def _async_wait_for_vacuum_state(
     ``current_area`` identifies the commanded room.
     """
 
+    room_list: tuple[CleaningRoom, ...] | None = None
+    if room is not None:
+        room_list = (room,) if isinstance(room, CleaningRoom) else tuple(room)
+
     def desired_state(state: Any) -> bool:
         return state.state in desired and (
-            room is None
-            or _area_matches_room(state.attributes.get("current_area"), room)
+            room_list is None
+            or any(
+                _area_matches_room(state.attributes.get("current_area"), candidate)
+                for candidate in room_list
+            )
         )
 
     failed = {"error"}
@@ -1914,17 +2423,18 @@ async def _async_execute_rooms(
                 if intelligent
                 else rooms
             )
+            legs = _leg_groups(chosen)
             prepared_dispatches: dict[str, _PreparedRoomDispatch] = {}
-            for index, room in enumerate(chosen):
+            for index, leg in enumerate(legs):
                 if cancel_event.is_set() or not manager.managed_motion_is_current(
                     serial_number, motion_token
                 ):
                     raise PlanCancelledError
-                prepared_dispatch = prepared_dispatches.pop(room.room_id, None)
-                next_room = chosen[index + 1] if index + 1 < len(chosen) else None
+                prepared_dispatch = prepared_dispatches.pop(leg[0].room_id, None)
+                next_leg = legs[index + 1] if index + 1 < len(legs) else None
 
                 async def prefetch_next(
-                    candidate: CleaningRoom | None = next_room,
+                    candidate: list[CleaningRoom] | None = next_leg,
                 ) -> _PreparedRoomDispatch | None:
                     if (
                         candidate is None
@@ -1936,10 +2446,10 @@ async def _async_execute_rooms(
                         or _stop_is_pending(manager, serial_number)
                     ):
                         return None
-                    if existing := prepared_dispatches.get(candidate.room_id):
+                    if existing := prepared_dispatches.get(candidate[0].room_id):
                         return existing
                     try:
-                        dispatched = await _async_dispatch_room_command(
+                        dispatched = await _async_dispatch_leg_command(
                             hass,
                             call,
                             entity_id,
@@ -1953,16 +2463,16 @@ async def _async_execute_rooms(
                             type(err).__name__,
                         )
                         return None
-                    prepared_dispatches[candidate.room_id] = dispatched
+                    prepared_dispatches[candidate[0].room_id] = dispatched
                     return dispatched
 
-                completion_verified = await _async_run_room(
+                completion_verified = await _async_run_leg(
                     hass,
                     call,
                     manager,
                     entity_id,
                     serial_number,
-                    room,
+                    leg,
                     cancel_event,
                     refresh,
                     motion_token,
@@ -1972,14 +2482,18 @@ async def _async_execute_rooms(
                     managed_user_command,
                     room_name_is_unique=(
                         not mapped_room_names
-                        or sum(
-                            name.strip().casefold() == room.name.strip().casefold()
-                            for name in mapped_room_names
+                        or all(
+                            sum(
+                                name.strip().casefold() == room.name.strip().casefold()
+                                for name in mapped_room_names
+                            )
+                            == 1
+                            for room in leg
                         )
-                        == 1
                     ),
                     prepared_dispatch=prepared_dispatch,
-                    prefetch_next=prefetch_next if next_room is not None else None,
+                    prefetch_next=prefetch_next if next_leg is not None else None,
+                    finish_room_event=finish_room_event,
                 )
                 if not completion_verified:
                     break

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -277,12 +277,17 @@ Room history advances only after the managed runner positively matches the end
 of the commanded room. Returning, idle, or docked state alone is not completion:
 a low-charge return is suspended and waits for the robot's automatic resume;
 an unexplained stop receives no credit. The private protocol does not yet expose
-a verified refill-specific signal. When the runner observes a commanded room's
-normal return, it sends the next room immediately so the robot can pivot without
-docking, then verifies the finished room against native history while the next
-room runs. An unverified room stops that started next room and receives no
-credit, and no next room is prepared while a native stop countdown settles; only
-the final room returns all the way to the dock.
+a verified refill-specific signal. Consecutive rooms that share one cleaning
+mode and coverage run as a single native mission (a leg), so the robot glides
+room to room without docking. Room history still advances per room from the
+leg's one native record: a room is credited only with its own completed status
+and a positive duration, partial legs credit exactly their verified subset, and
+everything else stays due. Between legs — current firmware queues a command
+sent during a return — the runner dispatches the next leg at the observed
+return and the robot briefly touches the dock. An unverified leg stops any
+started next leg and receives no further credit, no next leg is prepared while
+a native stop countdown settles, and only the final leg returns all the way to
+the dock.
 
 Motion commands are serialized per robot. An independent Home Assistant clean,
 custom-area clean, stop, or dock revokes the managed plan before that command is
@@ -297,8 +302,9 @@ coverage. Compatible samples are shared across plans on the same robot, so a new
 plan does not need to relearn an unchanged room. Stored aggregate duration data
 from earlier integration versions remains usable only when it represents at
 least three successful runs. A stop below the configured threshold remains
-immediate; at or above it, the current room completes, the next room is never
-started, and the robot docks. Until a confident compatible duration exists,
+immediate; at or above it, the current room completes and the robot docks: the
+next leg is never dispatched, and inside a leg the managed STOP is sent at the
+observed room boundary so later rooms remain due. Until a confident compatible duration exists,
 enabling the policy means the current room finishes. Set the threshold to `0%`
 to always finish it. This is a time-based estimate, not a measured area
 percentage; pauses, recharge, and other delays can reduce its accuracy.

--- a/docs/release-notes-0.3.8.md
+++ b/docs/release-notes-0.3.8.md
@@ -1,0 +1,52 @@
+# Release notes — 0.3.8
+
+Released: 2026-08-19
+
+## Summary
+
+0.3.8 restores true no-dock transitions inside managed cleaning plans. Since
+robot firmware v172 queues any command received during a return and executes
+it only after docking, per-room dispatch could no longer glide between rooms.
+Managed runs now group consecutive same-settings rooms into one native
+multi-room mission, so the robot moves room to room exactly the way its own
+full-floor cleans do.
+
+## Mission legs
+
+- After rotation ordering, consecutive rooms sharing one cleaning mode and
+  coverage form a leg and are dispatched as a single ordered native mission.
+  The robot glides between the leg's rooms without touching the dock; a
+  settings change starts the next leg at the observed return.
+- Room history still advances per room and only from native evidence: the
+  leg's single history record must mark each room completed with a positive
+  per-room duration. Partial legs credit exactly their verified subset, and
+  unverified, stopped, or skipped rooms stay due with their fairness ordering.
+- Live per-room tracking follows the robot's reported current area, so
+  room-started events, the active-plan sensor, and finish-current-room
+  progress estimation keep working inside a leg.
+- A finish-current-room stop inside a leg sends the managed STOP at the
+  observed room boundary, honoring the threshold policy without letting the
+  mission roll into later rooms. Immediate stops, low-charge recharge-resume
+  suspensions, cancellation, unload, and OEM stop-fence handling keep their
+  existing semantics.
+- An unverified leg stops any eagerly prepared next leg without credit, and
+  no next leg is prepared while a native stop countdown settles.
+
+This release adds no robot protocol commands — multi-room ordered missions
+use the same verified command as `matic_robot.clean` — and keeps all robot
+traffic, cleaning history, maps, and reconciliation data local to Home
+Assistant.
+
+## Verification
+
+The release candidate is gated by the full Python suite at 100% coverage,
+Ruff check and format, strict MyPy, the public-tree privacy gate, browser
+tests, HACS validation, and Hassfest.
+
+## Upgrading from 0.3.7
+
+Install 0.3.8 through HACS and restart Home Assistant. Existing entries,
+credentials, plans, custom areas, maps, cleaning history, and firmware
+snapshots are preserved. Plans whose rooms share one mode and coverage now
+run as a single glide; plans with mixed per-room settings dock briefly only
+between settings groups.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "matic-home-assistant"
-version = "0.3.7"
+version = "0.3.8"
 description = "Unofficial local-only Home Assistant integration for Matic robot vacuums"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -30,6 +30,7 @@ from custom_components.matic_robot.client.models import (
 from custom_components.matic_robot.const import DOMAIN
 from custom_components.matic_robot.plans import (
     OEM_STOP_RECONCILIATION_SECONDS,
+    PLAN_MOTION_TOKEN,
     AreaBindingUpgradeResult,
     CleaningPlanManager,
     CleaningRoom,
@@ -55,16 +56,29 @@ from custom_components.matic_robot.services import (
     RoomRunOutcome,
     RoomTakenOverError,
     _async_active_session_state,
+    _async_dispatch_leg_command,
     _async_execute_rooms,
+    _async_run_leg,
     _async_run_room,
     _async_session_history_baseline,
+    _async_verify_leg_completion,
     _async_verify_room_completion,
     _async_wait_for_active_session_resolution,
     _async_wait_for_room_outcome,
     _async_wait_for_vacuum_state,
     _entry_for_entity,
+    _leg_groups,
     _PreparedRoomDispatch,
 )
+
+
+def _heavy_room(name: str, room_id: str) -> CleaningRoom:
+    return CleaningRoom(
+        room_id=room_id,
+        name=name,
+        cleaning_mode="vacuum_and_mop",
+        coverage_setting="heavy_duty",
+    )
 
 
 def _room(name: str, room_id: str) -> CleaningRoom:
@@ -88,6 +102,97 @@ def _call(hass, *, return_to_base: bool = False) -> ServiceCall:
             "return_to_base": return_to_base,
         },
     )
+
+
+def test_leg_groups_split_only_on_settings_changes() -> None:
+    quick_a = _room("Living Room", "room-a")
+    quick_b = _room("Dining Room", "room-b")
+    standard = CleaningRoom(
+        room_id="room-c",
+        name="Master Bedroom",
+        cleaning_mode="vacuum",
+        coverage_setting="standard",
+    )
+    quick_c = _room("Quinns Room", "room-d")
+
+    assert _leg_groups([quick_a, quick_b, standard, quick_c]) == [
+        [quick_a, quick_b],
+        [standard],
+        [quick_c],
+    ]
+    assert _leg_groups([quick_a]) == [[quick_a]]
+    assert _leg_groups([]) == []
+
+
+async def test_leg_dispatch_sends_one_ordered_multi_room_mission(hass) -> None:
+    captured = []
+
+    async def send_command(call) -> None:
+        captured.append(call.data)
+
+    hass.services.async_register("vacuum", "send_command", send_command)
+    rooms = [_room("Kitchen", "room-kitchen"), _room("Office", "room-office")]
+
+    dispatch = await _async_dispatch_leg_command(
+        hass, _call(hass), "vacuum.matic", rooms, 7, None
+    )
+
+    assert dispatch.rooms == tuple(rooms)
+    assert captured[0]["command"] == "clean_rooms"
+    params = captured[0]["params"]
+    assert params["rooms"] == ["room-kitchen", "room-office"]
+    assert params["ordered"] is True
+    assert params["cleaning_mode"] == "vacuum_and_mop"
+    assert params["coverage"] == "standard"
+    assert params[PLAN_MOTION_TOKEN] == 7
+
+
+async def test_leg_dispatch_keeps_single_room_unordered(hass) -> None:
+    captured = []
+
+    async def send_command(call) -> None:
+        captured.append(call.data)
+
+    hass.services.async_register("vacuum", "send_command", send_command)
+
+    dispatch = await _async_dispatch_leg_command(
+        hass,
+        _call(hass),
+        "vacuum.matic",
+        [_room("Kitchen", "room-kitchen")],
+        None,
+        None,
+    )
+
+    assert dispatch.rooms == (_room("Kitchen", "room-kitchen"),)
+    params = captured[0]["params"]
+    assert params["rooms"] == ["room-kitchen"]
+    assert params["ordered"] is False
+    assert PLAN_MOTION_TOKEN not in params
+
+
+async def test_mark_completed_accepts_native_evidence(hass) -> None:
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    room = _room("Kitchen", "room-kitchen")
+    await manager.async_mark_started("serial", "plan", room)
+
+    await manager.async_mark_completed(
+        "serial",
+        "plan",
+        room,
+        completed_at="2026-08-20T04:16:13+00:00",
+        duration_seconds=57,
+    )
+
+    snapshot = manager.snapshot("serial")
+    record = snapshot["plan_history"]["plan"]["rooms"]["room-kitchen"]
+    assert record["last_completed"] == "2026-08-20T04:16:13+00:00"
+    assert record["last_duration_seconds"] == 57
+    assert record["average_duration_seconds"] == 57
+    by_room = snapshot["last_completed_by_room"]["room-kitchen"]
+    assert by_room["at"] == "2026-08-20T04:16:13+00:00"
+    assert snapshot["active_plan"] is None
 
 
 def test_rooms_resolve_live_names_ids_and_individual_settings() -> None:
@@ -1187,7 +1292,9 @@ async def test_replaced_cleanup_cannot_recreate_native_reconciliation(
             motion_token=token,
             session_history=AsyncMock(return_value=()),
             managed_user_command=replace_during_cleanup,
-            prepared_dispatch=_PreparedRoomDispatch(room, frozenset(), dispatched_at),
+            prepared_dispatch=_PreparedRoomDispatch(
+                (room,), frozenset(), dispatched_at
+            ),
         )
 
     assert failure.value.translation_key == translation_key
@@ -2715,7 +2822,7 @@ async def test_room_handoff_retries_prefetch_once_completion_is_verified(
         if prefetch_calls == 1:
             return None
         hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Study"})
-        return _PreparedRoomDispatch(next_room, frozenset(), dt_util.utcnow())
+        return _PreparedRoomDispatch((next_room,), frozenset(), dt_util.utcnow())
 
     sender = AsyncMock()
     completed = await _async_run_room(
@@ -2738,6 +2845,849 @@ async def test_room_handoff_retries_prefetch_once_completion_is_verified(
     manager.async_mark_verifying.assert_awaited_once()
     manager.async_mark_completed.assert_awaited_once()
     sender.assert_not_awaited()
+
+
+def _leg_manager(cancellation_reason: str | None = None) -> SimpleNamespace:
+    return SimpleNamespace(
+        async_mark_started=AsyncMock(),
+        async_mark_completed=AsyncMock(),
+        async_mark_ended_unverified=AsyncMock(),
+        async_mark_verifying=AsyncMock(),
+        async_mark_failed=AsyncMock(),
+        async_mark_interrupted=AsyncMock(),
+        async_mark_suspended=AsyncMock(),
+        async_mark_resumed=AsyncMock(),
+        async_mark_cancelled=AsyncMock(),
+        cancellation_reason=MagicMock(return_value=cancellation_reason),
+    )
+
+
+def _leg_record(
+    rooms: tuple[str, ...],
+    completed_rooms: tuple[str, ...],
+    *,
+    completed: bool | None = True,
+) -> CleaningSessionRecord:
+    ended = dt_util.utcnow()
+    return CleaningSessionRecord(
+        b"leg-evidence",
+        CleaningSession(
+            (ended - timedelta(seconds=120)).isoformat(),
+            ended.isoformat(),
+            120,
+            rooms,
+            tuple((name, 57) for name in rooms),
+            completed,
+            completed_rooms,
+        ),
+    )
+
+
+def _leg_call(hass, *, start_timeout: int = 120, completion_timeout: int = 21600):
+    return ServiceCall(
+        hass,
+        DOMAIN,
+        "intelligent_clean",
+        {
+            "plan_id": "away",
+            "start_timeout": start_timeout,
+            "completion_timeout": completion_timeout,
+            "return_to_base": False,
+        },
+    )
+
+
+def _leg_rooms() -> list[CleaningRoom]:
+    return [_room("Kitchen", "room-kitchen"), _room("Office", "room-office")]
+
+
+async def test_leg_rejects_duplicate_room_names(hass) -> None:
+    with pytest.raises(ServiceValidationError):
+        await _async_run_leg(
+            hass,
+            _call(hass),
+            _leg_manager(),
+            "vacuum.matic",
+            "serial",
+            _leg_rooms(),
+            room_name_is_unique=False,
+        )
+
+
+async def test_leg_uses_matching_prepared_dispatch_and_rejects_mismatch(hass) -> None:
+    rooms = _leg_rooms()
+    manager = _leg_manager()
+    hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Kitchen"})
+
+    async def end_leg() -> None:
+        await asyncio.sleep(0)
+        hass.states.async_set(
+            "vacuum.matic",
+            "returning",
+            {"current_area": "Kitchen", "low_charge": False},
+        )
+
+    hass.async_create_task(end_leg(), eager_start=True)
+
+    async def history() -> tuple[CleaningSessionRecord, ...]:
+        return (_leg_record(("Kitchen", "Office"), ("Kitchen", "Office")),)
+
+    confirmed: list[str] = []
+    prepared = _PreparedRoomDispatch(
+        tuple(rooms), frozenset(), dt_util.utcnow() - timedelta(seconds=1)
+    )
+    completed = await _async_run_leg(
+        hass,
+        _call(hass),
+        manager,
+        "vacuum.matic",
+        "serial",
+        rooms,
+        session_history=history,
+        confirm_room_completed=confirmed.append,
+        prepared_dispatch=prepared,
+    )
+    assert completed is True
+    assert confirmed == ["Kitchen", "Office"]
+
+    with pytest.raises(ValueError):
+        await _async_run_leg(
+            hass,
+            _call(hass),
+            _leg_manager(),
+            "vacuum.matic",
+            "serial",
+            rooms,
+            prepared_dispatch=_PreparedRoomDispatch(
+                (rooms[0],), frozenset(), dt_util.utcnow()
+            ),
+        )
+
+
+async def test_leg_start_timeout_marks_failure_and_stops(hass) -> None:
+    manager = _leg_manager()
+    hass.states.async_set("vacuum.matic", "docked", {})
+    hass.services.async_register("vacuum", "send_command", AsyncMock())
+    sender = AsyncMock()
+
+    with pytest.raises(ServiceValidationError):
+        await _async_run_leg(
+            hass,
+            _leg_call(hass, start_timeout=0),
+            manager,
+            "vacuum.matic",
+            "serial",
+            _leg_rooms(),
+            managed_user_command=sender,
+            motion_token=7,
+        )
+
+    manager.async_mark_failed.assert_awaited_once()
+    sender.assert_awaited_once_with(7, UserCommand.STOP)
+
+
+async def test_leg_paused_start_suspends_until_cleaning(hass) -> None:
+    rooms = _leg_rooms()
+    manager = _leg_manager()
+
+    async def send_command(_call) -> None:
+        hass.states.async_set("vacuum.matic", "paused", {"current_area": "Kitchen"})
+
+        async def resume() -> None:
+            await asyncio.sleep(0)
+            hass.states.async_set(
+                "vacuum.matic", "cleaning", {"current_area": "Kitchen"}
+            )
+            await asyncio.sleep(0)
+            hass.states.async_set(
+                "vacuum.matic",
+                "returning",
+                {"current_area": "Kitchen", "low_charge": False},
+            )
+
+        hass.async_create_task(resume(), eager_start=True)
+
+    hass.services.async_register("vacuum", "send_command", send_command)
+    reads = 0
+
+    async def history() -> tuple[CleaningSessionRecord, ...]:
+        nonlocal reads
+        reads += 1
+        if reads == 1:
+            return ()
+        return (_leg_record(("Kitchen", "Office"), ("Kitchen", "Office")),)
+
+    completed = await _async_run_leg(
+        hass,
+        _call(hass),
+        manager,
+        "vacuum.matic",
+        "serial",
+        rooms,
+        session_history=history,
+    )
+
+    assert completed is True
+    manager.async_mark_suspended.assert_awaited_once()
+    assert manager.async_mark_suspended.await_args.args[3] == "paused"
+
+
+async def test_leg_suspension_mid_leg_resumes(hass) -> None:
+    rooms = _leg_rooms()
+    manager = _leg_manager()
+
+    async def send_command(_call) -> None:
+        hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Kitchen"})
+
+        async def recharge() -> None:
+            await asyncio.sleep(0)
+            hass.states.async_set(
+                "vacuum.matic",
+                "returning",
+                {"current_area": "Kitchen", "low_charge": True},
+            )
+            await asyncio.sleep(0)
+            hass.states.async_set(
+                "vacuum.matic", "cleaning", {"current_area": "Office"}
+            )
+            await asyncio.sleep(0)
+            hass.states.async_set(
+                "vacuum.matic",
+                "returning",
+                {"current_area": "Office", "low_charge": False},
+            )
+
+        hass.async_create_task(recharge(), eager_start=True)
+
+    hass.services.async_register("vacuum", "send_command", send_command)
+    reads = 0
+
+    async def history() -> tuple[CleaningSessionRecord, ...]:
+        nonlocal reads
+        reads += 1
+        if reads == 1:
+            return ()
+        return (_leg_record(("Kitchen", "Office"), ("Kitchen", "Office")),)
+
+    completed = await _async_run_leg(
+        hass,
+        _call(hass),
+        manager,
+        "vacuum.matic",
+        "serial",
+        rooms,
+        session_history=history,
+    )
+
+    assert completed is True
+    manager.async_mark_suspended.assert_awaited_once()
+    assert manager.async_mark_suspended.await_args.args[3] == "low_charge"
+
+
+async def test_leg_completion_timeout_fails(hass) -> None:
+    manager = _leg_manager()
+
+    async def send_command(_call) -> None:
+        hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Kitchen"})
+
+    hass.services.async_register("vacuum", "send_command", send_command)
+
+    with pytest.raises(ServiceValidationError):
+        await _async_run_leg(
+            hass,
+            _leg_call(hass, completion_timeout=0),
+            manager,
+            "vacuum.matic",
+            "serial",
+            _leg_rooms(),
+        )
+
+    manager.async_mark_failed.assert_awaited_once()
+    assert "completion timeout" in manager.async_mark_failed.await_args.args[3]
+
+
+async def test_leg_matic_error_dispatch_fails(hass) -> None:
+    manager = _leg_manager()
+
+    async def send_command(_call) -> None:
+        raise MaticError("synthetic")
+
+    hass.services.async_register("vacuum", "send_command", send_command)
+
+    with pytest.raises(ServiceValidationError):
+        await _async_run_leg(
+            hass,
+            _call(hass),
+            manager,
+            "vacuum.matic",
+            "serial",
+            _leg_rooms(),
+        )
+
+    manager.async_mark_failed.assert_awaited_once()
+
+
+async def test_leg_replaced_dispatch_cancels(hass) -> None:
+    manager = _leg_manager()
+
+    async def send_command(_call) -> None:
+        raise ManagedMotionReplacedError("replaced")
+
+    hass.services.async_register("vacuum", "send_command", send_command)
+
+    with pytest.raises(PlanCancelledError):
+        await _async_run_leg(
+            hass,
+            _call(hass),
+            manager,
+            "vacuum.matic",
+            "serial",
+            _leg_rooms(),
+        )
+
+    manager.async_mark_cancelled.assert_awaited_once()
+
+
+@pytest.mark.parametrize("reason", [None, "config_entry_unload"])
+async def test_leg_cancellation_records_history(hass, reason: str | None) -> None:
+    manager = _leg_manager(reason)
+    cancel_event = asyncio.Event()
+
+    async def send_command(_call) -> None:
+        hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Kitchen"})
+
+        async def cancel() -> None:
+            await asyncio.sleep(0)
+            cancel_event.set()
+
+        hass.async_create_task(cancel(), eager_start=True)
+
+    hass.services.async_register("vacuum", "send_command", send_command)
+
+    with pytest.raises(PlanCancelledError):
+        await _async_run_leg(
+            hass,
+            _call(hass),
+            manager,
+            "vacuum.matic",
+            "serial",
+            _leg_rooms(),
+            cancel_event=cancel_event,
+        )
+
+    if reason is None:
+        manager.async_mark_cancelled.assert_awaited_once()
+    else:
+        manager.async_mark_interrupted.assert_awaited_once()
+
+
+async def test_leg_error_state_raises_robot_error(hass) -> None:
+    manager = _leg_manager()
+
+    async def send_command(_call) -> None:
+        hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Kitchen"})
+
+        async def fail() -> None:
+            await asyncio.sleep(0)
+            hass.states.async_set("vacuum.matic", "error", {})
+
+        hass.async_create_task(fail(), eager_start=True)
+
+    hass.services.async_register("vacuum", "send_command", send_command)
+
+    with pytest.raises(ServiceValidationError):
+        await _async_run_leg(
+            hass,
+            _call(hass),
+            manager,
+            "vacuum.matic",
+            "serial",
+            _leg_rooms(),
+        )
+
+    manager.async_mark_failed.assert_awaited_once()
+
+
+async def test_leg_takeover_during_verification_interrupts(hass) -> None:
+    manager = _leg_manager()
+
+    async def send_command(_call) -> None:
+        hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Kitchen"})
+
+        async def end_leg() -> None:
+            await asyncio.sleep(0)
+            hass.states.async_set(
+                "vacuum.matic",
+                "returning",
+                {"current_area": "Kitchen", "low_charge": False},
+            )
+
+        hass.async_create_task(end_leg(), eager_start=True)
+
+    hass.services.async_register("vacuum", "send_command", send_command)
+
+    async def takeover(*_args, **_kwargs) -> None:
+        hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Den"})
+
+    manager.async_mark_verifying = AsyncMock(side_effect=takeover)
+
+    with pytest.raises(ServiceValidationError):
+        await _async_run_leg(
+            hass,
+            _call(hass),
+            manager,
+            "vacuum.matic",
+            "serial",
+            _leg_rooms(),
+            session_history=AsyncMock(return_value=()),
+        )
+
+    manager.async_mark_interrupted.assert_awaited_once()
+
+
+async def test_leg_without_history_reader_credits_nothing(hass) -> None:
+    manager = _leg_manager()
+
+    async def send_command(_call) -> None:
+        hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Kitchen"})
+
+        async def end_leg() -> None:
+            await asyncio.sleep(0)
+            hass.states.async_set(
+                "vacuum.matic",
+                "returning",
+                {"current_area": "Kitchen", "low_charge": False},
+            )
+
+        hass.async_create_task(end_leg(), eager_start=True)
+
+    hass.services.async_register("vacuum", "send_command", send_command)
+
+    completed = await _async_run_leg(
+        hass,
+        _call(hass),
+        manager,
+        "vacuum.matic",
+        "serial",
+        _leg_rooms(),
+    )
+
+    assert completed is False
+    assert manager.async_mark_ended_unverified.await_count == 2
+    manager.async_mark_completed.assert_not_awaited()
+
+
+async def test_leg_partial_verification_stops_started_next_leg(hass) -> None:
+    rooms = _leg_rooms()
+    manager = _leg_manager()
+
+    async def send_command(_call) -> None:
+        hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Kitchen"})
+
+        async def end_leg() -> None:
+            await asyncio.sleep(0)
+            hass.states.async_set(
+                "vacuum.matic",
+                "returning",
+                {"current_area": "Kitchen", "low_charge": False},
+            )
+
+        hass.async_create_task(end_leg(), eager_start=True)
+
+    hass.services.async_register("vacuum", "send_command", send_command)
+    reads = 0
+
+    async def history() -> tuple[CleaningSessionRecord, ...]:
+        nonlocal reads
+        reads += 1
+        if reads == 1:
+            return ()
+        return (_leg_record(("Kitchen",), ("Kitchen",), completed=False),)
+
+    async def prefetch() -> _PreparedRoomDispatch:
+        return _PreparedRoomDispatch(
+            (_heavy_room("Den", "room-den"),), frozenset(), dt_util.utcnow()
+        )
+
+    sender = AsyncMock()
+    completed = await _async_run_leg(
+        hass,
+        _call(hass),
+        manager,
+        "vacuum.matic",
+        "serial",
+        rooms,
+        session_history=history,
+        managed_user_command=sender,
+        motion_token=7,
+        prefetch_next=prefetch,
+    )
+
+    assert completed is False
+    sender.assert_awaited_once_with(7, UserCommand.STOP)
+
+
+async def test_leg_verifier_filters_bad_records_and_ambiguity(hass) -> None:
+    rooms = _leg_rooms()
+    now = dt_util.utcnow()
+    dispatched_at = now - timedelta(seconds=60)
+
+    def session(
+        rooms_value: tuple[str, ...],
+        *,
+        started: str | None = None,
+        ended: str | None = None,
+        durations: tuple[tuple[str, int], ...] | None = None,
+    ) -> CleaningSession:
+        return CleaningSession(
+            started
+            if started is not None
+            else (now - timedelta(seconds=30)).isoformat(),
+            ended if ended is not None else (now - timedelta(seconds=5)).isoformat(),
+            25,
+            rooms_value,
+            durations if durations is not None else tuple((n, 20) for n in rooms_value),
+            True,
+            rooms_value,
+        )
+
+    baseline_key = b"old"
+    records = (
+        CleaningSessionRecord(baseline_key, session(("Kitchen",))),
+        CleaningSessionRecord(b"foreign", session(("Garage",))),
+        CleaningSessionRecord(
+            b"unparsable", session(("Kitchen",), started="", ended="")
+        ),
+        CleaningSessionRecord(
+            b"inverted",
+            session(
+                ("Kitchen",),
+                started=now.isoformat(),
+                ended=(now - timedelta(seconds=90)).isoformat(),
+            ),
+        ),
+        CleaningSessionRecord(
+            b"stale",
+            session(
+                ("Kitchen",),
+                started=(now - timedelta(seconds=300)).isoformat(),
+                ended=(now - timedelta(seconds=200)).isoformat(),
+            ),
+        ),
+        CleaningSessionRecord(
+            b"good",
+            session(
+                ("Kitchen", "Office"),
+                durations=(("Kitchen", 20), ("Office", 0)),
+            ),
+        ),
+    )
+
+    evidence = await _async_verify_leg_completion(
+        AsyncMock(return_value=records),
+        frozenset({baseline_key}),
+        rooms,
+        dispatched_at,
+        attempts=1,
+    )
+    assert evidence == {"room-kitchen": (records[-1].session.ended_at, 20)}
+
+    ambiguous = (*records, CleaningSessionRecord(b"twin", session(("Office",))))
+    assert (
+        await _async_verify_leg_completion(
+            AsyncMock(return_value=ambiguous),
+            frozenset({baseline_key}),
+            rooms,
+            dispatched_at,
+            attempts=1,
+        )
+        is None
+    )
+
+    assert (
+        await _async_verify_leg_completion(
+            AsyncMock(side_effect=MaticError("gone")),
+            frozenset(),
+            rooms,
+            dispatched_at,
+            attempts=1,
+        )
+        is None
+    )
+    assert (
+        await _async_verify_leg_completion(
+            None, frozenset(), rooms, dispatched_at, attempts=1
+        )
+        is None
+    )
+
+
+async def test_leg_unclassified_error_reraises_after_failure_mark(hass) -> None:
+    manager = _leg_manager()
+
+    async def send_command(_call) -> None:
+        raise HomeAssistantError("boom")
+
+    hass.services.async_register("vacuum", "send_command", send_command)
+
+    with pytest.raises(HomeAssistantError):
+        await _async_run_leg(
+            hass,
+            _call(hass),
+            manager,
+            "vacuum.matic",
+            "serial",
+            _leg_rooms(),
+        )
+
+    manager.async_mark_failed.assert_awaited_once()
+    assert manager.async_mark_failed.await_args.args[3] == "boom"
+
+
+async def test_leg_verifier_retries_and_honors_cancellation(hass) -> None:
+    rooms = _leg_rooms()
+    dispatched_at = dt_util.utcnow()
+
+    with patch(
+        "custom_components.matic_robot.services.SESSION_HISTORY_RETRY_SECONDS", 0
+    ):
+        assert (
+            await _async_verify_leg_completion(
+                AsyncMock(return_value=()),
+                frozenset(),
+                rooms,
+                dispatched_at,
+                attempts=2,
+            )
+            is None
+        )
+
+        cancel_event = asyncio.Event()
+        cancel_event.set()
+        reader = AsyncMock(return_value=())
+        with pytest.raises(PlanCancelledError):
+            await _async_verify_leg_completion(
+                reader,
+                frozenset(),
+                rooms,
+                dispatched_at,
+                cancel_event=cancel_event,
+                attempts=2,
+            )
+
+        quiet_cancel = asyncio.Event()
+        assert (
+            await _async_verify_leg_completion(
+                AsyncMock(return_value=()),
+                frozenset(),
+                rooms,
+                dispatched_at,
+                cancel_event=quiet_cancel,
+                attempts=2,
+            )
+            is None
+        )
+
+    late_cancel = asyncio.Event()
+    hass.loop.call_later(0.05, late_cancel.set)
+    with (
+        patch(
+            "custom_components.matic_robot.services.SESSION_HISTORY_RETRY_SECONDS", 1
+        ),
+        pytest.raises(PlanCancelledError),
+    ):
+        await _async_verify_leg_completion(
+            AsyncMock(return_value=()),
+            frozenset(),
+            rooms,
+            dispatched_at,
+            cancel_event=late_cancel,
+            attempts=2,
+        )
+
+
+async def test_leg_runs_two_rooms_in_one_mission_without_redispatch(hass) -> None:
+    """One leg mission glides room to room; credit comes from one record."""
+    rooms = [_room("Kitchen", "room-kitchen"), _room("Office", "room-office")]
+    manager = _leg_manager()
+    commands = []
+
+    async def send_command(call) -> None:
+        commands.append(call.data)
+        hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Kitchen"})
+
+        async def glide() -> None:
+            await asyncio.sleep(0)
+            hass.states.async_set(
+                "vacuum.matic", "cleaning", {"current_area": "Office"}
+            )
+            await asyncio.sleep(0)
+            hass.states.async_set(
+                "vacuum.matic",
+                "returning",
+                {"current_area": "Office", "low_charge": False},
+            )
+
+        hass.async_create_task(glide(), eager_start=True)
+
+    hass.services.async_register("vacuum", "send_command", send_command)
+    record: CleaningSessionRecord | None = None
+    reads = 0
+
+    async def history() -> tuple[CleaningSessionRecord, ...]:
+        nonlocal reads, record
+        reads += 1
+        if reads == 1:
+            return ()
+        if record is None:
+            record = _leg_record(("Kitchen", "Office"), ("Kitchen", "Office"))
+        return (record,)
+
+    started_events = []
+    completed_events = []
+    hass.bus.async_listen(
+        f"{DOMAIN}_room_started", lambda e: started_events.append(e.data["room"])
+    )
+    hass.bus.async_listen(
+        f"{DOMAIN}_room_completed", lambda e: completed_events.append(e.data["room"])
+    )
+    sender = AsyncMock()
+
+    completed = await _async_run_leg(
+        hass,
+        _call(hass),
+        manager,
+        "vacuum.matic",
+        "serial",
+        rooms,
+        refresh=AsyncMock(),
+        session_history=history,
+        managed_user_command=sender,
+        motion_token=7,
+    )
+    await hass.async_block_till_done()
+
+    assert completed is True
+    assert len(commands) == 1
+    assert commands[0]["params"]["rooms"] == ["room-kitchen", "room-office"]
+    assert started_events == ["Kitchen", "Office"]
+    assert sorted(completed_events) == ["Kitchen", "Office"]
+    assert manager.async_mark_completed.await_count == 2
+    assert record is not None
+    for call_args in manager.async_mark_completed.await_args_list:
+        assert call_args.kwargs["duration_seconds"] == 57
+        assert call_args.kwargs["completed_at"] == record.session.ended_at
+    sender.assert_not_awaited()
+
+
+async def test_leg_partial_record_credits_only_verified_subset(hass) -> None:
+    rooms = [_room("Kitchen", "room-kitchen"), _room("Office", "room-office")]
+    manager = _leg_manager()
+
+    async def send_command(_call) -> None:
+        hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Kitchen"})
+
+        async def end_leg() -> None:
+            await asyncio.sleep(0)
+            hass.states.async_set(
+                "vacuum.matic",
+                "returning",
+                {"current_area": "Kitchen", "low_charge": False},
+            )
+
+        hass.async_create_task(end_leg(), eager_start=True)
+
+    hass.services.async_register("vacuum", "send_command", send_command)
+    reads = 0
+
+    async def history() -> tuple[CleaningSessionRecord, ...]:
+        nonlocal reads
+        reads += 1
+        if reads == 1:
+            return ()
+        return (_leg_record(("Kitchen",), ("Kitchen",), completed=False),)
+
+    sender = AsyncMock()
+    completed = await _async_run_leg(
+        hass,
+        _call(hass),
+        manager,
+        "vacuum.matic",
+        "serial",
+        rooms,
+        session_history=history,
+        managed_user_command=sender,
+        motion_token=7,
+    )
+
+    assert completed is False
+    manager.async_mark_completed.assert_awaited_once()
+    assert manager.async_mark_completed.await_args.args[2].name == "Kitchen"
+    manager.async_mark_ended_unverified.assert_awaited_once()
+    assert manager.async_mark_ended_unverified.await_args.args[2].name == "Office"
+
+
+async def test_leg_boundary_stop_finishes_current_room_only(hass) -> None:
+    """A finish-current-room stop sends STOP at the observed room boundary."""
+    rooms = [_room("Kitchen", "room-kitchen"), _room("Office", "room-office")]
+    manager = _leg_manager()
+    finish_room_event = asyncio.Event()
+
+    async def send_command(call) -> None:
+        if call.data.get("command") != "clean_rooms":
+            return
+        hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Kitchen"})
+
+        async def cross_boundary() -> None:
+            await asyncio.sleep(0)
+            finish_room_event.set()
+            hass.states.async_set(
+                "vacuum.matic", "cleaning", {"current_area": "Office"}
+            )
+
+        hass.async_create_task(cross_boundary(), eager_start=True)
+
+    hass.services.async_register("vacuum", "send_command", send_command)
+    reads = 0
+
+    async def history() -> tuple[CleaningSessionRecord, ...]:
+        nonlocal reads
+        reads += 1
+        if reads == 1:
+            return ()
+        return (_leg_record(("Kitchen",), ("Kitchen",), completed=False),)
+
+    sender = AsyncMock()
+
+    async def stop_then_return(token, command) -> None:
+        assert command is UserCommand.STOP
+        hass.states.async_set(
+            "vacuum.matic",
+            "returning",
+            {"current_area": "Office", "low_charge": False},
+        )
+
+    sender.side_effect = stop_then_return
+
+    completed = await _async_run_leg(
+        hass,
+        _call(hass),
+        manager,
+        "vacuum.matic",
+        "serial",
+        rooms,
+        session_history=history,
+        managed_user_command=sender,
+        motion_token=7,
+        finish_room_event=finish_room_event,
+    )
+
+    assert completed is False
+    sender.assert_awaited_once_with(7, UserCommand.STOP)
+    manager.async_mark_completed.assert_awaited_once()
+    assert manager.async_mark_completed.await_args.args[2].name == "Kitchen"
+    manager.async_mark_cancelled.assert_awaited_once()
+    assert manager.async_mark_cancelled.await_args.args[2].name == "Office"
 
 
 async def test_room_handoff_dispatches_next_room_before_history_settles(hass) -> None:
@@ -2794,7 +3744,7 @@ async def test_room_handoff_dispatches_next_room_before_history_settles(hass) ->
         nonlocal prefetched
         prefetched = True
         hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Study"})
-        return _PreparedRoomDispatch(next_room, frozenset(), dt_util.utcnow())
+        return _PreparedRoomDispatch((next_room,), frozenset(), dt_util.utcnow())
 
     sender = AsyncMock()
     completed = await _async_run_room(
@@ -2849,7 +3799,7 @@ async def test_room_unverified_eager_handoff_stops_the_started_next_room(
 
     async def prefetch() -> _PreparedRoomDispatch:
         hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Study"})
-        return _PreparedRoomDispatch(next_room, frozenset(), dt_util.utcnow())
+        return _PreparedRoomDispatch((next_room,), frozenset(), dt_util.utcnow())
 
     sender = AsyncMock()
     with patch("custom_components.matic_robot.services.HANDOFF_HISTORY_ATTEMPTS", 1):
@@ -2889,7 +3839,7 @@ async def test_room_accepts_only_matching_prepared_dispatch() -> None:
         bus=SimpleNamespace(async_fire=MagicMock()),
         states=SimpleNamespace(get=MagicMock(return_value=None)),
     )
-    prepared = _PreparedRoomDispatch(room, None, dt_util.utcnow())
+    prepared = _PreparedRoomDispatch((room,), None, dt_util.utcnow())
     with (
         patch(
             "custom_components.matic_robot.services._async_wait_for_vacuum_state",
@@ -2911,7 +3861,9 @@ async def test_room_accepts_only_matching_prepared_dispatch() -> None:
             prepared_dispatch=prepared,
         )
 
-    wrong = _PreparedRoomDispatch(_room("Study", "room-study"), None, dt_util.utcnow())
+    wrong = _PreparedRoomDispatch(
+        (_room("Study", "room-study"),), None, dt_util.utcnow()
+    )
     with pytest.raises(ValueError, match="does not match"):
         await _async_run_room(
             hass,
@@ -3415,7 +4367,7 @@ async def test_execute_rooms_finishes_current_room_then_stops_and_docks(hass) ->
         return True
 
     with patch(
-        "custom_components.matic_robot.services._async_run_room",
+        "custom_components.matic_robot.services._async_run_leg",
         AsyncMock(side_effect=finish_then_stop),
     ) as run:
         await _async_execute_rooms(
@@ -3424,7 +4376,7 @@ async def test_execute_rooms_finishes_current_room_then_stops_and_docks(hass) ->
             manager,
             "vacuum.matic",
             "serial",
-            [_room("Kitchen", "one"), _room("Study", "two")],
+            [_room("Kitchen", "one"), _heavy_room("Study", "two")],
             intelligent=False,
             managed_user_command=managed_command,
         )
@@ -3434,12 +4386,55 @@ async def test_execute_rooms_finishes_current_room_then_stops_and_docks(hass) ->
     assert managed_command.await_args.args[1] is UserCommand.DOCK
 
 
+async def test_execute_rooms_groups_same_settings_rooms_into_one_leg(hass) -> None:
+    """Consecutive same-settings rooms run as one native mission leg."""
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    rooms = [
+        _room("Kitchen", "room-kitchen"),
+        _room("Office", "room-office"),
+        CleaningRoom(
+            room_id="room-master",
+            name="Master Bedroom",
+            cleaning_mode="vacuum",
+            coverage_setting="standard",
+        ),
+    ]
+    fake_hass = SimpleNamespace(
+        services=SimpleNamespace(async_call=AsyncMock()),
+        states=SimpleNamespace(
+            get=MagicMock(return_value=SimpleNamespace(state="docked"))
+        ),
+    )
+    legs_seen = []
+
+    async def run_leg(*args, **kwargs) -> bool:
+        legs_seen.append(args[5])
+        return True
+
+    with patch(
+        "custom_components.matic_robot.services._async_run_leg",
+        side_effect=run_leg,
+    ):
+        await _async_execute_rooms(
+            fake_hass,
+            _call(fake_hass),
+            manager,
+            "vacuum.matic",
+            "serial",
+            rooms,
+            intelligent=False,
+        )
+
+    assert legs_seen == [[rooms[0], rooms[1]], [rooms[2]]]
+
+
 async def test_execute_rooms_prepares_next_command_during_current_return(hass) -> None:
     manager = CleaningPlanManager(hass)
     manager._store = SimpleNamespace(async_save=AsyncMock())
     rooms = [
         _room("Kitchen", "room-kitchen"),
-        _room("Study", "room-study"),
+        _heavy_room("Study", "room-study"),
     ]
     service_call = AsyncMock()
     managed_command = AsyncMock()
@@ -3451,23 +4446,24 @@ async def test_execute_rooms_prepares_next_command_during_current_return(hass) -
     )
     prepared: _PreparedRoomDispatch | None = None
 
-    async def run_room(*args, **kwargs) -> bool:
+    async def run_leg(*args, **kwargs) -> bool:
         nonlocal prepared
-        room = args[5]
-        if room == rooms[0]:
+        leg = args[5]
+        if leg == [rooms[0]]:
             assert kwargs["prepared_dispatch"] is None
             prepared = await kwargs["prefetch_next"]()
             assert prepared is not None
-            assert prepared.room == rooms[1]
+            assert prepared.rooms == (rooms[1],)
             assert await kwargs["prefetch_next"]() == prepared
         else:
+            assert leg == [rooms[1]]
             assert kwargs["prepared_dispatch"] == prepared
             assert kwargs["prefetch_next"] is None
         return True
 
     with patch(
-        "custom_components.matic_robot.services._async_run_room",
-        side_effect=run_room,
+        "custom_components.matic_robot.services._async_run_leg",
+        side_effect=run_leg,
     ) as run:
         await _async_execute_rooms(
             fake_hass,
@@ -3495,7 +4491,7 @@ async def test_execute_rooms_cleans_up_prefetch_when_graceful_stop_arrives(
     manager._store = SimpleNamespace(async_save=AsyncMock())
     rooms = [
         _room("Kitchen", "room-kitchen"),
-        _room("Study", "room-study"),
+        _heavy_room("Study", "room-study"),
     ]
     fake_hass = SimpleNamespace(
         services=SimpleNamespace(async_call=AsyncMock()),
@@ -3505,14 +4501,14 @@ async def test_execute_rooms_cleans_up_prefetch_when_graceful_stop_arrives(
     )
     managed_command = AsyncMock()
 
-    async def run_room(*_args, **kwargs) -> bool:
+    async def run_leg(*_args, **kwargs) -> bool:
         assert await kwargs["prefetch_next"]() is not None
         manager.finish_room_event("serial").set()
         return True
 
     with patch(
-        "custom_components.matic_robot.services._async_run_room",
-        side_effect=run_room,
+        "custom_components.matic_robot.services._async_run_leg",
+        side_effect=run_leg,
     ) as run:
         await _async_execute_rooms(
             fake_hass,
@@ -3535,7 +4531,7 @@ async def test_execute_rooms_falls_back_when_prefetch_is_unavailable(hass) -> No
     manager._store = SimpleNamespace(async_save=AsyncMock())
     rooms = [
         _room("Kitchen", "room-kitchen"),
-        _room("Study", "room-study"),
+        _heavy_room("Study", "room-study"),
     ]
     fake_hass = SimpleNamespace(
         states=SimpleNamespace(
@@ -3543,17 +4539,17 @@ async def test_execute_rooms_falls_back_when_prefetch_is_unavailable(hass) -> No
         )
     )
 
-    async def run_room(*_args, **kwargs) -> bool:
+    async def run_leg(*_args, **kwargs) -> bool:
         assert await kwargs["prefetch_next"]() is None
         return False
 
     with (
         patch(
-            "custom_components.matic_robot.services._async_run_room",
-            side_effect=run_room,
+            "custom_components.matic_robot.services._async_run_leg",
+            side_effect=run_leg,
         ) as run,
         patch(
-            "custom_components.matic_robot.services._async_dispatch_room_command",
+            "custom_components.matic_robot.services._async_dispatch_leg_command",
             AsyncMock(side_effect=HomeAssistantError("synthetic failure")),
         ),
     ):
@@ -3575,7 +4571,7 @@ async def test_execute_rooms_skips_prefetch_after_stop_request(hass) -> None:
     manager._store = SimpleNamespace(async_save=AsyncMock())
     rooms = [
         _room("Kitchen", "room-kitchen"),
-        _room("Study", "room-study"),
+        _heavy_room("Study", "room-study"),
     ]
     managed_command = AsyncMock()
     fake_hass = SimpleNamespace(
@@ -3584,14 +4580,14 @@ async def test_execute_rooms_skips_prefetch_after_stop_request(hass) -> None:
         )
     )
 
-    async def run_room(*_args, **kwargs) -> bool:
+    async def run_leg(*_args, **kwargs) -> bool:
         manager.finish_room_event("serial").set()
         assert await kwargs["prefetch_next"]() is None
         return True
 
     with patch(
-        "custom_components.matic_robot.services._async_run_room",
-        side_effect=run_room,
+        "custom_components.matic_robot.services._async_run_leg",
+        side_effect=run_leg,
     ):
         await _async_execute_rooms(
             fake_hass,
@@ -3613,7 +4609,7 @@ async def test_execute_rooms_skips_prefetch_while_stop_fence_pending(hass) -> No
     manager._store = SimpleNamespace(async_save=AsyncMock())
     rooms = [
         _room("Kitchen", "room-kitchen"),
-        _room("Study", "room-study"),
+        _heavy_room("Study", "room-study"),
     ]
     fake_hass = SimpleNamespace(
         services=SimpleNamespace(async_call=AsyncMock()),
@@ -3622,14 +4618,14 @@ async def test_execute_rooms_skips_prefetch_while_stop_fence_pending(hass) -> No
         ),
     )
 
-    async def run_room(*_args, **kwargs) -> bool:
+    async def run_leg(*_args, **kwargs) -> bool:
         manager.mark_stop_pending("serial")
         assert await kwargs["prefetch_next"]() is None
         return False
 
     with patch(
-        "custom_components.matic_robot.services._async_run_room",
-        side_effect=run_room,
+        "custom_components.matic_robot.services._async_run_leg",
+        side_effect=run_leg,
     ) as run:
         await _async_execute_rooms(
             fake_hass,
@@ -3651,13 +4647,13 @@ async def test_execute_rooms_stops_after_unverified_room(hass) -> None:
     manager._store = SimpleNamespace(async_save=AsyncMock())
     rooms = [
         _room("Kitchen", "room-kitchen"),
-        _room("Study", "room-study"),
+        _heavy_room("Study", "room-study"),
     ]
     managed_command = AsyncMock()
     hass.states.async_set("vacuum.matic", "idle")
 
     with patch(
-        "custom_components.matic_robot.services._async_run_room",
+        "custom_components.matic_robot.services._async_run_leg",
         AsyncMock(return_value=False),
     ) as run:
         await _async_execute_rooms(
@@ -3672,7 +4668,7 @@ async def test_execute_rooms_stops_after_unverified_room(hass) -> None:
         )
 
     run.assert_awaited_once()
-    assert run.await_args.args[5] == rooms[0]
+    assert run.await_args.args[5] == [rooms[0]]
     managed_command.assert_awaited_once()
     assert managed_command.await_args.args[1] is UserCommand.DOCK
 

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -49,6 +49,12 @@ def test_github_validation_runs_hacs_and_hassfest() -> None:
     )
 
 
+SWITCHABLE_REVIEW_BOT = (
+    "REVIEW_BOT_EVENT_LOGIN: ${{ vars.REVIEW_PROVIDER == 'claude' && "
+    "'claude[bot]' || 'chatgpt-codex-connector[bot]' }}"
+)
+
+
 def test_review_gate_uses_only_regular_review_evidence() -> None:
     """Keep manual shipping independent from security-review availability."""
     review_gate = (ROOT / ".github" / "workflows" / "review-gate.yml").read_text()
@@ -83,7 +89,7 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "REVIEW_BASE_CONTEXT: review-gate-base-change" in review_gate
     assert "REVIEW_COMMENT_CONTEXT: review-gate-regular-comment" in review_gate
     assert "REVIEW_REVIEW_CONTEXT: review-gate-regular-review" in review_gate
-    assert "REVIEW_BOT_EVENT_LOGIN: chatgpt-codex-connector[bot]" in review_gate
+    assert SWITCHABLE_REVIEW_BOT in review_gate
     assert "Dedicated routers classify review and" in review_gate
     assert (
         "Exact-head regular PR reviews and explicit clean regular issue" in review_gate
@@ -113,12 +119,23 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "gh pr merge" not in review_gate
     assert "--auto" not in review_gate
 
+    claude_review = (ROOT / ".github" / "workflows" / "claude-review.yml").read_text()
+    assert "vars.REVIEW_PROVIDER == 'claude'" in claude_review
+    assert "anthropics/claude-code-action@" in claude_review
+    assert "claude_code_oauth_token" in claude_review
+    assert "-f commit_id=${{ github.event.pull_request.head.sha }}" in claude_review
+    assert "## Review result: No issues found." in claude_review
+    assert "## Review result: findings" in claude_review
+    assert "never edit files" in claude_review
+    assert "github.event.pull_request.title" not in claude_review
+    assert "github.event.pull_request.body" not in claude_review
+
     assert "name: Route Regular Codex Review Events" in regular_review
     assert "pull_request_review:" in regular_review
     assert "Run every review delivery independently" in regular_review
     assert "review-gate-review-event-" not in regular_review
     assert "cancel-in-progress: false" not in regular_review
-    assert "REVIEW_BOT_EVENT_LOGIN: chatgpt-codex-connector[bot]" in regular_review
+    assert SWITCHABLE_REVIEW_BOT in regular_review
     assert "EVENT_PREVIOUS_REVIEW_BODY" in regular_review
     assert "body_is_regular_review" in regular_review
     assert "def security_heading:" in regular_review
@@ -174,7 +191,7 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert '"$source_pr_number" == "$pr_number"' in fork_regular_review
     assert '"$head_repository" != "$REPO"' in fork_regular_review
     assert "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" in fork_regular_review
-    assert "REVIEW_BOT_EVENT_LOGIN: chatgpt-codex-connector[bot]" in fork_regular_review
+    assert SWITCHABLE_REVIEW_BOT in fork_regular_review
     assert "body_is_regular_review" in fork_regular_review
     assert "security_heading | not" in fork_regular_review
     assert "availability_notice | not" in fork_regular_review
@@ -192,7 +209,7 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "Run every comment delivery independently" in regular_comment
     assert "review-gate-comment-event-" not in regular_comment
     assert "cancel-in-progress: false" not in regular_comment
-    assert "REVIEW_BOT_EVENT_LOGIN: chatgpt-codex-connector[bot]" in regular_comment
+    assert SWITCHABLE_REVIEW_BOT in regular_comment
     assert "EVENT_PREVIOUS_COMMENT_BODY" in regular_comment
     assert "body_could_be_regular_comment" in regular_comment
     assert "before the pull request lookup" in regular_comment

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -28,7 +28,7 @@ def test_release_versions_and_links_are_consistent() -> None:
     hacs = json.loads((ROOT / "hacs.json").read_text())
     project = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]
 
-    assert manifest["version"] == "0.3.7"
+    assert manifest["version"] == "0.3.8"
     assert project["version"] == manifest["version"]
     assert hacs["homeassistant"] == "2026.7.0"
     assert manifest["documentation"].startswith("https://github.com/")


### PR DESCRIPTION
## Summary

Makes the regular review gate's reviewer identity switchable so Codex quota exhaustion never blocks shipping again.

- All review-gate workflows resolve `REVIEW_BOT`/`REVIEW_BOT_LOGIN`/`REVIEW_BOT_EVENT_LOGIN` from the `REVIEW_PROVIDER` repository variable. Unset or `codex` is byte-for-byte today's behavior; `claude` accepts the Claude GitHub App identity instead. Every hardening property (exact-head evidence, base-advance invalidation, availability-notice filtering, manual merge only) is unchanged.
- New `claude-review.yml`: when `REVIEW_PROVIDER == 'claude'`, `anthropics/claude-code-action@v1` (SHA-pinned) reviews every non-draft PR head against the repo's bar (privacy, protocol safety, rotation invariants, test adequacy) and posts one PR review with `commit_id` pinned to the exact head, ending in the gate's existing generic verdict envelope (`Review result: No issues found.` / `Review result: findings`). Only trusted values (PR number, repo, head SHA) are interpolated — no title/body/branch-name injection surface.
- Packaging tests updated to guard the switchable wiring and the new workflow's contract.

## Activation checklist (owner)

1. Install the Claude GitHub App on this repo (`/install-github-app` from Claude Code).
2. `claude setup-token` → save as the `CLAUDE_CODE_OAUTH_TOKEN` repository secret.
3. `gh variable set REVIEW_PROVIDER --body claude` (swap back anytime with `--body codex` or by deleting the variable).
4. Verify on the first Claude-reviewed PR that the review author login matches `claude[bot]`; if the app posts under a different login, adjust the three identity expressions.

## Testing

1034 tests at 100.00% coverage (packaging tests extended for the new wiring); Ruff check/format and the privacy scan pass. Workflow interpolations audited for injection surface.