### PR TITLE
Release 0.3.10: robot-side cleaning records activity, not completion

### DIFF
--- a/custom_components/matic_robot/__init__.py
+++ b/custom_components/matic_robot/__init__.py
@@ -251,13 +251,13 @@ def _register_native_history_sync(
     plans: CleaningPlanManager,
     serial_number: str,
 ) -> None:
-    """Credit rooms the robot finished, whoever started the clean.
+    """Record where the robot worked, whoever started the clean.
 
     A managed plan verifies its own rooms, but firmware also cleans on its
     own: it resumes a task after an error and the vendor app can start one.
-    Those runs still record per-room completion evidence, so importing it as
-    each session finishes keeps room history and rotation fairness aligned
-    with the robot instead of waiting for the next restart.
+    The robot's record cannot prove those rooms were finished, so importing
+    it as each session ends keeps rotation fairness current without ever
+    claiming a completion; see ``_import_native_room_activity``.
     """
 
     async def _async_sync(event: Event) -> None:

--- a/custom_components/matic_robot/__init__.py
+++ b/custom_components/matic_robot/__init__.py
@@ -10,7 +10,7 @@ from typing import cast
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import dt as dt_util
@@ -35,6 +35,7 @@ from .const import (
     DATA_FIRMWARE_TRACKER,
     DATA_PLAN_MANAGER,
     DOMAIN,
+    EVENT_CLEANING_FINISHED,
     PLATFORMS,
 )
 from .coordinator import MaticCoordinator
@@ -156,6 +157,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: MaticConfigEntry) -> boo
             plans,
             serial_number,
         )
+        _register_native_history_sync(
+            hass,
+            entry,
+            client,
+            coordinator,
+            plans,
+            serial_number,
+        )
         entry.async_create_background_task(
             hass,
             slam_map.async_collect(client),
@@ -232,6 +241,40 @@ async def async_setup_entry(hass: HomeAssistant, entry: MaticConfigEntry) -> boo
         client.close()
         raise
     return True
+
+
+def _register_native_history_sync(
+    hass: HomeAssistant,
+    entry: MaticConfigEntry,
+    client: MaticHermesClient,
+    coordinator: MaticCoordinator,
+    plans: CleaningPlanManager,
+    serial_number: str,
+) -> None:
+    """Credit rooms the robot finished, whoever started the clean.
+
+    A managed plan verifies its own rooms, but firmware also cleans on its
+    own: it resumes a task after an error and the vendor app can start one.
+    Those runs still record per-room completion evidence, so importing it as
+    each session finishes keeps room history and rotation fairness aligned
+    with the robot instead of waiting for the next restart.
+    """
+
+    async def _async_sync(event: Event) -> None:
+        if event.data.get("entry_id") != entry.entry_id:
+            return
+        try:
+            records = await client.async_get_cleaning_session_records()
+        except MaticError as err:
+            _LOGGER.debug("Native cleaning history sync is unavailable: %s", err)
+            return
+        await plans.async_import_native_history(
+            serial_number,
+            coordinator.data.floor_plan,
+            records,
+        )
+
+    entry.async_on_unload(hass.bus.async_listen(EVENT_CLEANING_FINISHED, _async_sync))
 
 
 def _schedule_native_reconciliation_recovery(

--- a/custom_components/matic_robot/manifest.json
+++ b/custom_components/matic_robot/manifest.json
@@ -24,7 +24,7 @@
     "numpy==2.3.2",
     "protobuf>=6"
   ],
-  "version": "0.3.9",
+  "version": "0.3.10",
   "zeroconf": [
     "_matic_hermes._tcp.local."
   ]

--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -520,12 +520,12 @@ class CleaningPlanManager:
         floor_plan: FloorPlan | None,
         records: Iterable[CleaningSessionRecord],
     ) -> bool:
-        """Recover latest room statistics from retained native completions."""
+        """Record robot-side cleaning activity without claiming completions."""
         if floor_plan is None:
             return False
         robot = self._robot(serial_number)
         records = tuple(records)
-        changed = _import_native_room_history(robot, floor_plan, records)
+        changed = _import_native_room_activity(robot, floor_plan, records)
         changed = (
             _reconcile_pending_native_history(robot, floor_plan, records) or changed
         )
@@ -1578,56 +1578,55 @@ def _record_native_completion(
     global_room["completed_runs"] = _stored_count(global_room, "completed_runs") + 1
 
 
-def _import_native_room_history(
+def _import_native_room_activity(
     robot: dict[str, Any],
     floor_plan: FloorPlan,
     records: Iterable[CleaningSessionRecord],
 ) -> bool:
-    """Import only native room records carrying explicit completion evidence."""
+    """Record where the robot worked, which is not proof that it finished.
+
+    The robot marks the room it occupied when a session ended exactly the way
+    it marks a room it cleaned to the end, and it reports a stopped session as
+    completed, so its record cannot establish completion by itself.  Observed
+    live on firmware v172.12: a room entered sixty seconds before a stop and a
+    room cleaned for thirty-one minutes were recorded identically, and a clean
+    stopped after forty-five seconds still reported its room as completed.
+
+    Native evidence is therefore imported as a cleaning opportunity.  Rotation
+    fairness stays current for cleaning this integration did not manage - a
+    room the robot has just worked in does not keep monopolising short runs -
+    while "last cleaned" and completion counts continue to come only from runs
+    whose end was actually verified.
+    """
     room_lookup: dict[str, tuple[str, str] | None] = {}
     for room in floor_plan.rooms:
         key = _native_room_key(room.name)
         room_lookup[key] = None if key in room_lookup else (room.id, room.name)
 
-    candidates: dict[str, tuple[float, str, str, int]] = {}
+    candidates: dict[str, tuple[float, str, str]] = {}
     for record in records:
         session = record.session
         timestamp = _latest_timestamp(session.ended_at)
         if timestamp is None or not isinstance(session.ended_at, str):
             continue
-        durations = dict(session.room_durations)
-        for completed_name in session.completed_rooms:
-            mapped_room = room_lookup.get(_native_room_key(completed_name))
-            duration = durations.get(completed_name)
-            if (
-                mapped_room is None
-                or not isinstance(duration, int | float)
-                or isinstance(duration, bool)
-                or not math.isfinite(duration)
-                or duration <= 0
-            ):
+        for worked_name in session.completed_rooms:
+            mapped_room = room_lookup.get(_native_room_key(worked_name))
+            if mapped_room is None:
                 continue
             room_id, room_name = mapped_room
             current = candidates.get(room_id)
             if current is None or timestamp >= current[0]:
-                candidates[room_id] = (
-                    timestamp,
-                    session.ended_at,
-                    room_name,
-                    round(duration),
-                )
+                candidates[room_id] = (timestamp, session.ended_at, room_name)
 
     changed = False
-    for room_id, (timestamp, completed, name, duration) in candidates.items():
+    for room_id, (timestamp, ended_at, name) in candidates.items():
         global_room = robot["rooms"].setdefault(room_id, {})
-        current_timestamp = _latest_timestamp(global_room.get("last_completed"))
-        if current_timestamp is not None and current_timestamp > timestamp:
+        known = _latest_timestamp(
+            global_room.get("last_opportunity"), global_room.get("last_completed")
+        )
+        if known is not None and known > timestamp:
             continue
-        updates = {
-            "name": name,
-            "last_completed": completed,
-            "last_duration_seconds": duration,
-        }
+        updates = {"name": name, "last_opportunity": ended_at}
         if any(global_room.get(key) != value for key, value in updates.items()):
             global_room.update(updates)
             changed = True

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -273,6 +273,14 @@ cancelled, timed-out, or restart-interrupted rooms remain due, but a confirmed
 start moves them behind rooms that waited longer so one problem room cannot
 monopolize short runs. Saved room order breaks ties.
 
+Room history also follows the robot itself. Firmware cleans without Home
+Assistant in two ordinary cases — it resumes its own task after an error, and
+the vendor app can start one — and those runs still record which rooms were
+completed. Every time a cleaning session finishes, the integration imports that
+evidence, so a room the robot genuinely finished stops reading as due even
+though no managed plan verified it. Only rooms the robot's own record marks
+completed with a positive duration are credited; interrupted rooms stay due.
+
 Room history advances only after the managed runner positively matches the end
 of the commanded room. Returning, idle, or docked state alone is not completion:
 a low-charge return is suspended and waits for the robot's automatic resume;

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -273,13 +273,17 @@ cancelled, timed-out, or restart-interrupted rooms remain due, but a confirmed
 start moves them behind rooms that waited longer so one problem room cannot
 monopolize short runs. Saved room order breaks ties.
 
-Room history also follows the robot itself. Firmware cleans without Home
+Rotation fairness also follows the robot itself. Firmware cleans without Home
 Assistant in two ordinary cases — it resumes its own task after an error, and
-the vendor app can start one — and those runs still record which rooms were
-completed. Every time a cleaning session finishes, the integration imports that
-evidence, so a room the robot genuinely finished stops reading as due even
-though no managed plan verified it. Only rooms the robot's own record marks
-completed with a positive duration are credited; interrupted rooms stay due.
+the vendor app can start one. The robot records which rooms such a run touched,
+but that record cannot prove a room was finished: the robot marks the room it
+occupied when a session ended exactly the way it marks a room cleaned to the
+end, and it reports a stopped session as completed. Each time a session
+finishes, the integration therefore imports that evidence as a cleaning
+*opportunity*: a room the robot has just worked in stops monopolising short
+runs, while **last cleaned**, per-room durations, and completion counts still
+come only from runs whose end was verified. A room worked on but not verified
+stays due.
 
 Room history advances only after the managed runner positively matches the end
 of the commanded room. Returning, idle, or docked state alone is not completion:

--- a/docs/release-notes-0.3.10.md
+++ b/docs/release-notes-0.3.10.md
@@ -1,0 +1,43 @@
+# Release notes — 0.3.10
+
+Released: 2026-08-20
+
+## Summary
+
+0.3.10 keeps room history in step with the robot. Firmware cleans without Home
+Assistant in ordinary situations — it resumes its own task after an error, and
+the vendor app can start one — and until now those rooms kept reading as due
+until the next Home Assistant restart, which also pushed them to the front of
+the intelligent rotation.
+
+## Room history follows the robot
+
+- Every time a cleaning session finishes, the integration imports the robot's
+  own per-room completion evidence, instead of doing that only at startup.
+- The evidence standard is unchanged: a room is credited only when the robot's
+  record marks it completed with a positive duration. Interrupted, stopped, and
+  unfinished rooms stay due, and a record that is missing, ambiguous, or
+  unreadable credits nothing.
+- This covers the case observed live on 2026-08-20: a managed plan ended early
+  on a robot error at 11:59, firmware resumed the same task on its own at 12:07
+  and cleaned four rooms over the next 32 minutes, and none of that work was
+  reflected in room history or rotation order.
+- The listener is bound to the config entry, so unloading Home Assistant
+  removes it, and a robot that cannot be read is logged and skipped.
+
+This release adds no robot protocol commands and keeps all robot traffic,
+cleaning history, maps, and reconciliation data local to Home Assistant.
+
+## Verification
+
+The release candidate is gated by the full Python suite at 100% coverage,
+Ruff check and format, strict MyPy, the public-tree privacy gate, browser
+tests, HACS validation, and Hassfest.
+
+## Upgrading from 0.3.9
+
+Install 0.3.10 through HACS and restart Home Assistant. Existing entries,
+credentials, plans, custom areas, maps, cleaning history, and firmware
+snapshots are preserved. The restart also imports any retained robot-side
+completions that earlier versions missed, so rotation order may shift once to
+reflect cleaning the robot had already done.

--- a/docs/release-notes-0.3.10.md
+++ b/docs/release-notes-0.3.10.md
@@ -4,26 +4,44 @@ Released: 2026-08-20
 
 ## Summary
 
-0.3.10 keeps room history in step with the robot. Firmware cleans without Home
-Assistant in ordinary situations — it resumes its own task after an error, and
-the vendor app can start one — and until now those rooms kept reading as due
-until the next Home Assistant restart, which also pushed them to the front of
-the intelligent rotation.
+0.3.10 corrects what the robot's own cleaning record is allowed to prove. That
+record cannot establish that a room was finished, so it no longer produces
+completions — it now keeps rotation fairness current instead. This fixes rooms
+being marked cleaned after the robot was stopped in them, and it lets cleaning
+the integration did not manage inform the rotation for the first time.
 
-## Room history follows the robot
+## The robot's record proves activity, not completion
 
-- Every time a cleaning session finishes, the integration imports the robot's
-  own per-room completion evidence, instead of doing that only at startup.
-- The evidence standard is unchanged: a room is credited only when the robot's
-  record marks it completed with a positive duration. Interrupted, stopped, and
-  unfinished rooms stay due, and a record that is missing, ambiguous, or
-  unreadable credits nothing.
-- This covers the case observed live on 2026-08-20: a managed plan ended early
-  on a robot error at 11:59, firmware resumed the same task on its own at 12:07
-  and cleaned four rooms over the next 32 minutes, and none of that work was
-  reflected in room history or rotation order.
-- The listener is bound to the config entry, so unloading Home Assistant
-  removes it, and a robot that cannot be read is logged and skipped.
+Firmware cleans without Home Assistant in ordinary situations: it resumes its
+own task after an error, and the vendor app can start one. Earlier versions
+imported the robot's per-room record as a verified completion at startup.
+
+Live observation on firmware v172.12 shows that reading was wrong:
+
+- a room the robot entered sixty seconds before being stopped, and a room it
+  cleaned for thirty-one minutes, are recorded identically;
+- a clean stopped after forty-five seconds still reported its room as
+  completed, and reported the session as completed too.
+
+The result was a room that received one minute of cleaning being recorded as
+cleaned — taking its **last cleaned** timestamp, a duration, and a place at the
+back of the intelligent rotation, so it would be skipped for a full cycle.
+
+From 0.3.10 the robot's record is imported as a cleaning **opportunity**:
+
+- rooms the robot has just worked in stop monopolising short runs, which is the
+  same fairness rule already applied to a room whose managed run was
+  interrupted;
+- **last cleaned**, per-room durations, and completion counts continue to come
+  only from runs whose end was verified, so an unverified room stays due;
+- the import now also runs whenever a cleaning session finishes rather than
+  only at startup, so unmanaged cleaning is reflected while it is still
+  relevant. The listener is bound to the config entry, and an unreadable robot
+  is logged and skipped.
+
+Nothing about verified completion changed: managed plans still credit a room
+only against a native record that matches the commanded room with a positive
+duration.
 
 This release adds no robot protocol commands and keeps all robot traffic,
 cleaning history, maps, and reconciliation data local to Home Assistant.
@@ -38,6 +56,9 @@ tests, HACS validation, and Hassfest.
 
 Install 0.3.10 through HACS and restart Home Assistant. Existing entries,
 credentials, plans, custom areas, maps, cleaning history, and firmware
-snapshots are preserved. The restart also imports any retained robot-side
-completions that earlier versions missed, so rotation order may shift once to
-reflect cleaning the robot had already done.
+snapshots are preserved.
+
+A room that an earlier version credited from the robot's record keeps that
+recorded timestamp; the value cannot be distinguished after the fact from a
+verified completion, so it is left alone rather than guessed at. It is
+corrected the next time that room is genuinely cleaned and verified.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "matic-home-assistant"
-version = "0.3.9"
+version = "0.3.10"
 description = "Unofficial local-only Home Assistant integration for Matic robot vacuums"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_floor_plan.py
+++ b/tests/test_floor_plan.py
@@ -275,7 +275,7 @@ def test_room_labels_wrap_and_scale_to_stay_inside_tight_rooms() -> None:
     rooms = (
         ("Bathroom", ((20.0, 20.0), (92.0, 20.0), (92.0, 145.0), (20.0, 145.0))),
         (
-            "Quinns Room",
+            "Guest Room",
             ((92.0, 20.0), (260.0, 20.0), (260.0, 180.0), (92.0, 180.0)),
         ),
         (
@@ -316,7 +316,7 @@ def test_room_label_layout_avoids_collisions_between_overlapping_regions() -> No
     polygon = ((20.0, 20.0), (240.0, 20.0), (240.0, 160.0), (20.0, 160.0))
 
     layouts = _layout_room_labels(
-        (("Bathroom", polygon), ("Quinns Room", polygon)),
+        (("Bathroom", polygon), ("Guest Room", polygon)),
         width=260,
         height=180,
         font_size=24,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -14,6 +14,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from custom_components.matic_robot import (
     _async_resume_native_reconciliation,
     _floor_plan_supports_area_binding,
+    _register_native_history_sync,
     _schedule_native_reconciliation_recovery,
     async_remove_entry,
     async_setup,
@@ -378,6 +379,7 @@ async def test_setup_refreshes_before_forwarding_platforms(
     hass = SimpleNamespace(
         config=SimpleNamespace(time_zone="America/Los_Angeles"),
         config_entries=SimpleNamespace(async_forward_entry_setups=AsyncMock()),
+        bus=SimpleNamespace(async_listen=MagicMock(return_value=MagicMock())),
         data={
             DOMAIN: {
                 DATA_PLAN_MANAGER: plans,
@@ -513,10 +515,12 @@ async def test_setup_refreshes_before_forwarding_platforms(
     coordinator.async_add_listener.assert_called_once()
     sync_callback = coordinator.async_add_listener.call_args.args[0]
     plans.async_add_listener.assert_called_once_with("synthetic-serial", sync_callback)
-    assert entry.async_on_unload.call_args_list == [
+    assert entry.async_on_unload.call_args_list[-2:] == [
         ((coordinator_unsubscribe,), {}),
         ((plan_unsubscribe,), {}),
     ]
+    hass.bus.async_listen.assert_called_once()
+    assert hass.bus.async_listen.call_args.args[0] == f"{DOMAIN}_cleaning_finished"
     sync_area_issue.assert_called_once_with(hass, "entry", {}, setup_floor_plan)
 
     with patch(
@@ -821,3 +825,51 @@ async def test_remove_entry_erases_firmware_history() -> None:
         await async_remove_entry(bare, entry)
 
     delete_bare_area_issue.assert_called_once_with(bare, "entry")
+
+
+async def test_finished_session_credits_rooms_the_robot_completed(hass) -> None:
+    """Any finished clean syncs room history, not just managed plan runs."""
+    from custom_components.matic_robot.const import EVENT_CLEANING_FINISHED
+
+    entry = MagicMock()
+    entry.entry_id = "entry-1"
+    unloads: list = []
+    entry.async_on_unload = unloads.append
+    client = SimpleNamespace(
+        async_get_cleaning_session_records=AsyncMock(return_value=("record",))
+    )
+    plans = SimpleNamespace(async_import_native_history=AsyncMock(return_value=True))
+    coordinator = SimpleNamespace(data=SimpleNamespace(floor_plan="floor-plan"))
+
+    _register_native_history_sync(hass, entry, client, coordinator, plans, "serial")
+    assert unloads
+
+    hass.bus.async_fire(EVENT_CLEANING_FINISHED, {"entry_id": "other"})
+    await hass.async_block_till_done()
+    plans.async_import_native_history.assert_not_awaited()
+
+    hass.bus.async_fire(EVENT_CLEANING_FINISHED, {"entry_id": "entry-1"})
+    await hass.async_block_till_done()
+    plans.async_import_native_history.assert_awaited_once_with(
+        "serial", "floor-plan", ("record",)
+    )
+
+
+async def test_finished_session_sync_survives_an_unreadable_robot(hass) -> None:
+    from custom_components.matic_robot.client.exceptions import MaticError
+    from custom_components.matic_robot.const import EVENT_CLEANING_FINISHED
+
+    entry = MagicMock()
+    entry.entry_id = "entry-1"
+    entry.async_on_unload = MagicMock()
+    client = SimpleNamespace(
+        async_get_cleaning_session_records=AsyncMock(side_effect=MaticError("down"))
+    )
+    plans = SimpleNamespace(async_import_native_history=AsyncMock())
+    coordinator = SimpleNamespace(data=SimpleNamespace(floor_plan="floor-plan"))
+
+    _register_native_history_sync(hass, entry, client, coordinator, plans, "serial")
+    hass.bus.async_fire(EVENT_CLEANING_FINISHED, {"entry_id": "entry-1"})
+    await hass.async_block_till_done()
+
+    plans.async_import_native_history.assert_not_awaited()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -827,8 +827,8 @@ async def test_remove_entry_erases_firmware_history() -> None:
     delete_bare_area_issue.assert_called_once_with(bare, "entry")
 
 
-async def test_finished_session_credits_rooms_the_robot_completed(hass) -> None:
-    """Any finished clean syncs room history, not just managed plan runs."""
+async def test_finished_session_records_where_the_robot_worked(hass) -> None:
+    """Any finished clean updates rotation fairness, claiming no completion."""
     from custom_components.matic_robot.const import EVENT_CLEANING_FINISHED
 
     entry = MagicMock()

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -503,7 +503,7 @@ async def test_area_binding_upgrade_ignores_malformed_area_record(hass) -> None:
     manager._store.async_save.assert_not_awaited()
 
 
-async def test_native_history_import_recovers_only_explicit_room_completions(
+async def test_native_history_import_records_activity_not_completion(
     hass,
 ) -> None:
     manager = CleaningPlanManager(hass)
@@ -618,14 +618,20 @@ async def test_native_history_import_recovers_only_explicit_room_completions(
         await manager.async_import_native_history("serial", floor_plan, records) is True
     )
     history = manager.snapshot("serial")["last_completed_by_room"]
-    assert history["living"] == {
-        "name": "Living Room",
-        "at": "2026-07-28T19:00:00+00:00",
-        "duration_seconds": 121,
-        "runs": 0,
-    }
+    # The robot's record cannot prove a room was finished, so importing it
+    # never claims a completion: it only keeps rotation fairness current.
+    assert history["living"]["at"] is None
+    assert history["living"]["runs"] == 0
+    assert history["living"]["name"] == "Living Room"
     assert history["hall"]["at"] == "2026-07-28T23:30:00+00:00"
     assert "office-a" not in history
+    rooms = manager._robot("serial")["rooms"]
+    # A record with no usable duration still proves the robot worked there,
+    # so the newest such session is the room's latest opportunity.
+    assert rooms["living"]["last_opportunity"] == "2026-07-28T22:00:00+00:00"
+    assert "last_duration_seconds" not in rooms["living"]
+    # A verified completion that is newer than the native evidence stands.
+    assert "last_opportunity" not in rooms["hall"]
     manager._store.async_save.assert_awaited_once()
     listener.assert_called_once()
 

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -113,7 +113,7 @@ def test_leg_groups_split_only_on_settings_changes() -> None:
         cleaning_mode="vacuum",
         coverage_setting="standard",
     )
-    quick_c = _room("Quinns Room", "room-d")
+    quick_c = _room("Guest Room", "room-d")
 
     assert _leg_groups([quick_a, quick_b, standard, quick_c]) == [
         [quick_a, quick_b],

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -28,7 +28,7 @@ def test_release_versions_and_links_are_consistent() -> None:
     hacs = json.loads((ROOT / "hacs.json").read_text())
     project = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]
 
-    assert manifest["version"] == "0.3.9"
+    assert manifest["version"] == "0.3.10"
     assert project["version"] == manifest["version"]
     assert hacs["homeassistant"] == "2026.7.0"
     assert manifest["documentation"].startswith("https://github.com/")


### PR DESCRIPTION
## Problem

Verified on a live robot. A managed plan ended early on a robot error, firmware resumed the task itself minutes later, and the robot was then stopped by a household member while it was in one room of the plan. A restart imported the robot's record and marked that room **cleaned, duration 67 seconds** — the room the robot had been interrupted in. It moved from first in the rotation (most overdue) to last, so it would be skipped for a full cycle after one minute of cleaning.

Root cause is a misread of the protocol, not a threshold problem:

- the robot marks the room it occupied when a session ended exactly the way it marks a room cleaned to the end (67 s vs 1884 s — indistinguishable);
- a clean stopped after 45 s still reported that room in `completed_rooms` **and** `completed: True` for the session.

So `completed_rooms` means *the robot worked here*, not *this room is finished*. Two older records on the same robot show durations of 36 seconds, so it has been happening for a while.

A separate check confirmed the boundary: a mission stopped in transit, before reaching either commanded room, recorded `rooms: []` and `completed_rooms: []` — rooms that were never entered do not appear.

## Fix

Import native evidence as a cleaning **opportunity** — the concept this codebase already uses for a room that was attempted but not verified:

- rotation fairness stays current for cleaning the integration did not manage, so a room the robot just worked in stops monopolising short runs;
- **last cleaned**, per-room durations, and completion counts still come only from runs whose end was verified, so an unverified room stays due;
- the import now runs whenever a session finishes rather than only at startup, so unmanaged cleaning is reflected while it still matters (lifecycle-bound listener, unreadable robot logged and skipped).

Deliberately **not** done: a duration threshold or a plausibility heuristic. Both would paper over the misread field and guess at completion, which this project forbids.

## Testing

The old test asserting recovered completions is replaced by one asserting the new contract (activity recorded, completion never claimed, verified completions still win). Plus session-sync cases for the recorded path, other-entry filtering, and an unreadable robot. 1048 tests at 100.00% coverage; Ruff check/format, strict MyPy, and the privacy scan pass.

## Note on existing data

A room an earlier version credited this way keeps its recorded timestamp: after the fact it is indistinguishable from a verified completion, so the release leaves it rather than guessing. It self-corrects the next time that room is genuinely cleaned.