### PR TITLE
Fix robot service authorization and resource bounds

### DIFF
--- a/custom_components/matic_robot/client/api.py
+++ b/custom_components/matic_robot/client/api.py
@@ -13,11 +13,11 @@ from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from datetime import UTC, datetime
 from time import monotonic
 from types import TracebackType
-from typing import cast
+from typing import Any, cast
 from uuid import UUID
 
 from google.protobuf.message import DecodeError
-from grpclib.client import Channel
+from grpclib.client import Channel, Stream
 from grpclib.const import Status
 from grpclib.exceptions import GRPCError, ProtocolError, StreamTerminatedError
 from grpclib.protocol import H2Protocol
@@ -86,7 +86,7 @@ from .tls import (
     validate_certificate,
 )
 from .trajectory import decode_approximate_trajectory
-from .wire import decode_fields, first_bytes, first_varint
+from .wire import WireField, decode_fields, first_bytes, first_varint
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -95,10 +95,26 @@ _RPC_TIMEOUT = 10.0
 # Streamed collection reads have per-message timeouts; this caps the whole
 # read so a slow-dripping stream cannot hold a poll cycle open for minutes.
 _COLLECTION_TIMEOUT = 30.0
-_TRACKED_COLLECTION_MAX_BYTES = 64 * 1024 * 1024
+MAX_HERMES_MESSAGE_BYTES = 16 * 1024 * 1024
+_COLLECTION_MAX_BYTES = 64 * 1024 * 1024
 _SESSION_COMPLETED_STATUS = 0
 _ROOM_MODE_NON_COMPLETION_STATUS = 1
 _ROOM_MODE_COMPLETED_STATUS = 2
+_OPERATIONAL_STATE_MAX_BYTES = 256 * 1024
+_OPERATIONAL_STATE_MAX_FIELDS = 1024
+_OPERATIONAL_STATE_MAX_CODES = 256
+_TELEMETRY_TEXT_MAX_BYTES = 512
+_TELEMETRY_NESTED_MAX_BYTES = 64 * 1024
+_TELEMETRY_NESTED_MAX_FIELDS = 256
+_WIFI_STATUS_MAX_BYTES = 256 * 1024
+_WIFI_NETWORK_MAX_COUNT = 256
+_SCHEDULE_MAX_BYTES = 64 * 1024
+_SCHEDULE_MAX_FIELDS = 1024
+_SCHEDULE_MAX_UUIDS = 256
+_SCHEDULE_MAX_DEPTH = 4
+_CLEANING_SESSION_MAX_BYTES = 256 * 1024
+_CLEANING_SESSION_MAX_FIELDS = 1024
+_CLEANING_SESSION_MAX_ROOMS = 256
 
 _TELEMETRY_PROPERTIES = (
     "current_version",
@@ -158,6 +174,48 @@ def _response_value_bytes(response: CollectionResponse) -> bytes:
     return bytes(payload)
 
 
+async def _async_recv_bounded_message(
+    stream: Any,
+    codec: Any,
+    message_type: type[Any],
+) -> Any | None:
+    """Decode one gRPC frame after validating its declared byte length."""
+    metadata = await stream.recv_data(5)
+    if not metadata:
+        return None
+    if len(metadata) != 5:
+        raise ProtocolError("truncated gRPC message header")
+    if struct.unpack("?", metadata[:1])[0]:
+        raise NotImplementedError("Compression not implemented")
+    message_length = struct.unpack(">I", metadata[1:])[0]
+    if message_length > MAX_HERMES_MESSAGE_BYTES:
+        raise CannotConnectError("Hermes response exceeds the message byte limit")
+    message_bytes = await stream.recv_data(message_length)
+    if len(message_bytes) != message_length:
+        raise ProtocolError("truncated gRPC message body")
+    return codec.decode(message_bytes, message_type)
+
+
+class _BoundedStream(Stream[Any, Any]):
+    """grpclib client stream with a preallocation message-size guard."""
+
+    async def recv_message(self) -> Any | None:
+        if not self._recv_initial_metadata_done:
+            await self.recv_initial_metadata()
+
+        with self._wrapper:
+            message = await _async_recv_bounded_message(
+                self._stream, self._codec, self._recv_type
+            )
+            if message is None:
+                return None
+            (message,) = await self._dispatch.recv_message(message)
+            self._messages_received += 1
+            self._stream.connection.messages_received += 1
+            self._stream.connection.last_message_received = monotonic()
+            return message
+
+
 async def _async_connection_candidates(
     host: str, hostname: str | None, port: int
 ) -> list[str]:
@@ -205,6 +263,14 @@ class _PinnedChannel(Channel):
         self._expected_hostname = expected_hostname
         self._expected_serial = expected_serial
         self._expected_fingerprint = expected_fingerprint
+
+    def request(self, *args: Any, **kwargs: Any) -> Stream[Any, Any]:
+        """Create the bounded stream used by every generated Hermes stub."""
+        stream = super().request(*args, **kwargs)
+        # grpclib has no public stream-factory hook. Its Stream has no slots, so
+        # switching to this behavior-only subclass preserves initialized state.
+        cast(Any, stream).__class__ = _BoundedStream
+        return stream
 
     async def _create_connection(self) -> H2Protocol:
         protocol = await super()._create_connection()
@@ -810,6 +876,7 @@ class MaticHermesClient(AbstractAsyncContextManager["MaticHermesClient"]):
             )
         )
         entries: list[HermesCollectionEntry] = []
+        collected_bytes = 0
         async with self._map_stream_errors(f"{collection_name} collection"):
             async with HermesStub(channel).FetchCollection.open(
                 metadata=self._metadata
@@ -833,6 +900,14 @@ class MaticHermesClient(AbstractAsyncContextManager["MaticHermesClient"]):
                     if not response.HasField("value"):
                         continue
                     payload = _response_value_bytes(response)
+                    entry_size = len(response.key_bytes) + len(payload)
+                    if collected_bytes + entry_size > _COLLECTION_MAX_BYTES:
+                        await _async_cancel_stream(stream)
+                        raise CannotConnectError(
+                            f"Hermes {collection_name} collection exceeds "
+                            "the byte limit"
+                        )
+                    collected_bytes += entry_size
                     entries.append(
                         HermesCollectionEntry(bytes(response.key_bytes), payload)
                     )
@@ -939,7 +1014,7 @@ class MaticHermesClient(AbstractAsyncContextManager["MaticHermesClient"]):
                     break
                 received = True
                 collected_bytes += len(entry.key) + len(entry.value)
-                if collected_bytes > _TRACKED_COLLECTION_MAX_BYTES:
+                if collected_bytes > _COLLECTION_MAX_BYTES:
                     raise CannotConnectError(
                         f"Hermes {collection_name} collection exceeds the byte limit"
                     )
@@ -1115,11 +1190,56 @@ class MaticHermesClient(AbstractAsyncContextManager["MaticHermesClient"]):
         return self._credential.metadata()
 
 
+def _bounded_fields(
+    payload: bytes,
+    *,
+    max_bytes: int,
+    max_fields: int,
+) -> tuple[WireField, ...]:
+    """Decode a protobuf message only within semantic byte and field budgets."""
+    if len(payload) > max_bytes:
+        raise DecodeError("telemetry payload exceeds the byte limit")
+    fields = decode_fields(payload)
+    if len(fields) > max_fields:
+        raise DecodeError("telemetry payload has too many fields")
+    return fields
+
+
+def _decode_text_from_fields(fields: tuple[WireField, ...], number: int) -> str | None:
+    """Decode one bounded UTF-8 string from already parsed fields."""
+    value = next(
+        (
+            field.value
+            for field in fields
+            if field.number == number
+            and field.wire_type == 2
+            and isinstance(field.value, bytes)
+        ),
+        None,
+    )
+    if value is None or len(value) > _TELEMETRY_TEXT_MAX_BYTES:
+        return None
+    try:
+        return value.decode("utf-8").strip() or None
+    except UnicodeDecodeError:
+        return None
+
+
 def _decode_operational_state(payload: bytes) -> RobotOperationalState:
     """Decode the verified subset of Matic's internal Kabuki output."""
+    fields = _bounded_fields(
+        payload,
+        max_bytes=_OPERATIONAL_STATE_MAX_BYTES,
+        max_fields=_OPERATIONAL_STATE_MAX_FIELDS,
+    )
     wire = KabukiOutputWire.FromString(payload)
+    if (
+        len(wire.states) > _OPERATIONAL_STATE_MAX_CODES
+        or len(wire.errors) > _OPERATIONAL_STATE_MAX_CODES
+    ):
+        raise DecodeError("operational state has too many status codes")
     voice_status, voice_intent, gesture_status, following_person = _decode_cues_state(
-        payload
+        fields
     )
     percentage = None
     if wire.HasField("battery_fraction") and math.isfinite(wire.battery_fraction):
@@ -1135,11 +1255,11 @@ def _decode_operational_state(payload: bytes) -> RobotOperationalState:
         paused=any(code in states for code in (120, 200, 302)),
         cleaning=119 in states,
         returning=104 in states,
-        software_version=_decode_text_field(payload, 4),
-        release_channel=_decode_text_field(payload, 5),
-        current_area=_decode_text_field(payload, 16),
-        previous_area=_decode_text_field(payload, 14),
-        robot_profile=_decode_text_field(payload, 17),
+        software_version=_decode_text_from_fields(fields, 4),
+        release_channel=_decode_text_from_fields(fields, 5),
+        current_area=_decode_text_from_fields(fields, 16),
+        previous_area=_decode_text_from_fields(fields, 14),
+        robot_profile=_decode_text_from_fields(fields, 17),
         cues_voice_status=voice_status,
         cues_voice_intent=voice_intent,
         cues_gesture_status=gesture_status,
@@ -1183,7 +1303,7 @@ _CUES_GESTURES_BY_FIELD = {
 
 
 def _decode_cues_state(
-    payload: bytes,
+    output_fields: tuple[WireField, ...],
 ) -> tuple[
     CuesVoiceStatus | None,
     CuesIntent | None,
@@ -1195,14 +1315,18 @@ def _decode_cues_state(
     voice_intent: CuesIntent | None = None
     gesture_status: CuesGestureStatus | None = None
     following_person: bool | None = None
-    for output_field in decode_fields(payload):
+    for output_field in output_fields:
         if (
             output_field.number != 18
             or output_field.wire_type != 2
             or not isinstance(output_field.value, bytes)
         ):
             continue
-        for cues_field in decode_fields(output_field.value):
+        for cues_field in _bounded_fields(
+            output_field.value,
+            max_bytes=_TELEMETRY_NESTED_MAX_BYTES,
+            max_fields=_TELEMETRY_NESTED_MAX_FIELDS,
+        ):
             if cues_field.number == 17 and cues_field.wire_type == 2:
                 assert isinstance(cues_field.value, bytes)
                 voice_status, voice_intent = _decode_cues_voice_status(cues_field.value)
@@ -1225,7 +1349,11 @@ def _decode_cues_voice_status(
     """Decode Matic's VoiceStatus oneof without retaining voice content."""
     status: CuesVoiceStatus | None = None
     intent: CuesIntent | None = None
-    for field in decode_fields(payload):
+    for field in _bounded_fields(
+        payload,
+        max_bytes=_TELEMETRY_NESTED_MAX_BYTES,
+        max_fields=_TELEMETRY_NESTED_MAX_FIELDS,
+    ):
         if field.wire_type != 2 or not isinstance(field.value, bytes):
             continue
         if field.number == 1:
@@ -1254,7 +1382,11 @@ def _decode_cues_voice_status(
 def _decode_cues_intent(payload: bytes) -> CuesIntent:
     """Decode the classified intent kind, excluding recording-only variants."""
     intent = CuesIntent.UNKNOWN
-    for field in decode_fields(payload):
+    for field in _bounded_fields(
+        payload,
+        max_bytes=_TELEMETRY_NESTED_MAX_BYTES,
+        max_fields=_TELEMETRY_NESTED_MAX_FIELDS,
+    ):
         if field.wire_type == 2 and isinstance(field.value, bytes):
             intent = _CUES_INTENTS_BY_FIELD.get(field.number, CuesIntent.UNKNOWN)
     return intent
@@ -1263,7 +1395,11 @@ def _decode_cues_intent(payload: bytes) -> CuesIntent:
 def _decode_cues_gesture_status(payload: bytes) -> CuesGestureStatus | None:
     """Decode Matic's gesture lifecycle oneof without coordinates or imagery."""
     status = None
-    for field in decode_fields(payload):
+    for field in _bounded_fields(
+        payload,
+        max_bytes=_TELEMETRY_NESTED_MAX_BYTES,
+        max_fields=_TELEMETRY_NESTED_MAX_FIELDS,
+    ):
         if field.wire_type == 2 and isinstance(field.value, bytes):
             status = _CUES_GESTURES_BY_FIELD.get(field.number, status)
     return status
@@ -1304,7 +1440,10 @@ def _decode_text_field(payload: object, number: int) -> str | None:
     if not isinstance(payload, bytes):
         return None
     try:
-        return first_bytes(payload, number).decode("utf-8").strip() or None
+        value = first_bytes(payload, number)
+        if len(value) > _TELEMETRY_TEXT_MAX_BYTES:
+            return None
+        return value.decode("utf-8").strip() or None
     except DecodeError, UnicodeDecodeError:
         return None
 
@@ -1401,7 +1540,7 @@ def _decode_wifi_status(
     payload: object,
 ) -> tuple[str | None, str | None, int | None, tuple[WifiNetwork, ...]]:
     """Decode the current Wi-Fi link and full locally visible network scan."""
-    if not isinstance(payload, bytes):
+    if not isinstance(payload, bytes) or len(payload) > _WIFI_STATUS_MAX_BYTES:
         return None, None, None, ()
     names = {
         0: "unknown",
@@ -1421,10 +1560,26 @@ def _decode_wifi_status(
     networks: list[WifiNetwork] = []
     try:
         scan = first_bytes(payload, 7)
-        for field in decode_fields(scan):
+        scan_fields = _bounded_fields(
+            scan,
+            max_bytes=_WIFI_STATUS_MAX_BYTES,
+            max_fields=_WIFI_NETWORK_MAX_COUNT * 2,
+        )
+        network_count = sum(
+            field.number == 1 and isinstance(field.value, bytes)
+            for field in scan_fields
+        )
+        if network_count > _WIFI_NETWORK_MAX_COUNT:
+            return state, ssid, None, ()
+        for field in scan_fields:
             if field.number != 1 or not isinstance(field.value, bytes):
                 continue
             item = field.value
+            _bounded_fields(
+                item,
+                max_bytes=_TELEMETRY_NESTED_MAX_BYTES,
+                max_fields=_TELEMETRY_NESTED_MAX_FIELDS,
+            )
             network_ssid = _decode_text_field(item, 1) or _decode_text_field(item, 7)
             if network_ssid is None:
                 continue
@@ -1501,6 +1656,8 @@ def _decode_coverage_time(payload: object) -> int | None:
 
 def _decode_schedule(payload: bytes) -> CleaningSchedule | None:
     """Decode a robot-native weekly cleaning schedule."""
+    if len(payload) > _SCHEDULE_MAX_BYTES:
+        return None
     try:
         weekly = first_bytes(payload, 1)
         days = first_bytes(weekly, 1)
@@ -1538,6 +1695,10 @@ def _decode_schedule(payload: bytes) -> CleaningSchedule | None:
     except DecodeError:
         pass
 
+    try:
+        room_ids = _uuid_candidates(payload)
+    except DecodeError:
+        return None
     return CleaningSchedule(
         name=_decode_text_field(payload, 2),
         weekdays=tuple(weekdays),
@@ -1545,21 +1706,27 @@ def _decode_schedule(payload: bytes) -> CleaningSchedule | None:
         timezone=timezone,
         ordered=ordered,
         enabled=enabled,
-        room_ids=_uuid_candidates(payload),
+        room_ids=room_ids,
     )
 
 
 def _uuid_candidates(payload: bytes) -> tuple[str, ...]:
     """Return stable UUID values nested in a protocol payload."""
     found: list[str] = []
+    seen: set[str] = set()
+    field_count = 0
 
     def walk(data: bytes, depth: int) -> None:
-        if depth > 10:
+        nonlocal field_count
+        if depth > _SCHEDULE_MAX_DEPTH:
             return
         try:
             fields = decode_fields(data)
         except DecodeError:
             return
+        field_count += len(fields)
+        if field_count > _SCHEDULE_MAX_FIELDS:
+            raise DecodeError("schedule has too many nested fields")
         fixed = {
             field.number: field.value
             for field in fields
@@ -1568,7 +1735,10 @@ def _uuid_candidates(payload: bytes) -> tuple[str, ...]:
         if set(fixed) >= {1, 2} and len(fixed[1]) == len(fixed[2]) == 8:
             low, high = struct.unpack("<QQ", fixed[1] + fixed[2])
             candidate = str(UUID(int=(low << 64) | high))
-            if candidate not in found:
+            if candidate not in seen:
+                if len(found) >= _SCHEDULE_MAX_UUIDS:
+                    raise DecodeError("schedule has too many room identifiers")
+                seen.add(candidate)
                 found.append(candidate)
         for field in fields:
             if field.wire_type == 2 and isinstance(field.value, bytes):
@@ -1580,6 +1750,8 @@ def _uuid_candidates(payload: bytes) -> tuple[str, ...]:
 
 def _decode_cleaning_session(payload: bytes) -> CleaningSession | None:
     """Decode native history without treating its global default as room proof."""
+    if len(payload) > _CLEANING_SESSION_MAX_BYTES:
+        return None
     try:
         summary = first_bytes(payload, 5)
     except DecodeError:
@@ -1587,18 +1759,27 @@ def _decode_cleaning_session(payload: bytes) -> CleaningSession | None:
     started_at = _decode_nested_timestamp(summary, 3)
     ended_at = _decode_nested_timestamp(summary, 4)
     rooms: list[str] = []
+    seen_rooms: set[str] = set()
     room_durations: dict[str, int] = {}
     room_mode_statuses: dict[str, set[int]] = {}
     rooms_with_unknown_status: set[str] = set()
     try:
-        fields = decode_fields(summary)
+        fields = _bounded_fields(
+            summary,
+            max_bytes=_CLEANING_SESSION_MAX_BYTES,
+            max_fields=_CLEANING_SESSION_MAX_FIELDS,
+        )
     except DecodeError:
         return None
     for group in fields:
         if group.number not in (6, 7) or not isinstance(group.value, bytes):
             continue
         try:
-            room_fields = decode_fields(group.value)
+            room_fields = _bounded_fields(
+                group.value,
+                max_bytes=_TELEMETRY_NESTED_MAX_BYTES,
+                max_fields=_TELEMETRY_NESTED_MAX_FIELDS,
+            )
         except DecodeError:
             continue
         for room_field in room_fields:
@@ -1606,13 +1787,20 @@ def _decode_cleaning_session(payload: bytes) -> CleaningSession | None:
                 continue
             try:
                 details = first_bytes(room_field.value, 2)
-                detail_fields = decode_fields(details)
+                detail_fields = _bounded_fields(
+                    details,
+                    max_bytes=_TELEMETRY_NESTED_MAX_BYTES,
+                    max_fields=_TELEMETRY_NESTED_MAX_FIELDS,
+                )
             except DecodeError:
                 continue
             name = _decode_text_field(details, 3)
             if name is None:
                 continue
-            if name not in rooms:
+            if name not in seen_rooms:
+                if len(rooms) >= _CLEANING_SESSION_MAX_ROOMS:
+                    return None
+                seen_rooms.add(name)
                 rooms.append(name)
             status_fields = [field for field in detail_fields if field.number in (5, 6)]
             statuses = room_mode_statuses.setdefault(name, set())

--- a/custom_components/matic_robot/client/floor_plan.py
+++ b/custom_components/matic_robot/client/floor_plan.py
@@ -42,6 +42,12 @@ _ROOM_FILL_ALPHA = 0x99
 _LABEL_BACKGROUND = (16, 21, 29, 0xCC)
 _ROBOT_GLOW = (255, 255, 255, 0x44)
 _OPAQUE_ONLY = (0,) * 255 + (255,)
+MAX_FLOOR_PLAN_PAYLOAD_BYTES = 2 * 1024 * 1024
+MAX_FLOOR_PLAN_ROOMS = 256
+MAX_ROOM_BOUNDARY_POINTS = 4096
+MAX_FLOOR_PLAN_BOUNDARY_POINTS = 65536
+MAX_ROOM_NAME_BYTES = 256
+MAX_MAP_COORDINATE = 10_000.0
 
 _Point = tuple[float, float]
 _Box = tuple[int, int, int, int]
@@ -68,6 +74,8 @@ def _rgba(hex_color: str, alpha: int) -> tuple[int, int, int, int]:
 
 def decode_floor_plan(payload: bytes) -> FloorPlan:
     """Decode the current standard partition and its named rooms."""
+    if len(payload) > MAX_FLOOR_PLAN_PAYLOAD_BYTES:
+        raise DecodeError("coverage plan exceeds the byte limit")
     partitions = bytes_fields(payload, 10)
     if not partitions:
         raise DecodeError("coverage plan has no standard partition")
@@ -77,15 +85,35 @@ def decode_floor_plan(payload: bytes) -> FloorPlan:
     partition_id_wire = first_bytes(partition, 1)
     region_collection = first_bytes(partition, 3)
 
+    region_wires = bytes_fields(region_collection, 1)
+    if len(region_wires) > MAX_FLOOR_PLAN_ROOMS:
+        raise DecodeError("coverage plan has too many rooms")
+
     rooms: list[Room] = []
-    for region_wire in bytes_fields(region_collection, 1):
+    total_boundary_points = 0
+    for region_wire in region_wires:
         region_id_wire = first_bytes(region_wire, 1)
         region = first_bytes(region_wire, 2)
         names = bytes_fields(region, 9)
-        name = names[0].decode("utf-8", errors="replace").strip() if names else ""
+        name_bytes = names[0] if names else b""
+        if len(name_bytes) > MAX_ROOM_NAME_BYTES:
+            raise DecodeError("coverage plan room name exceeds the byte limit")
+        name = name_bytes.decode("utf-8", errors="replace").strip()
         border = first_bytes(first_bytes(region, 10), 1)
         walk = first_bytes(border, 2)
-        boundary = tuple(point(value) for value in bytes_fields(walk, 1))
+        boundary_wires = bytes_fields(walk, 1)
+        if len(boundary_wires) > MAX_ROOM_BOUNDARY_POINTS:
+            raise DecodeError("coverage plan room has too many boundary points")
+        total_boundary_points += len(boundary_wires)
+        if total_boundary_points > MAX_FLOOR_PLAN_BOUNDARY_POINTS:
+            raise DecodeError("coverage plan has too many boundary points")
+        boundary = tuple(point(value) for value in boundary_wires)
+        if any(
+            not math.isfinite(coordinate) or abs(coordinate) > MAX_MAP_COORDINATE
+            for boundary_point in boundary
+            for coordinate in boundary_point
+        ):
+            raise DecodeError("coverage plan has an invalid boundary coordinate")
         if len(boundary) < 3:
             continue
         rooms.append(

--- a/custom_components/matic_robot/config_flow.py
+++ b/custom_components/matic_robot/config_flow.py
@@ -141,8 +141,23 @@ async def _async_discover_robots(
                 properties=info.decoded_properties,
             )
 
-    resolved = await asyncio.gather(*(_resolve(name) for name in sorted(names)))
-    return [info for info in resolved if info is not None]
+    tasks = [asyncio.create_task(_resolve(name)) for name in sorted(names)]
+    if not tasks:
+        return []
+    try:
+        done, _pending = await asyncio.wait(
+            tasks, timeout=DISCOVERY_RESOLVE_TIMEOUT_SECONDS
+        )
+        resolved = [
+            info
+            for task in tasks
+            if task in done and (info := task.result()) is not None
+        ]
+    finally:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+    return sorted(resolved, key=lambda info: info.name)
 
 
 def _preferred_discovery_host(discovery_info: ZeroconfServiceInfo) -> str:

--- a/custom_components/matic_robot/config_flow.py
+++ b/custom_components/matic_robot/config_flow.py
@@ -63,6 +63,7 @@ from .const import (
     DOMAIN,
     SERVICE_TYPE,
 )
+from .plans import MAX_SAVED_PLANS_PER_ROBOT
 from .room_plan_selector import MaticRoomPlanSelector
 from .slam_scene import scene_api_url
 
@@ -72,6 +73,9 @@ PAIRING_ATTEMPTS = PAIRING_TIMEOUT_SECONDS // PAIRING_RETRY_SECONDS
 MANUAL_DISCOVERY_SECONDS = 3
 DISCOVERY_PROBE_TIMEOUT_SECONDS = 5
 DISCOVERY_RESOLVE_TIMEOUT_SECONDS = 2
+MAX_DISCOVERY_SERVICES = 64
+MAX_DISCOVERY_ADDRESSES = 32
+DISCOVERY_RESOLVE_CONCURRENCY = 8
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -96,7 +100,8 @@ async def _async_discover_robots(
     ) -> None:
         del zeroconf, service_type
         if state_change in {ServiceStateChange.Added, ServiceStateChange.Updated}:
-            names.add(name)
+            if name in names or len(names) < MAX_DISCOVERY_SERVICES:
+                names.add(name)
 
     async_zeroconf = await async_get_async_instance(hass)
     browser = AsyncServiceBrowser(
@@ -109,25 +114,32 @@ async def _async_discover_robots(
     finally:
         await browser.async_cancel()
 
+    resolver_slots = asyncio.Semaphore(DISCOVERY_RESOLVE_CONCURRENCY)
+
     async def _resolve(name: str) -> ZeroconfServiceInfo | None:
-        info = AsyncServiceInfo(SERVICE_TYPE, name)
-        if not await info.async_request(
-            async_zeroconf.zeroconf, int(discovery_seconds * 1000)
-        ):
-            return None
-        addresses = info.parsed_scoped_addresses(IPVersion.All)
-        if not addresses or info.port is None or info.server is None:
-            return None
-        parsed_addresses = [ip_address(address.split("%")[0]) for address in addresses]
-        return ZeroconfServiceInfo(
-            ip_address=parsed_addresses[0],
-            ip_addresses=parsed_addresses,
-            port=info.port,
-            hostname=info.server,
-            type=info.type,
-            name=info.name,
-            properties=info.decoded_properties,
-        )
+        async with resolver_slots:
+            info = AsyncServiceInfo(SERVICE_TYPE, name)
+            if not await info.async_request(
+                async_zeroconf.zeroconf, int(discovery_seconds * 1000)
+            ):
+                return None
+            addresses = info.parsed_scoped_addresses(IPVersion.All)[
+                :MAX_DISCOVERY_ADDRESSES
+            ]
+            if not addresses or info.port is None or info.server is None:
+                return None
+            parsed_addresses = [
+                ip_address(address.split("%")[0]) for address in addresses
+            ]
+            return ZeroconfServiceInfo(
+                ip_address=parsed_addresses[0],
+                ip_addresses=parsed_addresses,
+                port=info.port,
+                hostname=info.server,
+                type=info.type,
+                name=info.name,
+                properties=info.decoded_properties,
+            )
 
     resolved = await asyncio.gather(*(_resolve(name) for name in sorted(names)))
     return [info for info in resolved if info is not None]
@@ -185,6 +197,7 @@ async def _async_select_discovery_host(
         )
     )
     candidates.sort(key=lambda address: ":" in address)
+    candidates = candidates[:MAX_DISCOVERY_ADDRESSES]
 
     async def _async_probe(address: str) -> str | None:
         try:
@@ -1615,6 +1628,11 @@ class MaticRobotOptionsFlow(config_entries.OptionsFlow):
             plan_id = slugify(user_input["name"])
             if not plan_id or plan_id in self._manager.plans(self._serial_number):
                 errors["name"] = "duplicate_plan"
+            elif (
+                len(self._manager.plans(self._serial_number))
+                >= MAX_SAVED_PLANS_PER_ROBOT
+            ):
+                errors["base"] = "plan_limit_reached"
             else:
                 rooms = self._rooms_from_editor(user_input)
                 if not rooms:

--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -34,6 +34,7 @@ STORAGE_KEY = f"{DOMAIN}.plans"
 PLAN_MOTION_TOKEN = "_matic_plan_run"
 DURATION_HISTORY_MAX_SAMPLES = 7
 DURATION_CONFIDENCE_MIN_SAMPLES = 3
+MAX_SAVED_PLANS_PER_ROBOT = 256
 ROTATION_FUTURE_TOLERANCE_SECONDS = 24 * 60 * 60
 # Matic's native STOP is graceful: it can keep the current task alive for
 # roughly ten minutes before returning to the dock.  Keep a small safety
@@ -41,6 +42,10 @@ ROTATION_FUTURE_TOLERANCE_SECONDS = 24 * 60 * 60
 OEM_STOP_RECONCILIATION_SECONDS = 12 * 60
 OEM_STOP_FENCE_SECONDS = OEM_STOP_RECONCILIATION_SECONDS
 STOP_FENCE_EXPIRES_AT = "stop_fence_expires_at"
+
+
+class SavedPlanLimitError(HomeAssistantError):
+    """Raised when a robot already has the maximum saved plans."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -640,7 +645,13 @@ class CleaningPlanManager:
     ) -> None:
         """Create or replace a validated room-native plan definition."""
         robot = self._robot(serial_number)
-        robot["plans"][plan_id] = deepcopy(dict(plan))
+        plans = robot["plans"]
+        if plan_id not in plans and len(plans) >= MAX_SAVED_PLANS_PER_ROBOT:
+            raise SavedPlanLimitError(
+                "A Matic robot can have at most "
+                f"{MAX_SAVED_PLANS_PER_ROBOT} saved plans"
+            )
+        plans[plan_id] = deepcopy(dict(plan))
         if select or robot.get("selected_plan") is None:
             robot["selected_plan"] = plan_id
         await self._async_save_and_notify(serial_number)

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -4,16 +4,18 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine, Sequence
 from contextlib import asynccontextmanager
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
+from functools import wraps
 from time import monotonic
 from typing import Any
 
 import voluptuous as vol
+from homeassistant.auth.permissions.const import POLICY_CONTROL
 from homeassistant.components.vacuum.const import DOMAIN as VACUUM_DOMAIN
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import (
@@ -33,7 +35,12 @@ from homeassistant.core import (
     SupportsResponse,
     callback,
 )
-from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.exceptions import (
+    HomeAssistantError,
+    ServiceValidationError,
+    Unauthorized,
+    UnknownUser,
+)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import target
@@ -63,6 +70,7 @@ from .plans import (
     CleaningPlanManager,
     CleaningRoom,
     ManagedMotionReplacedError,
+    SavedPlanLimitError,
     resolve_room_reference,
     resolve_rooms,
 )
@@ -268,6 +276,32 @@ INSPECT_ENDPOINT_SERVICE_SCHEMA = cv.make_entity_service_schema(
 FIRMWARE_SNAPSHOT_SCHEMA = cv.make_entity_service_schema({})
 
 
+def _require_matic_control[ServiceResult](
+    hass: HomeAssistant,
+    handler: Callable[[ServiceCall], Coroutine[Any, Any, ServiceResult]],
+) -> Callable[[ServiceCall], Coroutine[Any, Any, ServiceResult]]:
+    """Apply Home Assistant's entity-control policy to a domain service."""
+
+    @wraps(handler)
+    async def async_authorized(call: ServiceCall) -> ServiceResult:
+        user_id = call.context.user_id
+        if user_id is not None:
+            user = await hass.auth.async_get_user(user_id)
+            if user is None:
+                raise UnknownUser(context=call.context)
+            if not user.is_admin:
+                for entity_id in _resolve_loaded_matic_vacuums(hass, call):
+                    if not user.permissions.check_entity(entity_id, POLICY_CONTROL):
+                        raise Unauthorized(
+                            context=call.context,
+                            entity_id=entity_id,
+                            permission=POLICY_CONTROL,
+                        )
+        return await handler(call)
+
+    return async_authorized
+
+
 async def async_register_services(hass: HomeAssistant) -> None:
     """Register actions before any config entry is loaded."""
 
@@ -317,7 +351,7 @@ async def async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_CLEAN,
-        async_clean,
+        _require_matic_control(hass, async_clean),
         schema=CLEAN_SERVICE_SCHEMA,
     )
 
@@ -374,7 +408,7 @@ async def async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_CLEAN_AREA,
-        async_clean_area,
+        _require_matic_control(hass, async_clean_area),
         schema=CLEAN_AREA_SERVICE_SCHEMA,
     )
 
@@ -470,19 +504,19 @@ async def async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_INTELLIGENT_CLEAN,
-        async_intelligent_clean,
+        _require_matic_control(hass, async_intelligent_clean),
         schema=SAVED_PLAN_SERVICE_SCHEMA,
     )
     hass.services.async_register(
         DOMAIN,
         SERVICE_CLEAN_ENTIRE_PLAN,
-        async_clean_entire_plan,
+        _require_matic_control(hass, async_clean_entire_plan),
         schema=SAVED_PLAN_SERVICE_SCHEMA,
     )
     hass.services.async_register(
         DOMAIN,
         SERVICE_RUN_SELECTED_PLAN,
-        async_run_selected_plan,
+        _require_matic_control(hass, async_run_selected_plan),
         schema=SAVED_PLAN_SERVICE_SCHEMA,
     )
 
@@ -510,7 +544,7 @@ async def async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_PREVIEW_PLAN,
-        async_preview_plan,
+        _require_matic_control(hass, async_preview_plan),
         schema=SAVED_PLAN_SERVICE_SCHEMA,
         supports_response=SupportsResponse.ONLY,
     )
@@ -535,7 +569,7 @@ async def async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_STOP_INTELLIGENT_CLEANING,
-        async_stop_intelligent_cleaning,
+        _require_matic_control(hass, async_stop_intelligent_cleaning),
         schema=PLAN_TARGET_SCHEMA,
     )
 
@@ -557,7 +591,7 @@ async def async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_RESET_PLAN_HISTORY,
-        async_reset_plan_history,
+        _require_matic_control(hass, async_reset_plan_history),
         schema=RESET_PLAN_HISTORY_SCHEMA,
     )
 
@@ -580,7 +614,7 @@ async def async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_LIST_PLANS,
-        async_list_plans,
+        _require_matic_control(hass, async_list_plans),
         schema=LIST_PLANS_SCHEMA,
         supports_response=SupportsResponse.ONLY,
     )
@@ -606,15 +640,18 @@ async def async_register_services(hass: HomeAssistant) -> None:
             "start_timeout": call.data["start_timeout"],
             "completion_timeout": call.data["completion_timeout"],
         }
-        await manager.async_save_plan(
-            serial_number, plan_id, plan, select=call.data["select"]
-        )
+        try:
+            await manager.async_save_plan(
+                serial_number, plan_id, plan, select=call.data["select"]
+            )
+        except SavedPlanLimitError as err:
+            raise _validation_error(str(err), "plan_limit_reached") from err
         return {"plan": {"id": plan_id, **deepcopy(plan)}}
 
     hass.services.async_register(
         DOMAIN,
         SERVICE_SAVE_PLAN,
-        async_save_plan,
+        _require_matic_control(hass, async_save_plan),
         schema=SAVE_PLAN_SCHEMA,
         supports_response=SupportsResponse.OPTIONAL,
     )
@@ -631,7 +668,7 @@ async def async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_DELETE_PLAN,
-        async_delete_plan,
+        _require_matic_control(hass, async_delete_plan),
         schema=PLAN_REFERENCE_SCHEMA,
         supports_response=SupportsResponse.OPTIONAL,
     )
@@ -648,7 +685,7 @@ async def async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_SELECT_PLAN,
-        async_select_plan,
+        _require_matic_control(hass, async_select_plan),
         schema=PLAN_REFERENCE_SCHEMA,
         supports_response=SupportsResponse.OPTIONAL,
     )
@@ -678,7 +715,7 @@ async def async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_SAVE_PLAN_ROOM,
-        async_save_plan_room,
+        _require_matic_control(hass, async_save_plan_room),
         schema=SAVE_PLAN_ROOM_SCHEMA,
         supports_response=SupportsResponse.OPTIONAL,
     )
@@ -707,7 +744,7 @@ async def async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_DELETE_PLAN_ROOM,
-        async_delete_plan_room,
+        _require_matic_control(hass, async_delete_plan_room),
         schema=DELETE_PLAN_ROOM_SCHEMA,
         supports_response=SupportsResponse.OPTIONAL,
     )
@@ -749,7 +786,7 @@ async def async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_MOVE_PLAN_ROOM,
-        async_move_plan_room,
+        _require_matic_control(hass, async_move_plan_room),
         schema=MOVE_PLAN_ROOM_SCHEMA,
         supports_response=SupportsResponse.OPTIONAL,
     )
@@ -790,7 +827,7 @@ async def async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_INSPECT_HERMES_ENDPOINT,
-        async_inspect_endpoint,
+        _require_matic_control(hass, async_inspect_endpoint),
         schema=INSPECT_ENDPOINT_SERVICE_SCHEMA,
         supports_response=SupportsResponse.ONLY,
     )
@@ -814,7 +851,7 @@ async def async_register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         SERVICE_FIRMWARE_SNAPSHOT,
-        async_firmware_snapshot,
+        _require_matic_control(hass, async_firmware_snapshot),
         schema=FIRMWARE_SNAPSHOT_SCHEMA,
         supports_response=SupportsResponse.ONLY,
     )

--- a/custom_components/matic_robot/session_tracking.py
+++ b/custom_components/matic_robot/session_tracking.py
@@ -233,23 +233,26 @@ def _room_timeline(
     cursor = started_at
     durations: dict[str, float] = {}
     rooms: list[str] = []
+    seen_rooms: set[str] = set()
+    room_lookup = _room_lookup(room_names)
     events = sorted(area_states, key=lambda item: item.last_updated)
     for state in events:
         if state.last_updated <= started_at:
-            candidate = _canonical_room(state.state, room_names)
+            candidate = _canonical_room_from_lookup(state.state, room_lookup)
             if candidate is not None:
                 current_room = candidate
             continue
         if state.last_updated > ended_at:
             break
-        candidate = _canonical_room(state.state, room_names)
+        candidate = _canonical_room_from_lookup(state.state, room_lookup)
         if candidate is None or candidate == current_room:
             continue
         if current_room is not None:
             durations[current_room] = durations.get(current_room, 0.0) + max(
                 0.0, (state.last_updated - cursor).total_seconds()
             )
-            if current_room not in rooms:
+            if current_room not in seen_rooms:
+                seen_rooms.add(current_room)
                 rooms.append(current_room)
         current_room = candidate
         cursor = state.last_updated
@@ -258,20 +261,31 @@ def _room_timeline(
         durations[current_room] = durations.get(current_room, 0.0) + max(
             0.0, (ended_at - cursor).total_seconds()
         )
-        if current_room not in rooms:
+        if current_room not in seen_rooms:
             rooms.append(current_room)
     return durations, rooms, current_room, cursor
 
 
 def _canonical_room(value: str | None, room_names: tuple[str, ...]) -> str | None:
     """Map firmware phrases such as ``the Living Room`` to plan room names."""
+    return _canonical_room_from_lookup(value, _room_lookup(room_names))
+
+
+def _room_lookup(room_names: tuple[str, ...]) -> dict[str, str]:
+    """Index room names once for constant-time recorder event matching."""
+    lookup: dict[str, str] = {}
+    for name in room_names:
+        lookup.setdefault(_room_key(name), name)
+    return lookup
+
+
+def _canonical_room_from_lookup(
+    value: str | None, room_lookup: dict[str, str]
+) -> str | None:
+    """Map a firmware room phrase through a precomputed normalized index."""
     if value is None or value in {"unknown", "unavailable"}:
         return None
-    normalized = _room_key(value)
-    for name in room_names:
-        if _room_key(name) == normalized:
-            return name
-    return None
+    return room_lookup.get(_room_key(value))
 
 
 def _room_key(value: str) -> str:

--- a/custom_components/matic_robot/strings.json
+++ b/custom_components/matic_robot/strings.json
@@ -296,6 +296,7 @@
       "duplicate_area": "Use a unique area name with at least one letter or number.",
       "invalid_area": "Draw at least one mark on the map before saving.",
       "invalid_plan": "This plan cannot run with its current settings or room map.",
+      "plan_limit_reached": "Delete an existing plan before creating another one.",
       "no_rooms": "Turn on at least one room.",
       "room_plan_unavailable": "The live room map must be available before you can draw or save an area.",
       "area_map_changed": "The map changed while the editor was open. Previous marks were cleared; redraw the area on the current map."
@@ -821,6 +822,9 @@
     },
     "invalid_plan": {
       "message": "The saved cleaning plan is invalid: {error}"
+    },
+    "plan_limit_reached": {
+      "message": "This robot has reached the saved-plan limit. Delete an existing plan before creating another one."
     },
     "plan_timeout": {
       "message": "Timed out while cleaning {room}."

--- a/custom_components/matic_robot/translations/en.json
+++ b/custom_components/matic_robot/translations/en.json
@@ -296,6 +296,7 @@
       "duplicate_area": "Use a unique area name with at least one letter or number.",
       "invalid_area": "Draw at least one mark on the map before saving.",
       "invalid_plan": "This plan cannot run with its current settings or room map.",
+      "plan_limit_reached": "Delete an existing plan before creating another one.",
       "no_rooms": "Turn on at least one room.",
       "room_plan_unavailable": "The live room map must be available before you can draw or save an area.",
       "area_map_changed": "The map changed while the editor was open. Previous marks were cleared; redraw the area on the current map."
@@ -821,6 +822,9 @@
     },
     "invalid_plan": {
       "message": "The saved cleaning plan is invalid: {error}"
+    },
+    "plan_limit_reached": {
+      "message": "This robot has reached the saved-plan limit. Delete an existing plan before creating another one."
     },
     "plan_timeout": {
       "message": "Timed out while cleaning {room}."

--- a/tests/test_api_paths.py
+++ b/tests/test_api_paths.py
@@ -3,18 +3,23 @@
 from __future__ import annotations
 
 import asyncio
+import struct
+from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 from unittest.mock import call as mock_call
 
 import pytest
 from google.protobuf.message import DecodeError
-from grpclib.const import Status
+from grpclib.const import Cardinality, Status
 from grpclib.exceptions import GRPCError, ProtocolError, StreamTerminatedError
 
 from custom_components.matic_robot.client.api import (
+    MAX_HERMES_MESSAGE_BYTES,
     MaticHermesClient,
     _async_connection_candidates,
+    _async_recv_bounded_message,
+    _BoundedStream,
     _decode_cleaning_session,
     _decode_schedule,
     _decode_text_field,
@@ -332,6 +337,110 @@ def test_pinned_channel_rejects_missing_certificate() -> None:
         channel._validate_peer(None)
     with pytest.raises(InvalidRobotCertificateError, match="did not present"):
         channel._validate_peer(SimpleNamespace(getpeercert=lambda binary_form: None))
+
+
+class _RawFrameStream:
+    def __init__(self, *chunks: bytes) -> None:
+        self.chunks = iter(chunks)
+        self.requested: list[int] = []
+        self.connection = SimpleNamespace(
+            messages_received=0, last_message_received=None
+        )
+
+    async def recv_data(self, size: int) -> bytes:
+        self.requested.append(size)
+        return next(self.chunks)
+
+
+async def test_bounded_grpc_frame_rejects_length_before_reading_body(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "custom_components.matic_robot.client.api.MAX_HERMES_MESSAGE_BYTES", 4
+    )
+    raw = _RawFrameStream(b"\x00" + struct.pack(">I", 5))
+
+    with pytest.raises(CannotConnectError, match="message byte limit"):
+        await _async_recv_bounded_message(raw, MagicMock(), bytes)
+
+    assert raw.requested == [5]
+
+
+async def test_bounded_grpc_frame_decodes_legitimate_message() -> None:
+    raw = _RawFrameStream(b"\x00" + struct.pack(">I", 3), b"abc")
+    codec = SimpleNamespace(decode=MagicMock(return_value="decoded"))
+
+    assert await _async_recv_bounded_message(raw, codec, bytes) == "decoded"
+    assert raw.requested == [5, 3]
+    codec.decode.assert_called_once_with(b"abc", bytes)
+
+
+async def test_bounded_grpc_frame_rejects_malformed_framing() -> None:
+    assert (
+        await _async_recv_bounded_message(_RawFrameStream(b""), MagicMock(), bytes)
+        is None
+    )
+    with pytest.raises(ProtocolError, match="header"):
+        await _async_recv_bounded_message(
+            _RawFrameStream(b"\x00\x00"), MagicMock(), bytes
+        )
+    with pytest.raises(NotImplementedError, match="Compression"):
+        await _async_recv_bounded_message(
+            _RawFrameStream(b"\x01" + struct.pack(">I", 0)), MagicMock(), bytes
+        )
+    with pytest.raises(ProtocolError, match="body"):
+        await _async_recv_bounded_message(
+            _RawFrameStream(b"\x00" + struct.pack(">I", 2), b"x"),
+            MagicMock(),
+            bytes,
+        )
+
+
+async def test_bounded_stream_dispatches_and_records_received_message() -> None:
+    stream = object.__new__(_BoundedStream)
+    raw = _RawFrameStream(b"\x00" + struct.pack(">I", 3), b"abc")
+    stream._recv_initial_metadata_done = False
+    stream._wrapper = nullcontext()
+    stream._stream = raw
+    stream._codec = SimpleNamespace(decode=MagicMock(return_value="decoded"))
+    stream._recv_type = bytes
+    stream._dispatch = SimpleNamespace(
+        recv_message=AsyncMock(return_value=("dispatched",))
+    )
+    stream._messages_received = 0
+
+    async def receive_metadata() -> None:
+        stream._recv_initial_metadata_done = True
+
+    stream.recv_initial_metadata = AsyncMock(side_effect=receive_metadata)
+
+    assert await stream.recv_message() == "dispatched"
+    stream.recv_initial_metadata.assert_awaited_once_with()
+    assert stream._messages_received == 1
+    assert raw.connection.messages_received == 1
+    assert raw.connection.last_message_received is not None
+
+    raw.chunks = iter([b""])
+    stream._recv_initial_metadata_done = True
+    assert await stream.recv_message() is None
+
+
+def test_pinned_channel_uses_bounded_stream_for_every_rpc() -> None:
+    from custom_components.matic_robot.client.api import _PinnedChannel
+
+    channel = _PinnedChannel(
+        "192.0.2.1",
+        16320,
+        ssl=object(),
+        expected_hostname=None,
+        expected_serial=None,
+        expected_fingerprint=None,
+    )
+    stream = channel.request("/hermes.Test/Read", Cardinality.UNARY_UNARY, bytes, bytes)
+
+    assert isinstance(stream, _BoundedStream)
+    assert MAX_HERMES_MESSAGE_BYTES > 0
+    channel.close()
 
 
 async def test_rpc_entry_points_reconnect_and_reject_unopened_channels() -> None:
@@ -667,6 +776,31 @@ async def test_get_collection_entries_returns_bounded_values(monkeypatch) -> Non
     assert stream.cancelled is True
 
 
+async def test_get_collection_entries_enforces_cumulative_byte_budget(
+    monkeypatch,
+) -> None:
+    stream = _SequenceStream(
+        [
+            _collection_response(direct=b"first", key=b"one"),
+            _collection_response(direct=b"second", key=b"two"),
+        ]
+    )
+    monkeypatch.setattr(
+        "custom_components.matic_robot.client.api.HermesStub",
+        lambda channel: SimpleNamespace(FetchCollection=_OpenMethod(stream)),
+    )
+    monkeypatch.setattr(
+        "custom_components.matic_robot.client.api._COLLECTION_MAX_BYTES", 10
+    )
+    client = MaticHermesClient("robot.invalid", 16320, credential=_credential())
+    client._channel = object()
+
+    with pytest.raises(CannotConnectError, match="byte limit"):
+        await client.async_get_collection_entries("history", limit=2)
+
+    assert stream.cancelled is True
+
+
 async def test_subscribe_collection_entries_yields_snapshot_and_updates(
     monkeypatch,
 ) -> None:
@@ -839,7 +973,7 @@ async def test_get_tracked_collection_entries_enforces_bounds(monkeypatch) -> No
 
     monkeypatch.setattr(client, "async_subscribe_collection_entries", entries)
     monkeypatch.setattr(
-        "custom_components.matic_robot.client.api._TRACKED_COLLECTION_MAX_BYTES", 1
+        "custom_components.matic_robot.client.api._COLLECTION_MAX_BYTES", 1
     )
 
     with pytest.raises(CannotConnectError, match="byte limit"):
@@ -1182,6 +1316,7 @@ async def test_decode_wrappers_translate_malformed_payloads(monkeypatch) -> None
 
 def test_decode_text_field_rejects_non_bytes_payloads() -> None:
     assert _decode_text_field(None, 1) is None
+    assert _decode_text_field(_bfield(1, b"x" * 513), 1) is None
 
 
 def test_decode_schedule_reads_explicit_enabled_markers() -> None:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -229,6 +229,65 @@ async def test_manual_discovery_discards_incomplete_records(
     assert await _async_discover_robots(hass) == []
 
 
+async def test_manual_discovery_caps_names_addresses_and_resolution_concurrency(
+    hass, monkeypatch
+) -> None:
+    active = 0
+    max_active = 0
+    created_names: list[str] = []
+
+    class FakeBrowser:
+        def __init__(self, _zeroconf, _service_type, handlers):
+            for index in range(10):
+                handlers[0](
+                    zeroconf=None,
+                    service_type="service",
+                    name=f"robot-{index}.service",
+                    state_change=ServiceStateChange.Added,
+                )
+
+        async def async_cancel(self):
+            return None
+
+    class FakeServiceInfo:
+        def __init__(self, service_type, name):
+            self.type = service_type
+            self.name = name
+            self.port = 16320
+            self.server = "robot.local."
+            self.decoded_properties = {}
+            created_names.append(name)
+
+        async def async_request(self, _zeroconf, _timeout):
+            nonlocal active, max_active
+            active += 1
+            max_active = max(max_active, active)
+            await asyncio.sleep(0)
+            active -= 1
+            return True
+
+        def parsed_scoped_addresses(self, _ip_version):
+            return [f"192.0.2.{index}" for index in range(1, 10)]
+
+    monkeypatch.setattr(flow_module, "MAX_DISCOVERY_SERVICES", 3)
+    monkeypatch.setattr(flow_module, "MAX_DISCOVERY_ADDRESSES", 2)
+    monkeypatch.setattr(flow_module, "DISCOVERY_RESOLVE_CONCURRENCY", 2)
+    monkeypatch.setattr(
+        flow_module,
+        "async_get_async_instance",
+        AsyncMock(return_value=SimpleNamespace(zeroconf=object())),
+    )
+    monkeypatch.setattr(flow_module, "AsyncServiceBrowser", FakeBrowser)
+    monkeypatch.setattr(flow_module, "AsyncServiceInfo", FakeServiceInfo)
+
+    discoveries = await _async_discover_robots(hass, discovery_seconds=0)
+
+    assert len(created_names) == 3
+    assert len(discoveries) == 3
+    assert all(len(info.ip_addresses) == 2 for info in discoveries)
+    assert max_active == 2
+
+
 async def test_discovery_opens_single_action_pairing_form(hass, monkeypatch) -> None:
     monkeypatch.setattr(
         "custom_components.matic_robot.config_flow._async_select_discovery_host",
@@ -420,6 +479,45 @@ async def test_discovery_probe_timeout_falls_back_to_advertised_address(
     )
 
     assert await _async_select_discovery_host(info) == "192.0.2.2"
+
+
+async def test_discovery_caps_candidate_address_probe_fanout(monkeypatch) -> None:
+    info = ZeroconfServiceInfo(
+        ip_address=ip_address("192.0.2.1"),
+        ip_addresses=[ip_address(f"192.0.2.{index}") for index in range(1, 10)],
+        port=16320,
+        hostname="robot.local.",
+        type="_grpc._tcp.local.",
+        name="robot._grpc._tcp.local.",
+        properties={},
+    )
+    probed: list[str] = []
+
+    async def fetch_certificate(host: str, _port: int) -> bytes:
+        probed.append(host)
+        raise CannotConnectError("offline")
+
+    monkeypatch.setattr(flow_module, "MAX_DISCOVERY_ADDRESSES", 3)
+    monkeypatch.setattr(flow_module, "async_fetch_peer_certificate", fetch_certificate)
+    monkeypatch.setattr(
+        asyncio.get_running_loop(),
+        "getaddrinfo",
+        AsyncMock(
+            return_value=[
+                (
+                    socket.AF_INET,
+                    socket.SOCK_STREAM,
+                    socket.IPPROTO_TCP,
+                    "",
+                    (f"198.51.100.{index}", 16320),
+                )
+                for index in range(1, 10)
+            ]
+        ),
+    )
+
+    assert await _async_select_discovery_host(info) == "192.0.2.1"
+    assert len(probed) == 3
 
 
 async def test_zeroconf_uses_advertised_serial_for_duplicate_protection(
@@ -1102,6 +1200,27 @@ async def test_options_flow_rejects_empty_rooms_and_duplicate_plan(hass) -> None
         },
     )
     assert result["errors"]["name"] == "duplicate_plan"
+
+
+async def test_options_flow_reports_saved_plan_limit(hass, monkeypatch) -> None:
+    entry, _manager = await _options_entry(hass)
+    monkeypatch.setattr(flow_module, "MAX_SAVED_PLANS_PER_ROBOT", 1)
+    result = await _start_options_step(hass, entry, "add_plan")
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            "name": "Another plan",
+            "run_behavior": "intelligent",
+            "room_editor": _room_rows(
+                ("room-1", True, "vacuum", "standard"),
+                ("room-2", False, "vacuum", "standard"),
+            ),
+            "return_to_base": True,
+        },
+    )
+
+    assert result["errors"]["base"] == "plan_limit_reached"
 
 
 async def test_options_flow_draws_edits_and_deletes_custom_area(hass) -> None:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -229,6 +229,26 @@ async def test_manual_discovery_discards_incomplete_records(
     assert await _async_discover_robots(hass) == []
 
 
+async def test_manual_discovery_returns_empty_when_no_services_are_seen(
+    hass, monkeypatch
+) -> None:
+    class FakeBrowser:
+        def __init__(self, _zeroconf, _service_type, handlers):
+            assert handlers
+
+        async def async_cancel(self):
+            return None
+
+    monkeypatch.setattr(
+        flow_module,
+        "async_get_async_instance",
+        AsyncMock(return_value=SimpleNamespace(zeroconf=object())),
+    )
+    monkeypatch.setattr(flow_module, "AsyncServiceBrowser", FakeBrowser)
+
+    assert await _async_discover_robots(hass, discovery_seconds=0) == []
+
+
 async def test_manual_discovery_caps_names_addresses_and_resolution_concurrency(
     hass, monkeypatch
 ) -> None:
@@ -286,6 +306,52 @@ async def test_manual_discovery_caps_names_addresses_and_resolution_concurrency(
     assert len(discoveries) == 3
     assert all(len(info.ip_addresses) == 2 for info in discoveries)
     assert max_active == 2
+
+
+async def test_manual_discovery_has_one_global_resolution_deadline(
+    hass, monkeypatch
+) -> None:
+    started_names: list[str] = []
+    cancelled_names: list[str] = []
+    never = asyncio.Event()
+
+    class FakeBrowser:
+        def __init__(self, _zeroconf, _service_type, handlers):
+            for index in range(3):
+                handlers[0](
+                    zeroconf=None,
+                    service_type="service",
+                    name=f"stale-{index}.service",
+                    state_change=ServiceStateChange.Added,
+                )
+
+        async def async_cancel(self):
+            return None
+
+    class FakeServiceInfo:
+        def __init__(self, _service_type, name):
+            self.name = name
+
+        async def async_request(self, _zeroconf, _timeout):
+            started_names.append(self.name)
+            try:
+                await never.wait()
+            finally:
+                cancelled_names.append(self.name)
+
+    monkeypatch.setattr(flow_module, "DISCOVERY_RESOLVE_CONCURRENCY", 1)
+    monkeypatch.setattr(flow_module, "DISCOVERY_RESOLVE_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(
+        flow_module,
+        "async_get_async_instance",
+        AsyncMock(return_value=SimpleNamespace(zeroconf=object())),
+    )
+    monkeypatch.setattr(flow_module, "AsyncServiceBrowser", FakeBrowser)
+    monkeypatch.setattr(flow_module, "AsyncServiceInfo", FakeServiceInfo)
+
+    assert await _async_discover_robots(hass, discovery_seconds=0) == []
+    assert started_names == ["stale-0.service"]
+    assert cancelled_names == started_names
 
 
 async def test_discovery_opens_single_action_pairing_form(hass, monkeypatch) -> None:

--- a/tests/test_floor_plan.py
+++ b/tests/test_floor_plan.py
@@ -12,6 +12,7 @@ import pytest
 from google.protobuf.message import DecodeError
 from PIL import Image, ImageChops, ImageDraw
 
+from custom_components.matic_robot.client import floor_plan as floor_plan_module
 from custom_components.matic_robot.client.floor_plan import (
     _box_inside_mask,
     _boxes_overlap,
@@ -165,6 +166,40 @@ def test_robot_position_falls_back_to_the_current_room() -> None:
 def test_decode_rejects_plan_without_standard_partition() -> None:
     with pytest.raises(DecodeError, match="no standard partition"):
         decode_floor_plan(b"")
+
+
+@pytest.mark.parametrize(
+    ("limit_name", "limit", "message"),
+    [
+        ("MAX_FLOOR_PLAN_PAYLOAD_BYTES", 1, "byte limit"),
+        ("MAX_FLOOR_PLAN_ROOMS", 0, "too many rooms"),
+        ("MAX_ROOM_BOUNDARY_POINTS", 3, "room has too many"),
+        ("MAX_FLOOR_PLAN_BOUNDARY_POINTS", 3, "too many boundary"),
+        ("MAX_ROOM_NAME_BYTES", 1, "room name"),
+        ("MAX_MAP_COORDINATE", 3.0, "boundary coordinate"),
+    ],
+)
+def test_decode_floor_plan_enforces_geometry_budgets(
+    monkeypatch, limit_name, limit, message
+) -> None:
+    monkeypatch.setattr(floor_plan_module, limit_name, limit)
+
+    with pytest.raises(DecodeError, match=message):
+        decode_floor_plan(_floor_plan_payload())
+
+
+@pytest.mark.parametrize("coordinate", [float("nan"), float("inf")])
+def test_decode_floor_plan_rejects_non_finite_coordinates(coordinate) -> None:
+    payload = _plan_payload(
+        _region_wire(
+            REGION_ID,
+            "Unsafe",
+            ((0.0, 0.0), (coordinate, 0.0), (1.0, 1.0)),
+        )
+    )
+
+    with pytest.raises(DecodeError, match="boundary coordinate"):
+        decode_floor_plan(payload)
 
 
 def test_decode_skips_rooms_with_degenerate_outlines() -> None:

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -8,6 +8,7 @@ import pytest
 from google.protobuf.descriptor import FieldDescriptor
 from google.protobuf.message import DecodeError
 
+from custom_components.matic_robot.client import api as api_module
 from custom_components.matic_robot.client.api import _decode_operational_state
 from custom_components.matic_robot.client.models import (
     CleaningSchedule,
@@ -105,6 +106,41 @@ def test_decode_live_verified_activity_transitions(
 def test_decode_rejects_malformed_payload() -> None:
     with pytest.raises(DecodeError):
         _decode_operational_state(b"\x0a\xff")
+
+
+def test_operational_state_enforces_payload_field_and_code_budgets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = KabukiOutputWire(states=[106, 119]).SerializeToString()
+
+    monkeypatch.setattr(api_module, "_OPERATIONAL_STATE_MAX_BYTES", len(payload) - 1)
+    with pytest.raises(DecodeError, match="byte limit"):
+        _decode_operational_state(payload)
+
+    monkeypatch.setattr(api_module, "_OPERATIONAL_STATE_MAX_BYTES", len(payload))
+    monkeypatch.setattr(api_module, "_OPERATIONAL_STATE_MAX_FIELDS", 0)
+    with pytest.raises(DecodeError, match="too many fields"):
+        _decode_operational_state(payload)
+
+    monkeypatch.setattr(api_module, "_OPERATIONAL_STATE_MAX_FIELDS", 1024)
+    monkeypatch.setattr(api_module, "_OPERATIONAL_STATE_MAX_CODES", 1)
+    with pytest.raises(DecodeError, match="too many status codes"):
+        _decode_operational_state(payload)
+
+
+def test_operational_state_bounds_text_and_nested_cues(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = KabukiOutputWire(states=[106]).SerializeToString() + b"\x22\x06v200.1"
+    monkeypatch.setattr(api_module, "_TELEMETRY_TEXT_MAX_BYTES", 2)
+
+    assert _decode_operational_state(payload).software_version is None
+    invalid_utf8 = KabukiOutputWire(states=[106]).SerializeToString() + b"\x22\x01\xff"
+    assert _decode_operational_state(invalid_utf8).software_version is None
+
+    monkeypatch.setattr(api_module, "_TELEMETRY_NESTED_MAX_FIELDS", 0)
+    with pytest.raises(DecodeError, match="too many fields"):
+        _decode_operational_state(_cues_output(_message_field(20)))
 
 
 def test_decode_verified_build_and_area_fields() -> None:

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -29,6 +29,7 @@ from custom_components.matic_robot.client.models import (
 )
 from custom_components.matic_robot.const import DOMAIN
 from custom_components.matic_robot.plans import (
+    MAX_SAVED_PLANS_PER_ROBOT,
     OEM_STOP_RECONCILIATION_SECONDS,
     PLAN_MOTION_TOKEN,
     AreaBindingUpgradeResult,
@@ -36,6 +37,7 @@ from custom_components.matic_robot.plans import (
     CleaningRoom,
     ManagedMotionReplacedError,
     PlanStopDecision,
+    SavedPlanLimitError,
     _compatible_duration_history,
     _duration_history,
     _elapsed_seconds,
@@ -2194,6 +2196,33 @@ async def test_plan_validation_rejects_disabled_empty_unknown_and_missing(hass) 
         )
         with pytest.raises(ValueError, match=r"plan (has no|contains an invalid) room"):
             manager.rooms_for_plan("serial", {}, "corrupt")
+
+
+async def test_saved_plan_limit_rejects_creation_but_allows_replacement(hass) -> None:
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    plans = manager._robot("serial")["plans"]
+    plans.update(
+        {
+            f"plan-{index}": {"name": f"Plan {index}", "rooms": []}
+            for index in range(MAX_SAVED_PLANS_PER_ROBOT)
+        }
+    )
+
+    with pytest.raises(SavedPlanLimitError, match="at most"):
+        await manager.async_save_plan(
+            "serial", "new-plan", {"name": "New plan", "rooms": []}
+        )
+
+    assert "new-plan" not in plans
+    manager._store.async_save.assert_not_awaited()
+
+    await manager.async_save_plan(
+        "serial", "plan-0", {"name": "Replacement", "rooms": []}, select=False
+    )
+
+    assert plans["plan-0"]["name"] == "Replacement"
+    manager._store.async_save.assert_awaited_once_with(manager._data)
 
 
 async def test_room_execution_uses_its_individual_settings() -> None:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -7,8 +7,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.core import ServiceCall
-from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.core import Context, ServiceCall
+from homeassistant.exceptions import (
+    HomeAssistantError,
+    ServiceValidationError,
+    Unauthorized,
+    UnknownUser,
+)
 from homeassistant.util import dt as dt_util
 
 from custom_components.matic_robot.area_binding import (
@@ -33,7 +38,12 @@ from custom_components.matic_robot.client.models import (
     Room,
 )
 from custom_components.matic_robot.const import DOMAIN
-from custom_components.matic_robot.plans import CleaningPlanManager, CleaningRoom
+from custom_components.matic_robot.plans import (
+    MAX_SAVED_PLANS_PER_ROBOT,
+    CleaningPlanManager,
+    CleaningRoom,
+    SavedPlanLimitError,
+)
 from custom_components.matic_robot.services import (
     CLEAN_AREA_SERVICE_SCHEMA,
     DELETE_PLAN_ROOM_SCHEMA,
@@ -53,6 +63,7 @@ from custom_components.matic_robot.services import (
     _entry_for_entity,
     _native_completion_match,
     _NativeReconciliation,
+    _require_matic_control,
     _resolve_loaded_matic_vacuums,
     _resolve_room_id,
     _saved_plan_context,
@@ -939,6 +950,48 @@ async def test_room_native_plan_crud_is_complete(hass) -> None:
     assert manager.plans("serial") == {}
 
 
+async def test_save_plan_reports_the_per_robot_plan_limit(hass) -> None:
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    manager._robot("serial")["plans"].update(
+        {
+            f"plan-{index}": {"name": f"Plan {index}", "rooms": []}
+            for index in range(MAX_SAVED_PLANS_PER_ROBOT)
+        }
+    )
+    services = await _registered_services(hass, manager)
+    call = ServiceCall(
+        hass,
+        DOMAIN,
+        "save_plan",
+        SAVE_PLAN_SCHEMA(
+            {
+                "entity_id": ["vacuum.test"],
+                "name": "One too many",
+                "rooms": [{"room": "Kitchen"}],
+            }
+        ),
+    )
+    context = (
+        "vacuum.test",
+        SimpleNamespace(),
+        "serial",
+        {"room-kitchen": "Kitchen"},
+    )
+
+    with (
+        patch(
+            "custom_components.matic_robot.services._saved_plan_context",
+            return_value=context,
+        ),
+        pytest.raises(ServiceValidationError, match="at most") as raised,
+    ):
+        await _registered_handler(services, "save_plan")(call)
+
+    assert isinstance(raised.value.__cause__, SavedPlanLimitError)
+    manager._store.async_save.assert_not_awaited()
+
+
 async def test_room_crud_rejects_unknown_rooms_membership_and_positions(hass) -> None:
     manager = CleaningPlanManager(hass)
     manager._store = SimpleNamespace(async_save=AsyncMock())
@@ -1153,6 +1206,97 @@ def test_action_target_resolution_accepts_loaded_matic_vacuum() -> None:
         ),
     ):
         assert _resolve_loaded_matic_vacuums(hass, call) == ["vacuum.test"]
+
+
+async def test_domain_service_rejects_unauthorized_direct_and_indirect_targets() -> (
+    None
+):
+    user = SimpleNamespace(
+        is_admin=False,
+        permissions=SimpleNamespace(
+            check_entity=MagicMock(
+                side_effect=lambda entity_id, _policy: entity_id.endswith("allowed")
+            )
+        ),
+    )
+    hass = SimpleNamespace(
+        auth=SimpleNamespace(async_get_user=AsyncMock(return_value=user))
+    )
+    handler = AsyncMock()
+    call = ServiceCall(
+        hass,
+        DOMAIN,
+        "save_plan",
+        {"device_id": ["robot-device"]},
+        context=Context(user_id="restricted-user"),
+    )
+    with (
+        patch(
+            "custom_components.matic_robot.services._resolve_loaded_matic_vacuums",
+            return_value=["vacuum.allowed", "vacuum.denied"],
+        ),
+        pytest.raises(Unauthorized) as raised,
+    ):
+        await _require_matic_control(hass, handler)(call)
+
+    assert raised.value.entity_id == "vacuum.denied"
+    handler.assert_not_awaited()
+
+
+async def test_domain_service_allows_control_admin_and_system_contexts() -> None:
+    handler = AsyncMock(return_value={"ok": True})
+    allowed_user = SimpleNamespace(
+        is_admin=False,
+        permissions=SimpleNamespace(check_entity=MagicMock(return_value=True)),
+    )
+    admin = SimpleNamespace(
+        is_admin=True,
+        permissions=SimpleNamespace(check_entity=MagicMock(return_value=False)),
+    )
+    hass = SimpleNamespace(
+        auth=SimpleNamespace(
+            async_get_user=AsyncMock(side_effect=(allowed_user, admin, None))
+        )
+    )
+    guarded = _require_matic_control(hass, handler)
+    with patch(
+        "custom_components.matic_robot.services._resolve_loaded_matic_vacuums",
+        return_value=["vacuum.test"],
+    ):
+        assert await guarded(
+            ServiceCall(
+                hass,
+                DOMAIN,
+                "clean",
+                {"entity_id": ["vacuum.test"]},
+                context=Context(user_id="allowed-user"),
+            )
+        ) == {"ok": True}
+        assert await guarded(
+            ServiceCall(
+                hass,
+                DOMAIN,
+                "clean",
+                {"entity_id": ["vacuum.test"]},
+                context=Context(user_id="admin-user"),
+            )
+        ) == {"ok": True}
+        assert await guarded(
+            ServiceCall(hass, DOMAIN, "clean", {"entity_id": ["vacuum.test"]})
+        ) == {"ok": True}
+        with pytest.raises(UnknownUser):
+            await guarded(
+                ServiceCall(
+                    hass,
+                    DOMAIN,
+                    "clean",
+                    {"entity_id": ["vacuum.test"]},
+                    context=Context(user_id="missing-user"),
+                )
+            )
+
+    admin.permissions.check_entity.assert_not_called()
+    assert handler.await_count == 3
 
 
 @pytest.mark.parametrize(("loaded", "available"), [(False, True), (True, False)])

--- a/tests/test_session_tracking.py
+++ b/tests/test_session_tracking.py
@@ -6,12 +6,14 @@ from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
+from custom_components.matic_robot import session_tracking as session_tracking_module
 from custom_components.matic_robot.client.models import CleaningSession
 from custom_components.matic_robot.session_tracking import (
     CleaningSessionTracker,
     _build_session,
     _canonical_room,
     _parse_timestamp,
+    _room_timeline,
     _sessions_overlap,
 )
 
@@ -425,3 +427,35 @@ def test_helpers_reject_non_rooms_and_handle_timestamp_edges() -> None:
     assert reversed_session.room_durations == ()
     invalid_interval = CleaningSession("bad", "also-bad", 1, (), (), True)
     assert _sessions_overlap(invalid_interval, invalid_interval) is False
+
+
+def test_room_timeline_normalizes_names_once_per_room_and_event(
+    monkeypatch,
+) -> None:
+    start = datetime(2026, 7, 21, 8, tzinfo=UTC)
+    room_names = tuple(f"Room {index}" for index in range(100))
+    area_states = [
+        _state(f"the Room {index}", start + timedelta(seconds=index + 1))
+        for index in range(100)
+    ]
+    calls = 0
+    original = session_tracking_module._room_key
+
+    def counted_room_key(value: str) -> str:
+        nonlocal calls
+        calls += 1
+        return original(value)
+
+    monkeypatch.setattr(session_tracking_module, "_room_key", counted_room_key)
+
+    durations, rooms, current_room, _cursor = _room_timeline(
+        start,
+        start + timedelta(seconds=101),
+        area_states,
+        room_names,
+    )
+
+    assert len(durations) == len(room_names)
+    assert rooms == list(room_names)
+    assert current_room == "Room 99"
+    assert calls <= len(room_names) + len(area_states)

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, call
 
 import pytest
 
+from custom_components.matic_robot.client import api as api_module
 from custom_components.matic_robot.client.api import (
     MaticHermesClient,
     _decode_binary_state,
@@ -282,6 +283,64 @@ def test_decode_wifi_schedule_and_history() -> None:
     assert malformed_status.completed is None
     assert malformed_status.completed_rooms == ("Kitchen",)
     assert datetime.fromisoformat(session.started_at or "").tzinfo is UTC
+
+
+def test_wifi_decoder_enforces_payload_network_and_nested_budgets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    network = _bfield(1, b"Test LAN") + _vfield(3, 1)
+    wifi = _vfield(1, 3) + _bfield(7, _bfield(1, network) + _bfield(1, network))
+
+    monkeypatch.setattr(api_module, "_WIFI_STATUS_MAX_BYTES", len(wifi) - 1)
+    assert _decode_wifi_status(wifi) == (None, None, None, ())
+
+    monkeypatch.setattr(api_module, "_WIFI_STATUS_MAX_BYTES", len(wifi))
+    monkeypatch.setattr(api_module, "_WIFI_NETWORK_MAX_COUNT", 1)
+    assert _decode_wifi_status(wifi)[3] == ()
+
+    one_network = _vfield(1, 3) + _bfield(7, _bfield(1, network))
+    monkeypatch.setattr(api_module, "_TELEMETRY_NESTED_MAX_FIELDS", 0)
+    assert _decode_wifi_status(one_network)[3] == ()
+
+
+def test_schedule_decoder_enforces_payload_field_and_uuid_budgets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    room_id = _fixed64(1, 1) + _fixed64(2, 2)
+    weekly = _bfield(1, _vfield(1, 1)) + _bfield(3, _vfield(1, 510))
+    payload = _bfield(1, weekly) + _bfield(7, room_id)
+
+    monkeypatch.setattr(api_module, "_SCHEDULE_MAX_BYTES", len(payload) - 1)
+    assert _decode_schedule(payload) is None
+
+    monkeypatch.setattr(api_module, "_SCHEDULE_MAX_BYTES", len(payload))
+    monkeypatch.setattr(api_module, "_SCHEDULE_MAX_FIELDS", 1)
+    assert _decode_schedule(payload) is None
+
+    monkeypatch.setattr(api_module, "_SCHEDULE_MAX_FIELDS", 1024)
+    monkeypatch.setattr(api_module, "_SCHEDULE_MAX_UUIDS", 0)
+    assert _decode_schedule(payload) is None
+
+
+def test_cleaning_session_decoder_enforces_payload_field_and_room_budgets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def room(name: bytes) -> bytes:
+        details = _bfield(3, name) + _bfield(4, _vfield(1, 30))
+        return _bfield(6, _bfield(1, _bfield(2, details)))
+
+    payload = _bfield(5, room(b"Kitchen") + room(b"Office"))
+
+    monkeypatch.setattr(api_module, "_CLEANING_SESSION_MAX_BYTES", len(payload) - 1)
+    assert _decode_cleaning_session(payload) is None
+
+    monkeypatch.setattr(api_module, "_CLEANING_SESSION_MAX_BYTES", len(payload))
+    monkeypatch.setattr(api_module, "_CLEANING_SESSION_MAX_FIELDS", 1)
+    assert _decode_cleaning_session(payload) is None
+
+    monkeypatch.setattr(api_module, "_CLEANING_SESSION_MAX_FIELDS", 1024)
+    monkeypatch.setattr(api_module, "_CLEANING_SESSION_MAX_ROOMS", 1)
+    assert _decode_cleaning_session(payload) is None
 
 
 def test_decode_room_completion_statuses_fail_closed() -> None:


### PR DESCRIPTION
## Summary

- enforce Home Assistant entity-control permissions across every Matic domain service
- cap saved plans, discovery fan-out and total resolution time, gRPC messages, collection snapshots, and floor-plan geometry
- bound telemetry parsing and make recorder room matching linear
- add focused adversarial coverage for each security boundary

## Security scan disposition

Replacement scan `11845ece-5164-41fd-95df-125e536e8c4b` was sealed against base `0b4cbc0c4edfbd75cf3184a0d833ed871235f462` with seven reportable findings. All seven are fixed and covered on this PR head:

- `occ_70addd07fdce01c7c72e9d53` / `csf_09361b43e40ea962004db7e7`: entity-service authorization — fixed
- `occ_e0df82e4d396490332acda9e` / `csf_8bbdc023570dbe97d9626d1d`: saved-plan quota — fixed
- `occ_71850409f629931638da71d1` / `csf_34c93940f3314cce201a9d37`: collection byte budget — fixed
- `occ_c275c78678117c2abf00359b` / `csf_94ca6f53b8fcc0a30482f02b`: inbound gRPC message limit — fixed
- `occ_11d664e72e50e19addcbf550` / `csf_dbaddf08060ef6cb62f1f5ff`: zeroconf fan-out — fixed
- `occ_f8a652084d3c39b780636542` / `csf_a808b86001df33211e170e01`: floor-plan geometry — fixed
- `occ_c419a51e63ec1deda82485eb` / `csf_e8e38fe3f3b094e48f60efe5`: telemetry semantic budgets — fixed

The archived unsealed 26-row inventory is preserved with no orphaned rows: row 1 maps to saved-plan quota; rows 2–7, 9, 11, 14, 16–17, 20, 22–23, and 25 map to entity authorization; row 8 maps to collection byte budget; row 10 maps to the gRPC limit; row 12 maps to zeroconf fan-out; rows 15 and 24 map to floor-plan geometry; and rows 13, 18–19, 21, and 26 map to telemetry semantic budgets. The archived bundle is retained only as lineage, not as authoritative scan evidence.

## Verification

- 1,082 tests passed with 100.00% coverage
- ruff check and format check passed
- strict mypy passed for 47 source files
- public-tree privacy check passed
- sdist and wheel builds passed

## Scope

No deployment or merge is included.