### PR TITLE
Release 0.3.11: ending in place is a stop, not a completion

### DIFF
--- a/custom_components/matic_robot/manifest.json
+++ b/custom_components/matic_robot/manifest.json
@@ -24,7 +24,7 @@
     "numpy==2.3.2",
     "protobuf>=6"
   ],
-  "version": "0.3.10",
+  "version": "0.3.11",
   "zeroconf": [
     "_matic_hermes._tcp.local."
   ]

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -110,6 +110,7 @@ class RoomRunOutcome(StrEnum):
     SUSPENDED = "suspended"
     PAUSED = "paused"
     INTERRUPTED = "interrupted"
+    STOPPED_IN_PLACE = "stopped_in_place"
     ROOM_CHANGED = "room_changed"
 
 
@@ -1041,6 +1042,10 @@ async def _async_run_room(
                             serial_number, call.data["plan_id"], room
                         )
                         continue
+                    if outcome is RoomRunOutcome.STOPPED_IN_PLACE:
+                        raise RoomStoppedInPlaceError(
+                            f"{room.name} ended in place without returning"
+                        )
                     if outcome is RoomRunOutcome.INTERRUPTED:
                         raise RoomInterruptedError(
                             f"{room.name} stopped without verified completion"
@@ -1129,8 +1134,12 @@ async def _async_run_room(
             motion_token,
             dispatch_attempted,
         )
-        reconciliation = _build_native_reconciliation(
-            call.data["plan_id"], room, dispatched_at, room_started
+        reconciliation = (
+            None
+            if isinstance(err, RoomStoppedInPlaceError)
+            else _build_native_reconciliation(
+                call.data["plan_id"], room, dispatched_at, room_started
+            )
         )
         async with _managed_reconciliation_guard(
             manager, serial_number, motion_token
@@ -1446,6 +1455,10 @@ async def _async_run_leg(
                             allow_active_cleaning=next_dispatch is not None,
                         )
                         break
+                    if outcome is RoomRunOutcome.STOPPED_IN_PLACE:
+                        raise RoomStoppedInPlaceError(
+                            f"{active_room.name} ended in place without returning"
+                        )
                     # INTERRUPTED cannot occur here: the leg loop starts only
                     # after a confirmed in-room start, so the waiter is seeded
                     # with that observation.
@@ -1509,6 +1522,23 @@ async def _async_run_leg(
                 context=call.context,
             )
         raise
+    except RoomInterruptedError as err:
+        await _async_cleanup_managed_motion(
+            managed_user_command,
+            motion_token,
+            dispatch_attempted,
+        )
+        await manager.async_mark_interrupted(
+            serial_number, call.data["plan_id"], active_room, str(err)
+        )
+        hass.bus.async_fire(
+            f"{DOMAIN}_room_interrupted",
+            {**event_data(active_room), "error": str(err)},
+            context=call.context,
+        )
+        raise _validation_error(
+            str(err), "room_interrupted", {"room": active_room.name}
+        ) from err
     except RoomTakenOverError as err:
         await manager.async_mark_interrupted(
             serial_number, call.data["plan_id"], active_room, str(err)
@@ -1782,7 +1812,13 @@ async def _async_wait_for_leg_outcome(
                 future.set_result((RoomRunOutcome.HANDOFF_CANDIDATE, None))
             else:
                 future.set_result((RoomRunOutcome.INTERRUPTED, None))
-        elif state.state in {"docked", "idle"}:
+        elif state.state == "idle":
+            # Ending in place is a stop, not a finished room.  A task that
+            # completes normally goes through `returning` first and is
+            # resolved above; the robot's own record calls both completed, so
+            # this transition is the only thing that separates them.
+            future.set_result((RoomRunOutcome.STOPPED_IN_PLACE, None))
+        elif state.state == "docked":
             future.set_result(
                 (RoomRunOutcome.HANDOFF_CANDIDATE, None)
                 if observed_any
@@ -2391,6 +2427,17 @@ class RoomStartTimeoutError(TimeoutError):
 
 class RoomInterruptedError(HomeAssistantError):
     """A room command ended without positive completion evidence."""
+
+
+class RoomStoppedInPlaceError(RoomInterruptedError):
+    """The robot's task ended where it stood, so the room was not finished.
+
+    Home Assistant saw the task end in place rather than return, which is
+    positive evidence that the room was stopped.  Late native reconciliation
+    is deliberately not scheduled for it: the robot reports a stopped room the
+    same way it reports a finished one, so a marker would credit exactly the
+    room this transition proves was interrupted.
+    """
 
 
 class RoomTakenOverError(HomeAssistantError):

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -285,6 +285,11 @@ runs, while **last cleaned**, per-room durations, and completion counts still
 come only from runs whose end was verified. A room worked on but not verified
 stays due.
 
+A task that ends where the robot stood was stopped, not finished, and is
+recorded as interrupted: the robot reports a room it was stopped in exactly the
+way it reports a finished one, so the return to the dock is what separates
+them. Late reconciliation is never scheduled for such a run.
+
 Room history advances only after the managed runner positively matches the end
 of the commanded room. Returning, idle, or docked state alone is not completion:
 a low-charge return is suspended and waits for the robot's automatic resume;

--- a/docs/release-notes-0.3.11.md
+++ b/docs/release-notes-0.3.11.md
@@ -1,0 +1,44 @@
+# Release notes — 0.3.11
+
+Released: 2026-08-20
+
+## Summary
+
+0.3.11 closes the last place where a stopped room could still be recorded as
+cleaned: a managed run that ends where the robot stood.
+
+## Ending in place is a stop, not a finished room
+
+The robot reports a room it was stopped in exactly the way it reports a room it
+cleaned to the end, so the robot's record cannot tell them apart. Home
+Assistant can: a finished task returns to its dock, while a stopped one ends in
+place.
+
+- A managed room or leg whose task ends in place is now recorded as
+  interrupted. It receives no completion, no duration, and stays due.
+- A task that returns, or that reaches the dock, is unchanged and still
+  verifies its rooms against the robot's record before crediting them.
+- Late native reconciliation is never scheduled for a task that ended in
+  place. Reconciliation exists for runs Home Assistant lost sight of; here it
+  watched the room stop, so a marker could only ever re-credit the room that
+  stop disproved.
+
+This matters when a clean is stopped outside Home Assistant — from the vendor
+app, for example — while a managed plan is running. Before this release the
+plan verified the stopped room against the robot's record, the record claimed
+completion, and the room was credited and pushed to the back of the rotation.
+
+This release adds no robot protocol commands and keeps all robot traffic,
+cleaning history, maps, and reconciliation data local to Home Assistant.
+
+## Verification
+
+The release candidate is gated by the full Python suite at 100% coverage,
+Ruff check and format, strict MyPy, the public-tree privacy gate, browser
+tests, HACS validation, and Hassfest.
+
+## Upgrading from 0.3.10
+
+Install 0.3.11 through HACS and restart Home Assistant. Existing entries,
+credentials, plans, custom areas, maps, cleaning history, and firmware
+snapshots are preserved.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "matic-home-assistant"
-version = "0.3.10"
+version = "0.3.11"
 description = "Unofficial local-only Home Assistant integration for Matic robot vacuums"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -3283,6 +3283,43 @@ async def test_leg_without_history_reader_credits_nothing(hass) -> None:
     manager.async_mark_completed.assert_not_awaited()
 
 
+async def test_leg_that_ends_in_place_is_interrupted_without_credit(hass) -> None:
+    """A leg stopped mid-mission never credits the room it stood in."""
+    rooms = _leg_rooms()
+    manager = _leg_manager()
+
+    async def send_command(_call) -> None:
+        hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Kitchen"})
+
+        async def stop_in_place() -> None:
+            await asyncio.sleep(0)
+            hass.states.async_set("vacuum.matic", "idle", {"current_area": "Kitchen"})
+
+        hass.async_create_task(stop_in_place(), eager_start=True)
+
+    hass.services.async_register("vacuum", "send_command", send_command)
+    record = _leg_record(("Kitchen",), ("Kitchen",))
+
+    with pytest.raises(ServiceValidationError):
+        await _async_run_leg(
+            hass,
+            _call(hass),
+            manager,
+            "vacuum.matic",
+            "serial",
+            rooms,
+            session_history=AsyncMock(return_value=(record,)),
+            motion_token=7,
+        )
+
+    manager.async_mark_completed.assert_not_awaited()
+    assert (
+        manager.async_mark_interrupted.await_count
+        + manager.async_mark_failed.await_count
+        == 1
+    )
+
+
 async def test_leg_partial_verification_stops_started_next_leg(hass) -> None:
     rooms = _leg_rooms()
     manager = _leg_manager()
@@ -3510,6 +3547,42 @@ async def test_leg_verifier_retries_and_honors_cancellation(hass) -> None:
             cancel_event=late_cancel,
             attempts=2,
         )
+
+
+async def test_a_task_that_ends_in_place_is_not_a_completion_candidate(hass) -> None:
+    """Ending in place is a stop; only a return can end a room normally.
+
+    Live traces on firmware v172.12: a stopped task goes straight to ``idle``
+    where it stood, while a finished one goes ``returning`` first.  The robot's
+    own record calls both completed, so this transition is the only thing that
+    distinguishes them.
+    """
+    room = _room("Kitchen", "room-kitchen")
+    hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Kitchen"})
+
+    async def settle(state: str) -> None:
+        await asyncio.sleep(0)
+        hass.states.async_set("vacuum.matic", state, {"current_area": "Kitchen"})
+
+    hass.async_create_task(settle("idle"), eager_start=True)
+    assert (
+        await _async_wait_for_room_outcome(hass, "vacuum.matic", room)
+        is RoomRunOutcome.STOPPED_IN_PLACE
+    )
+
+    hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Kitchen"})
+    hass.async_create_task(settle("returning"), eager_start=True)
+    assert (
+        await _async_wait_for_room_outcome(hass, "vacuum.matic", room)
+        is RoomRunOutcome.HANDOFF_CANDIDATE
+    )
+
+    hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Kitchen"})
+    hass.async_create_task(settle("docked"), eager_start=True)
+    assert (
+        await _async_wait_for_room_outcome(hass, "vacuum.matic", room)
+        is RoomRunOutcome.HANDOFF_CANDIDATE
+    )
 
 
 async def test_leg_runs_two_rooms_in_one_mission_without_redispatch(hass) -> None:
@@ -4198,7 +4271,7 @@ async def test_room_outcome_requires_target_evidence_and_classifies_recharge(
     )
     await asyncio.sleep(0)
     hass.states.async_set("vacuum.matic", "idle")
-    assert await waiting is RoomRunOutcome.INTERRUPTED
+    assert await waiting is RoomRunOutcome.STOPPED_IN_PLACE
 
     hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "room-study"})
     waiting = asyncio.create_task(
@@ -4245,7 +4318,8 @@ async def test_room_outcome_propagates_errors_and_cancellation(hass) -> None:
     )
     await asyncio.sleep(0)
     hass.states.async_set("vacuum.matic", "idle", {"current_area": "Study"})
-    assert await stopped is RoomRunOutcome.HANDOFF_CANDIDATE
+    # Ending in place is a stop, never a finished room.
+    assert await stopped is RoomRunOutcome.STOPPED_IN_PLACE
 
 
 async def test_room_outcome_ignores_transit_through_other_mapped_rooms(hass) -> None:

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -28,7 +28,7 @@ def test_release_versions_and_links_are_consistent() -> None:
     hacs = json.loads((ROOT / "hacs.json").read_text())
     project = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]
 
-    assert manifest["version"] == "0.3.10"
+    assert manifest["version"] == "0.3.11"
     assert project["version"] == manifest["version"]
     assert hacs["homeassistant"] == "2026.7.0"
     assert manifest["documentation"].startswith("https://github.com/")

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1640,7 +1640,7 @@ async def test_room_handoff_after_returning_does_not_credit_completion(hass) -> 
 
 
 async def test_app_stop_after_partial_room_never_credits_or_advances(hass) -> None:
-    """A direct idle transition ends unverified and receives no credit."""
+    """A direct idle transition is an interruption and receives no credit."""
 
     async def send_command(*_args, **_kwargs) -> None:
         hass.states.async_set("vacuum.test", "cleaning", {"current_area": "Study"})
@@ -1665,23 +1665,22 @@ async def test_app_stop_after_partial_room_never_credits_or_advances(hass) -> No
     session_reader = AsyncMock(return_value=False)
     sender = AsyncMock()
 
-    completed = await _async_run_room(
-        hass,
-        _execution_call(hass),
-        manager,
-        "vacuum.test",
-        "serial",
-        CleaningRoom("room-study", "Study", "vacuum", "quick"),
-        motion_token=17,
-        active_session=session_reader,
-        managed_user_command=sender,
-    )
+    with pytest.raises(ServiceValidationError):
+        await _async_run_room(
+            hass,
+            _execution_call(hass),
+            manager,
+            "vacuum.test",
+            "serial",
+            CleaningRoom("room-study", "Study", "vacuum", "quick"),
+            motion_token=17,
+            active_session=session_reader,
+            managed_user_command=sender,
+        )
 
-    assert completed is False
-    session_reader.assert_awaited_once()
-    sender.assert_not_awaited()
-    manager.async_mark_interrupted.assert_not_awaited()
-    manager.async_mark_ended_unverified.assert_awaited_once()
+    session_reader.assert_not_awaited()
+    manager.async_mark_interrupted.assert_awaited_once()
+    manager.async_mark_ended_unverified.assert_not_awaited()
     manager.async_mark_completed.assert_not_awaited()
 
 


### PR DESCRIPTION
## Problem

Today's releases stopped the *robot's record* from claiming completions it cannot prove — in rotation credit (0.3.10) and in room statistics (0.3.10). One path was left: a managed run that is stopped **outside Home Assistant**, for example from the vendor app.

In that case the managed runner saw the task end, verified the room against the robot's record, and the record claimed completion — because the robot marks a room it was stopped in exactly the way it marks one cleaned to the end. The room was credited and pushed to the back of the rotation after as little as a minute of cleaning.

## Fix

The robot's record cannot separate the two cases, but Home Assistant can observe the difference: **a finished task returns to its dock; a stopped task ends where it stood.** Live traces on v172.12 show every stop going straight to `idle` in place, while completions pass through `returning` first.

- `idle` is now a distinct `STOPPED_IN_PLACE` outcome for both the single-room and leg runners, recorded as interrupted: no completion, no duration, stays due.
- `returning` and `docked` are unchanged and still verify against the robot's record before crediting.
- Late native reconciliation is never scheduled for a task that ended in place. Reconciliation exists for runs Home Assistant lost sight of; here it watched the room stop, so a marker could only re-credit the room the stop disproved. Without this the fix would have moved the false credit rather than removing it.
- The leg runner gains the interrupted handler it was missing, so an interruption is recorded as interrupted rather than surfacing as a raw error.

## Testing

New cases: in-place idle is not a completion candidate while returning and docked still are; a leg stopped mid-mission is interrupted with no credit. Two tests that encoded the old classification are updated. 1052 tests at 100.00% coverage; Ruff check/format, strict MyPy, and the privacy scan pass.

## Live verification

Cannot be fully exercised from Home Assistant, since every HA stop path sets the stop fence and takes the cancellation route. Confirming it needs a stop from the vendor app during a managed plan run — the exact scenario that produced the original report.