### PR TITLE
Release 0.3.9: dock as soon as a stop settles

### DIFF
--- a/custom_components/matic_robot/manifest.json
+++ b/custom_components/matic_robot/manifest.json
@@ -24,7 +24,7 @@
     "numpy==2.3.2",
     "protobuf>=6"
   ],
-  "version": "0.3.8",
+  "version": "0.3.9",
   "zeroconf": [
     "_matic_hermes._tcp.local."
   ]

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -66,6 +66,7 @@ from .plans import (
     resolve_room_reference,
     resolve_rooms,
 )
+from .stop_return import schedule_dock_after_stop
 
 SERVICE_CLEAN = "clean"
 SERVICE_CLEAN_AREA = "clean_area"
@@ -409,6 +410,15 @@ async def async_register_services(hass: HomeAssistant) -> None:
                 if command is UserCommand.STOP:
                     await manager.async_mark_stop_pending(serial_number)
                 await entry.runtime_data.coordinator.async_request_refresh()
+            if command is UserCommand.STOP:
+                schedule_dock_after_stop(
+                    hass,
+                    client=entry.runtime_data.client,
+                    refresh=entry.runtime_data.coordinator.async_request_refresh,
+                    manager=manager,
+                    serial_number=serial_number,
+                    entity_id=entity_id,
+                )
 
         await _async_execute_rooms(
             hass,

--- a/custom_components/matic_robot/stop_return.py
+++ b/custom_components/matic_robot/stop_return.py
@@ -1,0 +1,122 @@
+"""Send a stopped robot home as soon as its native task settles.
+
+Matic's firmware owns a graceful countdown after an accepted STOP and docks
+only once it expires.  A DOCK sent while that task is still running is
+reinterpreted as recharge-and-resume, which is why the integration lets STOP
+own the return.  Once the task has actually ended there is nothing left to
+resume, so a DOCK then simply sends the robot home: measured live on firmware
+v172.12, stop-to-docked falls from 11.5 minutes to under one.
+
+The watcher is deliberately evidence-driven and fails closed.  It docks only
+while the robot is idle, the robot's own session reports inactive, and this
+stop still owns the fence; anything else leaves the firmware countdown in
+charge exactly as before.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from time import monotonic
+from typing import Protocol
+
+from homeassistant.core import HomeAssistant
+
+from .client.commands import UserCommand
+from .client.exceptions import MaticError
+from .const import DOMAIN
+from .plans import OEM_STOP_FENCE_SECONDS, CleaningPlanManager
+
+DOCK_SETTLE_POLL_SECONDS = 3
+DOCK_SETTLE_TIMEOUT_SECONDS = OEM_STOP_FENCE_SECONDS
+
+SETTLED_STATE = "idle"
+HOMEWARD_STATES = frozenset({"docked", "returning"})
+REPLACEMENT_STATES = frozenset({"cleaning", "paused"})
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class StopReturnClient(Protocol):
+    """The small part of the robot client this watcher needs."""
+
+    async def async_has_active_cleaning_session(self) -> bool | None:
+        """Return whether the robot still owns an active cleaning task."""
+
+    async def async_send_user_command(self, command: UserCommand) -> None:
+        """Send one vetted user command to the robot."""
+
+
+async def async_dock_when_stop_settles(
+    hass: HomeAssistant,
+    *,
+    client: StopReturnClient,
+    refresh: Callable[[], Awaitable[None]],
+    manager: CleaningPlanManager,
+    serial_number: str,
+    entity_id: str,
+) -> bool:
+    """Dock once the stopped task ends and report whether DOCK was sent."""
+    deadline = monotonic() + DOCK_SETTLE_TIMEOUT_SECONDS
+    while True:
+        if not manager.stop_pending(serial_number):
+            return False
+        state = hass.states.get(entity_id)
+        if state is not None:
+            if state.state in HOMEWARD_STATES:
+                return False
+            if state.state in REPLACEMENT_STATES:
+                return False
+            if state.state == SETTLED_STATE:
+                try:
+                    active = await client.async_has_active_cleaning_session()
+                except MaticError as err:
+                    _LOGGER.debug(
+                        "Native Matic stop settlement unreadable (%s)",
+                        type(err).__name__,
+                    )
+                    active = None
+                if active is False:
+                    try:
+                        await client.async_send_user_command(UserCommand.DOCK)
+                    except MaticError as err:
+                        _LOGGER.warning(
+                            "Unable to dock Matic after its stop settled (%s)",
+                            type(err).__name__,
+                        )
+                        return False
+                    await refresh()
+                    return True
+        if monotonic() >= deadline:
+            return False
+        await asyncio.sleep(DOCK_SETTLE_POLL_SECONDS)
+
+
+def schedule_dock_after_stop(
+    hass: HomeAssistant,
+    *,
+    client: StopReturnClient,
+    refresh: Callable[[], Awaitable[None]],
+    manager: CleaningPlanManager,
+    serial_number: str,
+    entity_id: str,
+) -> None:
+    """Start a lifecycle-bound watcher that docks a settled stop."""
+    create_background_task = getattr(hass, "async_create_background_task", None)
+    if not callable(create_background_task):
+        return
+    task = create_background_task(
+        async_dock_when_stop_settles(
+            hass,
+            client=client,
+            refresh=refresh,
+            manager=manager,
+            serial_number=serial_number,
+            entity_id=entity_id,
+        ),
+        f"{DOMAIN} dock after stop",
+    )
+    register_task = getattr(manager, "register_reconciliation_task", None)
+    if isinstance(task, asyncio.Task) and callable(register_task):
+        register_task(serial_number, task)

--- a/custom_components/matic_robot/vacuum.py
+++ b/custom_components/matic_robot/vacuum.py
@@ -19,6 +19,7 @@ from .client.models import FloorPlan, RobotActivity, Room
 from .const import DOMAIN
 from .entity import MaticEntity
 from .plans import PLAN_MOTION_TOKEN, resolve_room_reference
+from .stop_return import schedule_dock_after_stop
 
 PARALLEL_UPDATES = 1
 
@@ -124,6 +125,8 @@ class MaticVacuum(MaticEntity, StateVacuumEntity):
             if command is UserCommand.STOP:
                 await self._plans.async_mark_stop_pending(serial_number)
             await self.coordinator.async_request_refresh()
+        if command is UserCommand.STOP:
+            self._schedule_dock_after_stop(serial_number)
 
     async def _async_ensure_stop_settled(self, serial_number: str) -> None:
         """Reject new motion while the firmware's graceful STOP is counting down."""
@@ -211,17 +214,35 @@ class MaticVacuum(MaticEntity, StateVacuumEntity):
         )
         async with self._plans.external_motion(serial_number):
             if stop_before_dock:
-                # STOP is the OEM final-return command: firmware counts down
-                # for roughly ten minutes and then docks.  Sending DOCK here
-                # can interrupt that graceful stop and turn it into a
-                # recharge-and-resume cycle, so let STOP own the return.
+                # STOP is the OEM final-return command, and DOCK sent while the
+                # task still runs is reinterpreted as recharge-and-resume, so
+                # STOP owns the end of the task.  A watcher then docks the robot
+                # as soon as that task actually settles instead of waiting out
+                # firmware's ten-minute countdown.
                 self.coordinator.async_discard_current_room()
                 await self.coordinator.client.async_send_user_command(UserCommand.STOP)
                 await self._plans.async_mark_stop_pending(serial_number)
                 await self.coordinator.async_request_refresh()
-                return
-            await self.coordinator.client.async_send_user_command(UserCommand.DOCK)
-            await self.coordinator.async_request_refresh()
+                stopped = True
+            else:
+                await self.coordinator.client.async_send_user_command(UserCommand.DOCK)
+                await self.coordinator.async_request_refresh()
+                stopped = False
+        if stopped:
+            self._schedule_dock_after_stop(serial_number)
+
+    def _schedule_dock_after_stop(self, serial_number: str) -> None:
+        """Dock the robot as soon as its accepted stop settles."""
+        if self.entity_id is None:
+            return
+        schedule_dock_after_stop(
+            self.hass,
+            client=self.coordinator.client,
+            refresh=self.coordinator.async_request_refresh,
+            manager=self._plans,
+            serial_number=serial_number,
+            entity_id=self.entity_id,
+        )
 
     async def async_get_segments(self) -> list[Segment]:
         """Return native Home Assistant cleaning areas for every named room."""

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -292,6 +292,15 @@ the dock.
 Motion commands are serialized per robot. An independent Home Assistant clean,
 custom-area clean, stop, or dock revokes the managed plan before that command is
 sent; pause and resume are serialized without revoking the resumable plan.
+
+Stopping ends the robot's task with the OEM STOP command, because a DOCK sent
+while a task is still running is reinterpreted as recharge-and-resume. Firmware
+would then hold the robot in place for a ten-minute graceful countdown before
+returning, so the integration watches that stop and sends DOCK as soon as the
+task actually settles: the robot heads home in seconds instead. Docking is
+withheld unless the robot is idle, its own session reports no active task, and
+that stop still owns the robot, so a replacement clean, an unreadable robot, or
+a return already under way all leave the firmware countdown in charge.
 Commands sent by another client cannot be arbitrated before they reach the
 robot, so an unexplained terminal transition is treated as interrupted rather
 than completed.

--- a/docs/release-notes-0.3.9.md
+++ b/docs/release-notes-0.3.9.md
@@ -1,0 +1,55 @@
+# Release notes — 0.3.9
+
+Released: 2026-08-20
+
+## Summary
+
+0.3.9 sends a stopped robot home immediately. Stopping a clean — from the
+vacuum entity, the stop-plan action, a presence automation, or a managed
+plan's own cleanup — previously left the robot parked where it stopped for
+firmware's full ten-minute graceful countdown before it returned. It now docks
+as soon as the stopped task settles.
+
+## Prompt return after a stop
+
+- An accepted OEM STOP still owns the end of the task: a DOCK sent while the
+  task is running is reinterpreted by firmware as recharge-and-resume, so that
+  ordering is unchanged.
+- A lifecycle-bound watcher then follows the stop and issues DOCK the moment
+  the task actually settles. Measured on firmware v172.12, stop-to-docked drops
+  from 11 minutes 30 seconds to 56 seconds.
+- Docking is withheld unless every condition holds: the robot is idle, its own
+  session reports no active cleaning task, and that stop still owns the robot.
+  A replacement clean, a return already under way, a robot that never reports a
+  settled task, or an unreadable session all leave firmware's countdown in
+  charge exactly as before, and a rejected DOCK is logged without disturbing
+  it.
+- The watcher is tied to the config entry, so unloading or reloading Home
+  Assistant cancels it, and the existing stop fence still blocks replacement
+  work while a countdown is genuinely settling.
+
+This release adds no robot protocol commands — DOCK is the same vetted command
+the dock button already sends — and keeps all robot traffic, cleaning history,
+maps, and reconciliation data local to Home Assistant.
+
+## Verification
+
+The release candidate is gated by the full Python suite at 100% coverage,
+Ruff check and format, strict MyPy, the public-tree privacy gate, browser
+tests, HACS validation, and Hassfest. The timing above was measured on a live
+robot: stop at 12:59:23, settled at 13:00:13, DOCK issued, returning at
+13:00:39, docked at 13:01:09, with no recharge-and-resume afterwards.
+
+## Upgrading from 0.3.8
+
+Install 0.3.9 through HACS and restart Home Assistant. Existing entries,
+credentials, plans, custom areas, maps, cleaning history, and firmware
+snapshots are preserved. Stops now dock promptly; no configuration changes are
+required.
+
+Presence automations that stop cleaning only when an integration-managed plan
+is active are worth reviewing: if a managed run ends early — for example after
+a robot error — firmware can resume the task on its own, and a stop conditioned
+on the managed plan will not stop that native run. Conditioning on the vacuum
+state instead (`cleaning`, `paused`, or `idle`) and calling
+`vacuum.return_to_base` covers both cases.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "matic-home-assistant"
-version = "0.3.8"
+version = "0.3.9"
 description = "Unofficial local-only Home Assistant integration for Matic robot vacuums"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -28,7 +28,7 @@ def test_release_versions_and_links_are_consistent() -> None:
     hacs = json.loads((ROOT / "hacs.json").read_text())
     project = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]
 
-    assert manifest["version"] == "0.3.8"
+    assert manifest["version"] == "0.3.9"
     assert project["version"] == manifest["version"]
     assert hacs["homeassistant"] == "2026.7.0"
     assert manifest["documentation"].startswith("https://github.com/")

--- a/tests/test_stop_return.py
+++ b/tests/test_stop_return.py
@@ -1,0 +1,168 @@
+"""Docking as soon as an accepted OEM stop settles."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.matic_robot import stop_return
+from custom_components.matic_robot.client.commands import UserCommand
+from custom_components.matic_robot.client.exceptions import MaticError
+from custom_components.matic_robot.stop_return import (
+    async_dock_when_stop_settles,
+    schedule_dock_after_stop,
+)
+
+ENTITY = "vacuum.matic"
+
+
+@pytest.fixture(autouse=True)
+def _fast_poll(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the watcher's real control flow but drop its wait between polls."""
+    monkeypatch.setattr(stop_return, "DOCK_SETTLE_POLL_SECONDS", 0)
+
+
+def _manager(pending: bool = True) -> SimpleNamespace:
+    return SimpleNamespace(
+        stop_pending=MagicMock(return_value=pending),
+        register_reconciliation_task=MagicMock(),
+    )
+
+
+def _client(session: object = False) -> SimpleNamespace:
+    reader = (
+        AsyncMock(side_effect=session)
+        if isinstance(session, list)
+        else AsyncMock(return_value=session)
+    )
+    return SimpleNamespace(
+        async_has_active_cleaning_session=reader,
+        async_send_user_command=AsyncMock(),
+    )
+
+
+async def _run(hass, client, manager, refresh=None) -> bool:
+    return await async_dock_when_stop_settles(
+        hass,
+        client=client,
+        refresh=refresh or AsyncMock(),
+        manager=manager,
+        serial_number="serial",
+        entity_id=ENTITY,
+    )
+
+
+async def test_docks_once_the_stopped_task_reports_inactive(hass) -> None:
+    """A settled stop docks immediately instead of waiting out the countdown."""
+    hass.states.async_set(ENTITY, "idle", {})
+    client = _client(session=False)
+    refresh = AsyncMock()
+
+    docked = await _run(hass, client, _manager(), refresh)
+
+    assert docked is True
+    client.async_send_user_command.assert_awaited_once_with(UserCommand.DOCK)
+    refresh.assert_awaited_once()
+
+
+@pytest.mark.parametrize("state", ["docked", "returning"])
+async def test_skips_when_the_robot_is_already_home_or_heading_there(
+    hass, state: str
+) -> None:
+    hass.states.async_set(ENTITY, state, {})
+    client = _client(session=False)
+
+    assert await _run(hass, client, _manager()) is False
+    client.async_send_user_command.assert_not_awaited()
+
+
+@pytest.mark.parametrize("state", ["cleaning", "paused"])
+async def test_skips_when_new_work_replaced_the_stop(hass, state: str) -> None:
+    hass.states.async_set(ENTITY, state, {})
+    client = _client(session=False)
+
+    assert await _run(hass, client, _manager()) is False
+    client.async_send_user_command.assert_not_awaited()
+
+
+async def test_skips_when_the_stop_fence_was_cleared(hass) -> None:
+    hass.states.async_set(ENTITY, "idle", {})
+    client = _client(session=False)
+
+    assert await _run(hass, client, _manager(pending=False)) is False
+    client.async_send_user_command.assert_not_awaited()
+
+
+async def test_waits_for_an_active_session_to_end_before_docking(hass) -> None:
+    """A still-running task is never docked mid-flight."""
+    hass.states.async_set(ENTITY, "idle", {})
+    client = _client(session=[True, None, False])
+
+    docked = await _run(hass, client, _manager())
+
+    assert docked is True
+    assert client.async_has_active_cleaning_session.await_count == 3
+    client.async_send_user_command.assert_awaited_once_with(UserCommand.DOCK)
+
+
+async def test_missing_entity_and_unreadable_session_never_dock(
+    hass, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Absent evidence leaves the firmware countdown in charge."""
+    monkeypatch.setattr(stop_return, "DOCK_SETTLE_TIMEOUT_SECONDS", 0)
+    client = _client()
+    client.async_has_active_cleaning_session = AsyncMock(
+        side_effect=MaticError("unavailable")
+    )
+    hass.states.async_set(ENTITY, "idle", {})
+
+    assert await _run(hass, client, _manager()) is False
+    client.async_send_user_command.assert_not_awaited()
+
+    hass.states.async_remove(ENTITY)
+    assert await _run(hass, _client(session=False), _manager()) is False
+
+
+async def test_a_rejected_dock_command_is_reported_without_raising(hass) -> None:
+    hass.states.async_set(ENTITY, "idle", {})
+    client = _client(session=False)
+    client.async_send_user_command = AsyncMock(side_effect=MaticError("rejected"))
+
+    assert await _run(hass, client, _manager()) is False
+
+
+async def test_schedule_registers_a_lifecycle_bound_task(hass) -> None:
+    manager = _manager()
+    hass.states.async_set(ENTITY, "docked", {})
+
+    schedule_dock_after_stop(
+        hass,
+        client=_client(),
+        refresh=AsyncMock(),
+        manager=manager,
+        serial_number="serial",
+        entity_id=ENTITY,
+    )
+    await hass.async_block_till_done()
+
+    manager.register_reconciliation_task.assert_called_once()
+    assert isinstance(
+        manager.register_reconciliation_task.call_args.args[1], asyncio.Task
+    )
+
+
+async def test_schedule_is_a_no_op_without_background_task_support() -> None:
+    manager = _manager()
+    fake_hass = SimpleNamespace(states=SimpleNamespace(get=MagicMock()))
+
+    schedule_dock_after_stop(
+        fake_hass,
+        client=_client(),
+        refresh=AsyncMock(),
+        manager=manager,
+        serial_number="serial",
+        entity_id=ENTITY,
+    )
+
+    manager.register_reconciliation_task.assert_not_called()

--- a/tests/test_vacuum_areas.py
+++ b/tests/test_vacuum_areas.py
@@ -222,3 +222,27 @@ async def test_lifecycle_runs_area_mapping_and_change_checks() -> None:
     entity._async_auto_map_rooms.assert_called_once()
     entity._async_check_segment_changes.assert_called_once()
     parent_update.assert_called_once()
+
+
+def test_dock_after_stop_is_skipped_before_the_entity_is_registered() -> None:
+    """An entity without an entity ID has no state for the watcher to read."""
+    entity = _vacuum()
+    entity.entity_id = None
+
+    with patch(
+        "custom_components.matic_robot.vacuum.schedule_dock_after_stop"
+    ) as schedule:
+        entity._schedule_dock_after_stop("serial")
+
+    schedule.assert_not_called()
+
+    entity.entity_id = "vacuum.test"
+    entity.coordinator.client = MagicMock()
+    entity.coordinator.async_request_refresh = AsyncMock()
+    with patch(
+        "custom_components.matic_robot.vacuum.schedule_dock_after_stop"
+    ) as schedule:
+        entity._schedule_dock_after_stop("serial")
+
+    schedule.assert_called_once()
+    assert schedule.call_args.kwargs["entity_id"] == "vacuum.test"


### PR DESCRIPTION
## Problem

Stopping a clean left the robot parked where it stopped for firmware's full ten-minute graceful countdown before it returned. Measured live yesterday: stop at 12:39:20, first movement at 12:49:20 (exactly 600 s later), docked at 12:50:50 — **11m30s** from stop to dock.

The integration deliberately sends STOP and withholds DOCK, because a DOCK sent while the task is still running is reinterpreted by firmware as recharge-and-resume (the 0.3.5 finding). That ordering is correct — but it left the countdown owning the entire return.

## Fix

A lifecycle-bound watcher follows every accepted STOP and issues DOCK once the task actually settles. At that point there is no task left to resume, so the hazard does not apply.

Live proof on firmware v172.12, run today:

| | |
|---|---|
| 12:59:23 | STOP sent |
| 13:00:13 | task settled (idle, session inactive) → DOCK issued |
| 13:00:39 | returning (**+26 s**, vs 600 s countdown) |
| 13:01:09 | docked (**+56 s**, vs 11m30s) |
| 13:06 | still docked — **no recharge-and-resume** |

Guards (all fail closed, leaving firmware's countdown in charge):
- docks only while the robot is `idle` and its own session reports no active task;
- aborts if the stop fence was cleared, a replacement clean started (`cleaning`/`paused`), or a return is already under way;
- an unreadable session or a rejected DOCK never escalates;
- bounded by the existing stop-fence window and cancelled on config-entry unload.

Wired into all three STOP paths: the vacuum entity's stop, its return-to-base, and a managed plan's own cleanup — so plan stops, the stop-plan action, and presence automations all benefit.

## Testing

New `tests/test_stop_return.py` (11 cases: happy path, each abort guard, waits-for-active-session, unreadable evidence, rejected DOCK, scheduler registration/no-op) plus an entity-guard case. 1046 tests at 100.00% coverage; Ruff check/format, strict MyPy, and the privacy scan pass.

## Note for operators

The release notes flag a related gap found in the same investigation: a presence automation that stops only when an integration-managed plan is active will not stop a *native* run that firmware resumed after a managed run ended early. Conditioning on vacuum state and calling `vacuum.return_to_base` covers both.