### PR TITLE
Release-candidate process, plus two unverified-report fixes it caught

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,5 +39,29 @@ surfaces a Home Assistant-native exception.
 - Explain the user-visible behavior and security impact.
 - Add or update tests and documentation.
 - Keep protocol captures and live-device evidence private; describe the result
-  without attaching the underlying data.
+  without attaching the underlying data. That includes pull request and issue
+  text: no real room names, household names, addresses, serials, or raw
+  timings from a real home.
 - Confirm that tests, Ruff, the privacy check, Hassfest, and HACS validation pass.
+
+## Releasing
+
+A green test suite proves the code does what its tests say. It does not prove
+the robot behaves as expected, and several defects here were only visible on
+real hardware. Every release therefore goes out as a candidate first.
+
+1. Merge the change and tag a candidate from the merge commit as a GitHub
+   **pre-release**: `vX.Y.Z-rcN`. HACS does not offer a pre-release as an
+   update unless a user opts in, so publishing one is safe.
+2. Install it on a real robot: HACS -> the integration -> Redownload ->
+   enable **Show beta versions** -> pick the candidate -> restart Home
+   Assistant.
+3. Verify against the robot, not the test suite. Confirm the loaded version,
+   exercise the behavior the change claims to fix, and confirm the failure it
+   guards against still fails closed.
+4. Promote only after that passes: publish `vX.Y.Z` as a normal release from
+   the same commit. If the candidate misbehaves, nothing was ever offered to
+   users; fix it and cut `-rc2`.
+
+Fold related fixes into one candidate rather than publishing a string of
+point releases.

--- a/custom_components/matic_robot/firmware.py
+++ b/custom_components/matic_robot/firmware.py
@@ -257,7 +257,7 @@ class FirmwareTracker:
         snapshot = self._data.get("robots", {}).get(robot_id, {}).get("snapshot", {})
         return bool(
             snapshot.get("firmware_version") != version
-            or snapshot.get("protocol_version") != protocol
+            or (protocol is not None and snapshot.get("protocol_version") != protocol)
             or snapshot.get("analysis_version") != ANALYSIS_VERSION
         )
 
@@ -334,15 +334,30 @@ def _compare_snapshots(
             new_wire_shapes[name] = added
     return {
         "baseline": False,
-        "firmware_changed": previous.get("firmware_version")
-        != current.get("firmware_version"),
-        "protocol_changed": previous.get("protocol_version")
-        != current.get("protocol_version"),
+        "firmware_changed": _release_changed(
+            previous.get("firmware_version"), current.get("firmware_version")
+        ),
+        "protocol_changed": _release_changed(
+            previous.get("protocol_version"), current.get("protocol_version")
+        ),
         "changed_endpoints": availability_changed,
         "content_changed_endpoints": content_changed,
         "wire_shape_changed_endpoints": sorted(new_wire_shapes),
         "new_wire_shapes": new_wire_shapes,
     }
+
+
+def _release_changed(previous: object, current: object) -> bool:
+    """Report a release change only when both readings are known.
+
+    A version the robot could not report is missing information, not a new
+    release.  Comparing it directly made a transient connection failure look
+    like an OTA in both directions - once when the reading was lost and again
+    when it returned - so an unknown reading never counts as a change.
+    """
+    if previous is None or current is None:
+        return False
+    return previous != current
 
 
 def _endpoint_wire_shapes(endpoint: Mapping[str, Any]) -> frozenset[str] | None:

--- a/custom_components/matic_robot/sensor.py
+++ b/custom_components/matic_robot/sensor.py
@@ -725,16 +725,12 @@ class _MaticRoomStatisticsSensor(MaticEntity, RestoreSensor):
         )
         if managed:
             return True, _latest_room_statistics_value(managed_value, historical)
-        completed_rooms = session.completed_rooms
-        if not completed_rooms and session.completed is True:
-            completed_rooms = session.rooms
-        if room.name not in completed_rooms:
-            return historical is not None, historical
-        durations = dict(session.room_durations)
-        if room.name not in durations:
-            return historical is not None, historical
-        native = (session.ended_at, durations[room.name])
-        return historical is not None, _latest_room_statistics_value(native, historical)
+        # A robot-reported session cannot establish that a room was finished:
+        # the robot marks the room it occupied when a session ended, and
+        # reports a stopped session as completed, so trusting it here credited
+        # a room that was interrupted after a minute.  Room statistics
+        # therefore keep the last verified value instead.
+        return historical is not None, historical
 
     @callback
     def _async_apply_session(self) -> None:

--- a/docs/release-notes-0.3.10.md
+++ b/docs/release-notes-0.3.10.md
@@ -46,6 +46,23 @@ duration.
 This release adds no robot protocol commands and keeps all robot traffic,
 cleaning history, maps, and reconciliation data local to Home Assistant.
 
+## Room statistics need the same proof
+
+The per-room **last cleaned** and **clean duration** sensors trusted the same
+robot-reported session, including a fallback that accepted every room in a
+session the robot called completed. A clean stopped after a minute therefore
+recorded that room as cleaned. They now report only verified managed runs and
+otherwise keep their last trusted value.
+
+## An unreadable version is not an update
+
+Firmware analysis compared version readings directly, so a version the robot
+could not report counted as a change - once when the reading was lost and again
+when it returned. A brief connection interruption produced two firmware-change
+events, and any automation listening for them announced an update that never
+happened. A release change is now reported only when both readings are known,
+and an unreadable protocol version no longer requests a fresh snapshot.
+
 ## Verification
 
 The release candidate is gated by the full Python suite at 100% coverage,

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -394,10 +394,11 @@ async def test_room_statistics_sensors_apply_and_restore_sessions() -> None:
         await duration.async_added_to_hass()
         await last_cleaned.async_added_to_hass()
 
-    assert duration.available is True
-    assert duration.native_value == 600
-    assert last_cleaned.native_value is not None
-    assert last_cleaned.native_value.isoformat() == "2026-01-01T08:10:00+00:00"
+    # The robot's own session cannot prove a room was finished, so an
+    # unverified session leaves room statistics empty rather than claiming a
+    # clean that may have been a stop after one minute.
+    assert duration.native_value is None
+    assert last_cleaned.native_value is None
 
     # A room the latest session did not include keeps its restored value.
     stored = SimpleNamespace(native_value=120)
@@ -444,11 +445,11 @@ async def test_room_statistics_sensors_apply_and_restore_sessions() -> None:
     )
     duration._async_apply_session()
     last_cleaned._async_apply_session()
-    assert duration.native_value == 600
-    assert last_cleaned.native_value is not None
-    assert last_cleaned.native_value.isoformat() == "2026-01-01T08:10:00+00:00"
+    assert duration.native_value is None
+    assert last_cleaned.native_value is None
 
-    # A partially completed native run updates only its verified rooms.
+    # A partially completed native run proves nothing either: the robot marks
+    # the room it was stopped in the same way it marks a finished one.
     coordinator.data = replace(
         coordinator.data,
         telemetry=replace(
@@ -468,9 +469,8 @@ async def test_room_statistics_sensors_apply_and_restore_sessions() -> None:
     last_cleaned._async_apply_session()
     study_duration._async_apply_session()
     study_last._async_apply_session()
-    assert duration.native_value == 420
-    assert last_cleaned.native_value is not None
-    assert last_cleaned.native_value.isoformat() == "2026-01-03T08:10:00+00:00"
+    assert duration.native_value is None
+    assert last_cleaned.native_value is None
     assert study_duration.native_value == 120
     assert study_last.native_value == stored_when.native_value
 
@@ -492,7 +492,7 @@ async def test_room_statistics_sensors_apply_and_restore_sessions() -> None:
     fresh = sensor.MaticRoomDurationSensor(entry, kitchen)
     fresh.async_write_ha_state = MagicMock()
     fresh._handle_coordinator_update()
-    assert fresh.native_value == 600
+    assert fresh.native_value is None
 
     # A remap retires statistics entities whose stable room id disappeared,
     # without erasing their restored values.
@@ -1484,3 +1484,46 @@ async def test_vacuum_dock_from_idle_sends_no_stop() -> None:
     client = entry.runtime_data.coordinator.client
     commands = [call.args[0] for call in client.async_send_user_command.await_args_list]
     assert commands == [UserCommand.DOCK]
+
+
+async def test_room_statistics_sensors_use_verified_managed_runs() -> None:
+    """A verified managed run still populates room statistics."""
+    entry = _entry()
+    kitchen = entry.runtime_data.coordinator.data.floor_plan.rooms[0]
+    entry.runtime_data.cleaning_plans.snapshot.return_value = {
+        **entry.runtime_data.cleaning_plans.snapshot.return_value,
+        "plan_history": {
+            "whole_home": {
+                "rooms": {
+                    kitchen.id: {
+                        "room_id": kitchen.id,
+                        "last_started": "2026-01-01T08:00:00+00:00",
+                        "last_completed": "2026-01-01T08:10:00+00:00",
+                        "last_duration_seconds": 600,
+                        "last_result": "completed",
+                    }
+                }
+            }
+        },
+    }
+    duration = sensor.MaticRoomDurationSensor(entry, kitchen)
+    last_cleaned = sensor.MaticRoomLastCleanedSensor(entry, kitchen)
+    with (
+        patch.object(MaticEntity, "async_added_to_hass", AsyncMock()),
+        patch.object(
+            sensor.MaticRoomDurationSensor,
+            "async_get_last_sensor_data",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            sensor.MaticRoomLastCleanedSensor,
+            "async_get_last_sensor_data",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        await duration.async_added_to_hass()
+        await last_cleaned.async_added_to_hass()
+
+    assert duration.native_value == 600
+    assert last_cleaned.native_value is not None
+    assert last_cleaned.native_value.isoformat() == "2026-01-01T08:10:00+00:00"

--- a/tests/test_firmware.py
+++ b/tests/test_firmware.py
@@ -122,7 +122,10 @@ async def test_tracker_persists_snapshots_caps_history_and_summarizes(hass) -> N
     }
     assert tracker.summary("missing")["snapshot_count"] == 0
     assert tracker.needs_snapshot("entry", "v169.0", 25) is False
-    assert tracker.needs_snapshot("entry", "v169.0", None) is True
+    # An unreadable protocol version is missing information, not a new
+    # release: re-snapshotting on it turned a connection blip into a
+    # firmware-change event.
+    assert tracker.needs_snapshot("entry", "v169.0", None) is False
     assert tracker.needs_snapshot("entry", "v170", 25) is True
     legacy_snapshot = _snapshot("v169.0")
     legacy_snapshot.pop("analysis_version")
@@ -420,3 +423,28 @@ def test_fingerprint_entry_keeps_only_hashes_sizes_and_wire_shape() -> None:
     rendered = repr(fingerprint)
     assert "private-key" not in rendered
     assert repr(payload) not in rendered
+
+
+def test_unreadable_version_is_not_reported_as_a_release_change() -> None:
+    """A version that could not be read is not an OTA."""
+    known = _snapshot("v172.12")
+    unreadable = _snapshot("v172.12")
+    unreadable["protocol_version"] = None
+
+    lost = _compare_snapshots(known, unreadable)
+    assert lost["protocol_changed"] is False
+    assert lost["firmware_changed"] is False
+
+    regained = _compare_snapshots(unreadable, known)
+    assert regained["protocol_changed"] is False
+    assert regained["firmware_changed"] is False
+
+    missing_firmware = _snapshot("v172.12")
+    missing_firmware["firmware_version"] = None
+    assert _compare_snapshots(known, missing_firmware)["firmware_changed"] is False
+
+    upgraded = _snapshot("v173.0")
+    assert _compare_snapshots(known, upgraded)["firmware_changed"] is True
+    protocol_bump = _snapshot("v172.12")
+    protocol_bump["protocol_version"] = 26
+    assert _compare_snapshots(known, protocol_bump)["protocol_changed"] is True


### PR DESCRIPTION
## Why

Green CI proved nothing about the robot today. Three defects were invisible to a fully covered suite and only appeared on hardware, so releases now ship as a candidate first — and installing that candidate immediately caught two more, both included here.

## Process

`CONTRIBUTING.md` gains a **Releasing** section and `CLAUDE.md` a matching rule: merge, tag `vX.Y.Z-rcN` as a GitHub **pre-release** (not offered to users), install on a real robot via HACS **Show beta versions**, verify the loaded version and the fixed behavior *and* that the guarded failure still fails closed, then publish `vX.Y.Z` from the same commit. Fold related fixes into one candidate rather than a string of point releases.

The privacy rule now also covers pull request and issue **text**, not just tracked files: no real room names, household names, or raw live timings.

## Fix 1 — room statistics claimed unverified completions

The per-room **last cleaned** and **clean duration** sensors had their own path that trusted `completed_rooms`, plus a fallback accepting *every* room in a session the robot reported as completed. The robot marks the room it was stopped in exactly like a finished one and calls stopped sessions completed, so a clean stopped after ~45 seconds recorded that room as cleaned with a 93-second duration. Measured on rc1.

They now report verified managed runs only and otherwise keep their last trusted value — the same standard 0.3.10 applied to rotation credit.

## Fix 2 — an unreadable version was reported as an update

Firmware analysis compared version readings with `!=`, so a version the robot could not report counted as a change in both directions. One connection interruption produced two firmware-change events (`25 → unknown` then `unknown → 25`), and automations listening for them announced an OTA that never happened.

A release change is now reported only when both readings are known, and an unreadable protocol version no longer requests a fresh snapshot.

## Testing

1050 tests at 100.00% coverage; Ruff check/format, strict MyPy, and the privacy scan pass. The tests that encoded the old assumptions are rewritten to assert the fail-closed contract, with a separate case proving verified managed runs still populate statistics.