### PR TITLE
Reconciliation needs the same evidence as any other completion

### DIFF
--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -2205,9 +2205,22 @@ async def _async_reconcile_native_stop(
     confirm_room_completed: Callable[[str], None] | None,
     context: Context | None,
 ) -> None:
-    """Reconcile one late native completion without issuing another motion command."""
+    """Reconcile one late native completion without issuing another motion command.
+
+    Reconciliation exists for a room Home Assistant lost sight of, so it leans
+    on the robot's own record.  That record reports a room the robot was
+    stopped in exactly like a finished one, so watching the task end in place
+    is positive evidence against it: the watcher abandons the marker instead of
+    crediting the room its own observation disproves.
+    """
     deadline = monotonic() + OEM_STOP_RECONCILIATION_SECONDS
     while monotonic() < deadline:
+        state = hass.states.get(entity_id)
+        if state is not None and state.state == "idle":
+            _LOGGER.debug(
+                "Native Matic reconciliation abandoned: the task ended in place"
+            )
+            break
         try:
             records = await session_history()
         except MaticError as err:

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -285,6 +285,14 @@ runs, while **last cleaned**, per-room durations, and completion counts still
 come only from runs whose end was verified. A room worked on but not verified
 stays due.
 
+The `matic_robot_cleaning_finished` event and the local-sessions sensor pass
+the robot's own session report through unchanged, including its `completed` and
+`completed_rooms` fields. Those are what the robot said, not proof: it reports
+a room it was stopped in, and a stopped session, exactly the way it reports
+finished ones. Automations that need a room to have actually been cleaned
+should use the `matic_robot_room_completed` event or the room's **last
+cleaned** sensor, both of which come only from verified runs.
+
 A task that ends where the robot stood was stopped, not finished, and is
 recorded as interrupted: the robot reports a room it was stopped in exactly the
 way it reports a finished one, so the return to the dock is what separates

--- a/docs/release-notes-0.3.11.md
+++ b/docs/release-notes-0.3.11.md
@@ -31,6 +31,19 @@ completion, and the room was credited and pushed to the back of the rotation.
 This release adds no robot protocol commands and keeps all robot traffic,
 cleaning history, maps, and reconciliation data local to Home Assistant.
 
+## Reconciliation needs the same evidence
+
+Late native reconciliation recovers a room Home Assistant lost sight of, so it
+leans on the robot's record. When the integration can see the robot stop, that
+record is contradicted: the watcher now abandons its marker instead of
+crediting a room its own observation disproves.
+
+The `matic_robot_cleaning_finished` event and the local-sessions sensor still
+report the robot's own `completed` and `completed_rooms` values unchanged.
+Those are the robot's claims rather than verified results, and the
+documentation now says so; use `matic_robot_room_completed` or a room's **last
+cleaned** sensor when an automation needs proof.
+
 ## Verification
 
 The release candidate is gated by the full Python suite at 100% coverage,

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1785,6 +1785,65 @@ async def test_oem_stop_reconciliation_credits_late_native_session(hass) -> None
     confirmed.assert_called_once_with(room.name)
 
 
+async def test_reconciliation_abandons_a_room_seen_ending_in_place(hass) -> None:
+    """Watching the robot stop disproves the completion its record claims."""
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    room = CleaningRoom("room-study", "Study", "vacuum", "quick")
+    dispatched_at = dt_util.utcnow() - timedelta(seconds=30)
+    manager._robot("serial")["pending_native_reconciliation"] = {
+        "plan_id": "away",
+        "room_id": room.room_id,
+        "room": room.name,
+        "dispatched_at": dispatched_at.isoformat(),
+        "expires_at": (dt_util.utcnow() + timedelta(minutes=12)).isoformat(),
+    }
+    ended = dt_util.utcnow()
+    record = CleaningSessionRecord(
+        b"late",
+        CleaningSession(
+            (ended - timedelta(seconds=20)).isoformat(),
+            ended.isoformat(),
+            20,
+            ("Study",),
+            (("Study", 20),),
+            True,
+            completed_rooms=("Study",),
+        ),
+    )
+    hass.states.async_set("vacuum.matic", "idle", {"current_area": "Study"})
+    confirmed: list[str] = []
+
+    with (
+        patch(
+            "custom_components.matic_robot.services.OEM_STOP_RECONCILIATION_SECONDS",
+            0.05,
+        ),
+        patch(
+            "custom_components.matic_robot.services."
+            "OEM_STOP_RECONCILIATION_POLL_SECONDS",
+            0,
+        ),
+    ):
+        await _async_reconcile_native_stop(
+            hass,
+            manager,
+            "serial",
+            "vacuum.matic",
+            room,
+            _NativeReconciliation("away", room.room_id, room.name, dispatched_at),
+            frozenset(),
+            None,
+            AsyncMock(return_value=(record,)),
+            confirmed.append,
+            None,
+        )
+
+    assert confirmed == []
+    snapshot = manager.snapshot("serial")
+    assert snapshot["last_completed_by_room"].get(room.room_id) is None
+
+
 async def test_native_stop_reconciliation_handles_transport_and_timeout(hass) -> None:
     room = CleaningRoom("room-study", "Study", "vacuum", "quick")
     now = dt_util.utcnow()


### PR DESCRIPTION
Completes the audit of everything that trusted the robot's completion report. Folds into the unreleased 0.3.11 candidate rather than becoming another point release.

## The residual

0.3.11 stopped a managed run from crediting a room the robot was stopped in — but a room whose run failed for another reason (transport error, timeout) still gets a late-reconciliation marker. That watcher then trusts the robot's record, which reports a stopped room exactly like a finished one. A stop landing in that room during the window would be credited.

## Fix

Reconciliation exists for a room Home Assistant lost sight of, which is why it leans on the robot's record. But when the integration *can* see the robot stop, that record is contradicted by direct observation. The watcher now abandons its marker on an observed in-place end instead of crediting the room its own observation disproves.

Where Home Assistant genuinely has no evidence — it restarted mid-window — the robot's record remains the only source, and that is unchanged and documented.

## Also documented

The `matic_robot_cleaning_finished` event and the local-sessions sensor pass the robot's `completed` and `completed_rooms` through unchanged. Nothing credits off them, but an automation could inherit the same false signal, so the docs now say these are the robot's claims and point at `matic_robot_room_completed` and the room **last cleaned** sensors for verified results.

## Testing

New case: a watcher that sees the robot idle in the room abandons the marker and credits nothing. 1053 tests at 100.00% coverage; Ruff check/format, strict MyPy, and the privacy scan pass.