### PR TITLE
Fix multi-floor pose and segment handling

### DIFF
--- a/custom_components/matic_robot/camera.py
+++ b/custom_components/matic_robot/camera.py
@@ -165,14 +165,19 @@ class MaticPhotorealisticMapCamera(MaticEntity, Camera):
     @property
     def extra_state_attributes(self) -> dict[str, object]:
         """Expose cache readiness without exposing private map content."""
+        data = self.coordinator.data
+        floor_plan_coherent = self._store.floor_plan_is_current(data.floor_plan)
         return {
             "matic_entry_id": self._config_entry.entry_id,
             "cached_tiles": self._store.tile_count,
             "structural_tiles": self._store.structure_tile_count,
             "map_complete": self._store.map_complete,
             "map_revision": self._store.revision,
-            "map_floor_coherent": self._store.floor_plan_is_current(
-                self.coordinator.data.floor_plan
+            "map_floor_coherent": floor_plan_coherent,
+            "robot_location_source": robot_location_source(
+                data.floor_plan if floor_plan_coherent else None,
+                data.pose,
+                data.operational.current_area,
             ),
             "source": "local_robot_slam",
             "scene_url": scene_api_url(self._config_entry.entry_id),

--- a/custom_components/matic_robot/camera.py
+++ b/custom_components/matic_robot/camera.py
@@ -10,7 +10,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import MaticConfigEntry
-from .client.floor_plan import render_floor_plan, resolve_robot_map_position
+from .client.floor_plan import (
+    render_floor_plan,
+    resolve_robot_map_position,
+    robot_location_source,
+)
 from .client.models import HermesCollectionEntry, RobotState
 from .client.slam_map import (
     decode_slam_structure_tile,
@@ -79,16 +83,13 @@ class MaticMapCamera(MaticEntity, Camera):
 
     @property
     def extra_state_attributes(self) -> dict[str, object]:
-        """Expose whether the marker is exact or a room-level fallback."""
+        """Expose exact-position or non-positional room-presence availability."""
         data = self.coordinator.data
-        position = resolve_robot_map_position(
-            data.floor_plan, data.pose, data.operational.current_area
-        )
         return {
             "matic_entry_id": self._config_entry.entry_id,
-            "robot_location_source": position[2]
-            if position is not None
-            else "unavailable",
+            "robot_location_source": robot_location_source(
+                data.floor_plan, data.pose, data.operational.current_area
+            ),
         }
 
 

--- a/custom_components/matic_robot/camera.py
+++ b/custom_components/matic_robot/camera.py
@@ -90,6 +90,7 @@ class MaticMapCamera(MaticEntity, Camera):
             "robot_location_source": robot_location_source(
                 data.floor_plan, data.pose, data.operational.current_area
             ),
+            "source": "local_room_map",
         }
 
 

--- a/custom_components/matic_robot/client/floor_plan.py
+++ b/custom_components/matic_robot/client/floor_plan.py
@@ -305,7 +305,7 @@ def render_floor_plan(
                 robot_x + radius,
                 robot_y + radius,
             ),
-            fill="#FFFFFF" if robot_position[2] == "exact_pose" else "#F6C85F",
+            fill="#FFFFFF",
             outline="#10151D",
             width=3,
         )
@@ -328,7 +328,15 @@ def resolve_robot_map_position(
     pose: RobotPose | None,
     current_area: str | None,
 ) -> tuple[float, float, str] | None:
-    """Return an exact pose or a truthful room-level fallback for the map."""
+    """Return only a verified exact pose for a positional map marker.
+
+    The robot's current-area label proves room presence, not a point inside the
+    room. Rendering that label at the polygon center creates a stationary dot
+    that looks exact while the robot moves, especially after a floor change.
+    Keep ``current_area`` in the signature for callers that also use
+    :func:`robot_location_source`, but never turn it into coordinates here.
+    """
+    del current_area
     if floor_plan is None or not floor_plan.rooms:
         return None
     all_points = [point for room in floor_plan.rooms for point in room.boundary]
@@ -343,17 +351,27 @@ def resolve_robot_map_position(
         and min_y <= pose.y <= max_y
     ):
         return pose.x, pose.y, "exact_pose"
+    return None
+
+
+def robot_location_source(
+    floor_plan: FloorPlan | None,
+    pose: RobotPose | None,
+    current_area: str | None,
+) -> str:
+    """Classify exact position, room-only presence, or unavailable location."""
+    if resolve_robot_map_position(floor_plan, pose, current_area) is not None:
+        return "exact_pose"
+    if floor_plan is None or not floor_plan.rooms:
+        return "unavailable"
     area_key = _room_name_key(current_area)
     if area_key is None:
-        return None
+        return "unavailable"
     room = next(
         (item for item in floor_plan.rooms if _room_name_key(item.name) == area_key),
         None,
     )
-    if room is None:
-        return None
-    x, y = _polygon_center(room.boundary)
-    return x, y, "current_area"
+    return "current_area" if room is not None else "unavailable"
 
 
 def _room_name_key(value: str | None) -> str | None:

--- a/custom_components/matic_robot/matic_map_studio.js
+++ b/custom_components/matic_robot/matic_map_studio.js
@@ -425,7 +425,7 @@ class MaticMapStudio extends HTMLElement {
       photo: scoped.find(([, state]) =>
         state.attributes?.source === "local_robot_slam"),
       rooms: scoped.find(([, state]) =>
-        state.attributes?.robot_location_source),
+        state.attributes?.source === "local_room_map"),
       vacuum: scoped.find(([entityId]) => entityId.startsWith("vacuum.")),
     };
   }
@@ -920,6 +920,7 @@ class MaticMapStudio extends HTMLElement {
   }
 
   async _loadHistoricalScene(snapshot) {
+    this._setPoseStatus("unavailable");
     if (!snapshot.scene_url.startsWith("/")) return;
     this._stableLiveSnapshotId = undefined;
     this._stableLiveSourceIdentity = undefined;

--- a/custom_components/matic_robot/matic_map_studio.js
+++ b/custom_components/matic_robot/matic_map_studio.js
@@ -847,6 +847,7 @@ class MaticMapStudio extends HTMLElement {
     }
     const snapshot = this._history.at(-1);
     this._selectedHistoryId = snapshot?.id;
+    this._setPoseStatus("unavailable");
     this._syncTimeline();
     if (snapshot) this._loadHistoricalScene(snapshot);
   }
@@ -1069,6 +1070,7 @@ class MaticMapStudio extends HTMLElement {
     this._stableLiveSourceIdentity = undefined;
     this._stableLiveSourceUrl = undefined;
     this._robot = undefined;
+    this._setPoseStatus("unavailable");
     this._renderFloorCount = undefined;
     this._renderSurfaceCount = undefined;
     this._renderPointCount = undefined;
@@ -1850,7 +1852,10 @@ class MaticMapStudio extends HTMLElement {
   }
 
   async _fetchPose(state) {
-    if (this._selectedHistoryId) return;
+    if (this._selectedHistoryId) {
+      this._setPoseStatus("unavailable");
+      return;
+    }
     const url = state?.attributes?.pose_url;
     const sceneUrl = state?.attributes?.scene_url;
     if (!url) return;
@@ -1890,8 +1895,11 @@ class MaticMapStudio extends HTMLElement {
         )
       ) return;
       const position = payload?.position;
+      const source = String(payload?.source || "unavailable");
+      this._setPoseStatus(source);
       if (
-        Array.isArray(position)
+        source === "exact_pose"
+        && Array.isArray(position)
         && position.length === 2
         && position.every(Number.isFinite)
       ) {
@@ -1899,7 +1907,7 @@ class MaticMapStudio extends HTMLElement {
         this._robot = {
           x: position[0] / metadata.metersPerCell - metadata.origin[0],
           y: position[1] / metadata.metersPerCell - metadata.origin[1],
-          source: String(payload.source || "unavailable"),
+          source,
         };
       } else {
         this._robot = undefined;
@@ -1919,6 +1927,19 @@ class MaticMapStudio extends HTMLElement {
         this._fetchPose(this._latestPoseState || state);
       }
     }
+  }
+
+  _setPoseStatus(source) {
+    const status = this.shadowRoot.querySelector(".pose-status");
+    if (!status) return;
+    const roomOnly = source === "current_area" && !this._selectedHistoryId;
+    status.hidden = !roomOnly;
+    status.textContent = roomOnly
+      ? this._localize(
+        "map_robot_room_presence",
+        "Robot is in the current room · exact position unavailable",
+      )
+      : "";
   }
 
   _updateSceneStatus(state) {
@@ -2072,6 +2093,7 @@ class MaticMapStudio extends HTMLElement {
     canvas.hidden = true;
     overlays.hidden = true;
     if (!selected) {
+      this._setPoseStatus("unavailable");
       this._cancelFallbackLoad();
       this._setLoading(false);
       image.hidden = true;
@@ -2084,6 +2106,7 @@ class MaticMapStudio extends HTMLElement {
       return;
     }
     const [entityId, state] = selected;
+    this._setPoseStatus(state.attributes?.robot_location_source);
     const version = `${entityId}:${state.last_updated}:${state.attributes?.map_revision || "rooms"}`;
     const viewport = this.shadowRoot.querySelector(".viewport");
     const pixelRatio = maticClamp(window.devicePixelRatio || 1, 1, 2);
@@ -4126,6 +4149,7 @@ class MaticMapStudio extends HTMLElement {
         .top-down .room-label { color: var(--primary-text-color); border-color: color-mix(in srgb, var(--primary-text-color) 18%, transparent); background: color-mix(in srgb, var(--card-background-color) 84%, transparent); }
         .robot-marker { position: absolute; top: 0; left: 0; width: 14px; height: 14px; border: 2px solid #fff; border-radius: 50%; background: #101923; box-shadow: 0 0 0 5px rgba(255,255,255,.16), 0 4px 14px rgba(0,0,0,.3); will-change: transform; }
         .top-down .robot-marker { border-color: #fff; background: #1438d0; box-shadow: 0 0 0 7px rgba(20,56,208,.16), 0 5px 18px rgba(0,0,0,.25); }
+        .pose-status { position: absolute; z-index: 4; top: 68px; left: 16px; max-width: min(360px, calc(100% - 32px)); padding: 7px 11px; border: 1px solid color-mix(in srgb, var(--primary-text-color) 16%, transparent); border-radius: 999px; color: var(--primary-text-color); background: color-mix(in srgb, var(--card-background-color) 88%, transparent); box-shadow: 0 6px 20px rgba(0,0,0,.18); backdrop-filter: blur(18px) saturate(1.15); font-size: 12px; line-height: 1.35; pointer-events: none; }
         .viewport.loading::after { content: ""; position: absolute; top: 16px; right: 16px; width: 24px; height: 24px; border: 3px solid rgba(255,255,255,.25); border-top-color: var(--primary-color); border-radius: 50%; animation: spin .8s linear infinite; z-index: 3; }
         @keyframes spin { to { transform: rotate(360deg); } }
         .empty { position: absolute; inset: 0; display: grid; place-items: center; color: var(--secondary-text-color); font-size: 17px; text-align: center; padding: 40px; z-index: 2; }
@@ -4309,6 +4333,7 @@ class MaticMapStudio extends HTMLElement {
             <div class="room-labels"></div>
             <span class="robot-marker" role="img" hidden></span>
           </div>
+          <span class="pose-status" role="status" aria-live="polite" hidden></span>
           <div class="empty">${text("map_empty_loading", "Loading the private local map…")}</div>
           <div class="spatial-controls floating-controls" role="toolbar" aria-label="${text("map_camera_controls", "Map camera controls")}">
             <button class="home-view" aria-label="${text("map_home_view", "Fit map")}" title="${text("map_home_view", "Fit map")}"><ha-icon icon="mdi:fit-to-screen-outline" aria-hidden="true"></ha-icon><span class="control-label visually-hidden">${text("map_home_view", "Fit map")}</span></button>

--- a/custom_components/matic_robot/slam_scene.py
+++ b/custom_components/matic_robot/slam_scene.py
@@ -30,7 +30,7 @@ from .area_binding import (
 from .area_selector import MaticAreaSelector
 from .client.commands import CleaningMode, CoverageSetting
 from .client.exceptions import MaticError
-from .client.floor_plan import resolve_robot_map_position
+from .client.floor_plan import resolve_robot_map_position, robot_location_source
 from .client.models import FloorPlan, HermesCollectionEntry, RobotPose
 from .client.slam_map import decode_slam_tile, encode_slam_scene
 from .const import DOMAIN
@@ -614,10 +614,17 @@ class MaticSlamPoseView(HomeAssistantView):
             if floor_plan_coherent
             else None
         )
+        source = (
+            robot_location_source(
+                data.floor_plan, cached.pose, data.operational.current_area
+            )
+            if floor_plan_coherent
+            else "unavailable"
+        )
         return self.json(
             {
                 "position": list(position[:2]) if position is not None else None,
-                "source": position[2] if position is not None else "unavailable",
+                "source": source,
                 "revision": runtime.slam_map.revision,
                 "map_floor_coherent": floor_plan_coherent,
                 "pose_revision": cached.revision,

--- a/custom_components/matic_robot/strings.json
+++ b/custom_components/matic_robot/strings.json
@@ -153,6 +153,7 @@
     "map_resolution_sampled": "{rendered} of {total} pts · 1.5 cm",
     "map_room_default": "Room",
     "map_robot_position": "Robot position · {source}",
+    "map_robot_room_presence": "Robot is in the current room · exact position unavailable",
     "map_rotate_left": "Rotate left",
     "map_rotate_right": "Rotate right",
     "map_sampling_adaptive": "adaptive 1:{step} sampling",

--- a/custom_components/matic_robot/translations/en.json
+++ b/custom_components/matic_robot/translations/en.json
@@ -153,6 +153,7 @@
     "map_resolution_sampled": "{rendered} of {total} pts · 1.5 cm",
     "map_room_default": "Room",
     "map_robot_position": "Robot position · {source}",
+    "map_robot_room_presence": "Robot is in the current room · exact position unavailable",
     "map_rotate_left": "Rotate left",
     "map_rotate_right": "Rotate right",
     "map_sampling_adaptive": "adaptive 1:{step} sampling",

--- a/custom_components/matic_robot/vacuum.py
+++ b/custom_components/matic_robot/vacuum.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict
+from hashlib import sha256
 from typing import Any
 
 from homeassistant.components.vacuum import Segment, StateVacuumEntity
@@ -45,6 +46,12 @@ ACTIVITY_MAP = {
 }
 
 SegmentSignature = tuple[tuple[str, str, str | None], ...]
+
+_FLOOR_SCOPE_OPTION = "matic_floor_scope"
+_FLOOR_CATALOGS_OPTION = "matic_floor_catalogs"
+_UNSCOPED_CATALOG_OPTION = "matic_unscoped_catalog"
+_FLOOR_SCOPE_DOMAIN = b"matic-vacuum-floor-segments-v1\0"
+_MAX_FLOOR_CATALOGS = 12
 
 
 async def async_setup_entry(
@@ -266,6 +273,10 @@ class MaticVacuum(MaticEntity, StateVacuumEntity):
         if (entity_entry := entity_registry.async_get(self.entity_id)) is None:
             return
         options = dict(entity_entry.options.get("vacuum", {}))
+        scope = _floor_scope(self.coordinator.data.floor_plan)
+        stored_scope = options.get(_FLOOR_SCOPE_OPTION)
+        if isinstance(stored_scope, str) and stored_scope != scope:
+            return
         if "area_mapping" in options:
             return
         segments = self._current_segments()
@@ -281,17 +292,96 @@ class MaticVacuum(MaticEntity, StateVacuumEntity):
                 "last_seen_segments": [asdict(segment) for segment in segments],
             }
         )
+        options[_FLOOR_SCOPE_OPTION] = scope
+        catalogs = _floor_catalogs(options)
+        catalogs[scope] = _catalog_from_options(options)
+        options[_FLOOR_CATALOGS_OPTION] = _bounded_floor_catalogs(catalogs, scope)
         entity_registry.async_update_entity_options(self.entity_id, "vacuum", options)
 
     @callback
     def _async_check_segment_changes(self) -> None:
-        """Raise Home Assistant's native repair when configured rooms change."""
-        if self.coordinator.data.floor_plan is None:
+        """Separate expected floor swaps from real same-floor room changes."""
+        floor_plan = self.coordinator.data.floor_plan
+        if self.entity_id is None or floor_plan is None:
             return
+        entity_registry = er.async_get(self.hass)
+        if (entity_entry := entity_registry.async_get(self.entity_id)) is None:
+            return
+        options = dict(entity_entry.options.get("vacuum", {}))
         current = self._current_segments()
         signature = _segment_signature(current)
-        configured = self.last_seen_segments
-        if configured is None or _segment_signature(configured) == signature:
+        current_payload = [asdict(segment) for segment in current]
+        current_scope = _floor_scope(floor_plan)
+        stored_scope = options.get(_FLOOR_SCOPE_OPTION)
+        configured = _segments_from_payload(options.get("last_seen_segments"))
+        catalogs = _floor_catalogs(options)
+
+        if not isinstance(stored_scope, str):
+            if configured is not None and _segment_signature(configured) != signature:
+                options[_UNSCOPED_CATALOG_OPTION] = _catalog_from_options(options)
+                options.pop("area_mapping", None)
+            options["last_seen_segments"] = current_payload
+            options[_FLOOR_SCOPE_OPTION] = current_scope
+            catalogs[current_scope] = _catalog_from_options(options)
+            options[_FLOOR_CATALOGS_OPTION] = _bounded_floor_catalogs(
+                catalogs, current_scope
+            )
+            entity_registry.async_update_entity_options(
+                self.entity_id, "vacuum", options
+            )
+            self._reported_segment_change = None
+            return
+
+        if stored_scope != current_scope:
+            if configured is not None:
+                catalogs[stored_scope] = _catalog_from_options(options)
+            target = catalogs.get(current_scope)
+            unscoped = options.get(_UNSCOPED_CATALOG_OPTION)
+            if target is None and isinstance(unscoped, dict):
+                legacy_segments = _segments_from_payload(
+                    unscoped.get("last_seen_segments")
+                )
+                if (
+                    legacy_segments is not None
+                    and _segment_signature(legacy_segments) == signature
+                ):
+                    target = dict(unscoped)
+                    options.pop(_UNSCOPED_CATALOG_OPTION, None)
+            if target is None:
+                target = {"last_seen_segments": current_payload}
+            catalogs[current_scope] = target
+            _activate_floor_catalog(options, current_scope, target)
+            options[_FLOOR_CATALOGS_OPTION] = _bounded_floor_catalogs(
+                catalogs, current_scope
+            )
+            entity_registry.async_update_entity_options(
+                self.entity_id, "vacuum", options
+            )
+            self._reported_segment_change = None
+            return
+
+        if configured is None:
+            options["last_seen_segments"] = current_payload
+            catalogs[current_scope] = _catalog_from_options(options)
+            options[_FLOOR_CATALOGS_OPTION] = _bounded_floor_catalogs(
+                catalogs, current_scope
+            )
+            entity_registry.async_update_entity_options(
+                self.entity_id, "vacuum", options
+            )
+            self._reported_segment_change = None
+            return
+
+        if _segment_signature(configured) == signature:
+            current_catalog = _catalog_from_options(options)
+            if catalogs.get(current_scope) != current_catalog:
+                catalogs[current_scope] = current_catalog
+                options[_FLOOR_CATALOGS_OPTION] = _bounded_floor_catalogs(
+                    catalogs, current_scope
+                )
+                entity_registry.async_update_entity_options(
+                    self.entity_id, "vacuum", options
+                )
             self._reported_segment_change = None
             return
         if self._reported_segment_change != signature:
@@ -452,6 +542,82 @@ def _validation_error(
         translation_key=translation_key,
         translation_placeholders=placeholders,
     )
+
+
+def _floor_scope(floor_plan: FloorPlan) -> str:
+    """Return a private stable token for one robot partition."""
+    identity = floor_plan.partition_id_wire or floor_plan.partition_protocol_id.encode()
+    return sha256(_FLOOR_SCOPE_DOMAIN + identity).hexdigest()[:24]
+
+
+def _segments_from_payload(value: object) -> list[Segment] | None:
+    """Decode Home Assistant's stored segment payload defensively."""
+    if not isinstance(value, list):
+        return None
+    segments: list[Segment] = []
+    for item in value:
+        if not isinstance(item, dict):
+            return None
+        segment_id = item.get("id")
+        name = item.get("name")
+        group = item.get("group")
+        if (
+            not isinstance(segment_id, str)
+            or not isinstance(name, str)
+            or (group is not None and not isinstance(group, str))
+        ):
+            return None
+        segments.append(Segment(segment_id, name, group))
+    return segments
+
+
+def _catalog_from_options(options: dict[str, Any]) -> dict[str, Any]:
+    """Copy the active floor's HA-native mapping fields into its catalog."""
+    catalog: dict[str, Any] = {
+        "last_seen_segments": list(options.get("last_seen_segments", []))
+    }
+    if isinstance(options.get("area_mapping"), dict):
+        catalog["area_mapping"] = dict(options["area_mapping"])
+    return catalog
+
+
+def _floor_catalogs(options: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Return only structurally valid private floor catalogs."""
+    raw = options.get(_FLOOR_CATALOGS_OPTION)
+    if not isinstance(raw, dict):
+        return {}
+    return {
+        scope: dict(catalog)
+        for scope, catalog in raw.items()
+        if isinstance(scope, str) and isinstance(catalog, dict)
+    }
+
+
+def _bounded_floor_catalogs(
+    catalogs: dict[str, dict[str, Any]], current_scope: str
+) -> dict[str, dict[str, Any]]:
+    """Keep a bounded catalog while always retaining the active floor."""
+    ordered = {
+        scope: catalog for scope, catalog in catalogs.items() if scope != current_scope
+    }
+    ordered[current_scope] = catalogs[current_scope]
+    while len(ordered) > _MAX_FLOOR_CATALOGS:
+        ordered.pop(next(iter(ordered)))
+    return ordered
+
+
+def _activate_floor_catalog(
+    options: dict[str, Any], scope: str, catalog: dict[str, Any]
+) -> None:
+    """Swap HA's single active mapping view to one known floor catalog."""
+    segments = _segments_from_payload(catalog.get("last_seen_segments"))
+    options["last_seen_segments"] = [asdict(segment) for segment in (segments or [])]
+    mapping = catalog.get("area_mapping")
+    if isinstance(mapping, dict):
+        options["area_mapping"] = dict(mapping)
+    else:
+        options.pop("area_mapping", None)
+    options[_FLOOR_SCOPE_OPTION] = scope
 
 
 def _matching_area_mapping(

--- a/custom_components/matic_robot/vacuum.py
+++ b/custom_components/matic_robot/vacuum.py
@@ -382,7 +382,18 @@ class MaticVacuum(MaticEntity, StateVacuumEntity):
             entity_registry.async_update_entity_options(
                 self.entity_id, "vacuum", options
             )
-            self._reported_segment_change = None
+            target_segments = _segments_from_payload(target.get("last_seen_segments"))
+            target_signature = (
+                _segment_signature(target_segments)
+                if target_segments is not None
+                else signature
+            )
+            if target_signature != signature:
+                if self._reported_segment_change != signature:
+                    self.async_create_segments_issue()
+                    self._reported_segment_change = signature
+            else:
+                self._reported_segment_change = None
             return
 
         if configured is None:

--- a/custom_components/matic_robot/vacuum.py
+++ b/custom_components/matic_robot/vacuum.py
@@ -344,10 +344,24 @@ class MaticVacuum(MaticEntity, StateVacuumEntity):
             return
 
         if stored_scope != current_scope:
-            if configured is not None:
+            unscoped = options.get(_UNSCOPED_CATALOG_OPTION)
+            stored_catalog = catalogs.get(stored_scope)
+            stored_segments = (
+                _segments_from_payload(stored_catalog.get("last_seen_segments"))
+                if isinstance(stored_catalog, dict)
+                else None
+            )
+            active_matches_stored_scope = (
+                configured is not None
+                and stored_segments is not None
+                and _segment_signature(configured)
+                == _segment_signature(stored_segments)
+            )
+            if configured is not None and (
+                not isinstance(unscoped, dict) or active_matches_stored_scope
+            ):
                 catalogs[stored_scope] = _catalog_from_options(options)
             target = catalogs.get(current_scope)
-            unscoped = options.get(_UNSCOPED_CATALOG_OPTION)
             if target is None and isinstance(unscoped, dict):
                 legacy_segments = _segments_from_payload(
                     unscoped.get("last_seen_segments")

--- a/custom_components/matic_robot/vacuum.py
+++ b/custom_components/matic_robot/vacuum.py
@@ -80,14 +80,14 @@ class MaticVacuum(MaticEntity, StateVacuumEntity):
     async def async_added_to_hass(self) -> None:
         """Auto-link unconfigured robot rooms to matching Home Assistant Areas."""
         await super().async_added_to_hass()
-        self._async_auto_map_rooms()
         self._async_check_segment_changes()
+        self._async_auto_map_rooms()
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Detect room changes and retry safe exact-name auto-mapping."""
-        self._async_auto_map_rooms()
         self._async_check_segment_changes()
+        self._async_auto_map_rooms()
         super()._handle_coordinator_update()
 
     @property

--- a/custom_components/matic_robot/vacuum.py
+++ b/custom_components/matic_robot/vacuum.py
@@ -319,7 +319,18 @@ class MaticVacuum(MaticEntity, StateVacuumEntity):
         if not isinstance(stored_scope, str):
             if configured is not None and _segment_signature(configured) != signature:
                 options[_UNSCOPED_CATALOG_OPTION] = _catalog_from_options(options)
-                options.pop("area_mapping", None)
+                catalogs[current_scope] = {"last_seen_segments": current_payload}
+                options[_FLOOR_SCOPE_OPTION] = current_scope
+                options[_FLOOR_CATALOGS_OPTION] = _bounded_floor_catalogs(
+                    catalogs, current_scope
+                )
+                if self._reported_segment_change != signature:
+                    self.async_create_segments_issue()
+                    self._reported_segment_change = signature
+                entity_registry.async_update_entity_options(
+                    self.entity_id, "vacuum", options
+                )
+                return
             options["last_seen_segments"] = current_payload
             options[_FLOOR_SCOPE_OPTION] = current_scope
             catalogs[current_scope] = _catalog_from_options(options)

--- a/tests/browser/ui.spec.mjs
+++ b/tests/browser/ui.spec.mjs
@@ -1098,6 +1098,8 @@ test.describe("map studio", () => {
     const timeline = studio.locator(".timeline");
     await expect(timeline).toBeVisible();
     await expect(timeline.locator(".timeline-live")).toHaveAttribute("aria-pressed", "true");
+    await page.evaluate(() => window.__studio._setPoseStatus("current_area"));
+    await expect(studio.locator(".pose-status")).toBeVisible();
     expect(await timeline.locator(".timeline-summary").evaluate((summary) => {
       const event = new PointerEvent("pointerdown", {
         bubbles: true,
@@ -1128,6 +1130,7 @@ test.describe("map studio", () => {
     await expect.poll(() => page.evaluate(() =>
       window.__studio._scene?.metadata?.rooms?.[0]?.name,
     )).toBe("Recent room");
+    await expect(studio.locator(".pose-status")).toBeHidden();
     await expect(studio.locator(".status")).toContainText("Map captured");
     await timeline.locator(".timeline-earlier").click();
     await expect.poll(() => page.evaluate(() =>
@@ -2207,6 +2210,7 @@ test.describe("map studio", () => {
         attributes: {
           matic_entry_id: "alpha",
           robot_location_source: "exact_pose",
+          source: "local_room_map",
         },
       },
       "camera.beta_rooms": {
@@ -2215,6 +2219,7 @@ test.describe("map studio", () => {
         attributes: {
           matic_entry_id: "beta",
           robot_location_source: "exact_pose",
+          source: "local_room_map",
         },
       },
     });
@@ -2469,6 +2474,36 @@ test.describe("map studio", () => {
     expect(await page.evaluate(() => window.__glCalls.some(([name]) => name === "bufferData"))).toBe(true);
   });
 
+  test("keeps the photorealistic camera out of the room-camera match", async ({ page }) => {
+    await installBrowserDoubles(page);
+    await loadStudio(page, {
+      "camera.synthetic_photo": {
+        state: "idle",
+        last_updated: "2026-01-01T00:00:00Z",
+        attributes: {
+          source: "local_robot_slam",
+          robot_location_source: "current_area",
+        },
+      },
+      "camera.synthetic_rooms": {
+        state: "idle",
+        last_updated: "2026-01-01T00:00:00Z",
+        attributes: {
+          source: "local_room_map",
+          robot_location_source: "exact_pose",
+        },
+      },
+    });
+
+    expect(await page.evaluate(() => {
+      const entities = window.__studio._entities();
+      return { photo: entities.photo?.[0], rooms: entities.rooms?.[0] };
+    })).toEqual({
+      photo: "camera.synthetic_photo",
+      rooms: "camera.synthetic_rooms",
+    });
+  });
+
   test("uses the local camera map when WebGL 2 is unavailable", async ({ page }) => {
     await installBrowserDoubles(page, { images: true });
     const studio = await loadStudio(page, {
@@ -2684,7 +2719,10 @@ test.describe("map studio", () => {
           "camera.synthetic_rooms": {
             state: "idle",
             last_updated: "2026-01-01T00:00:00Z",
-            attributes: { robot_location_source: "exact_pose" },
+            attributes: {
+              robot_location_source: "exact_pose",
+              source: "local_room_map",
+            },
           },
         },
         auth: { data: { access_token: "synthetic-token" } },

--- a/tests/browser/ui.spec.mjs
+++ b/tests/browser/ui.spec.mjs
@@ -2475,7 +2475,11 @@ test.describe("map studio", () => {
       "camera.synthetic_map": {
         state: "idle",
         last_updated: "2026-01-01T00:00:00Z",
-        attributes: { source: "local_robot_slam", map_revision: 1 },
+        attributes: {
+          source: "local_robot_slam",
+          map_revision: 1,
+          robot_location_source: "current_area",
+        },
       },
     });
     await expect(studio.locator(".map-image")).toBeVisible();
@@ -2483,6 +2487,10 @@ test.describe("map studio", () => {
     await expect(studio.locator(".status")).toContainText("3D rendering paused");
     await expect(studio.locator(".status")).toHaveAttribute("data-tone", "warning");
     await expect(studio.locator(".resolution-value")).toHaveText("640 × 480");
+    await expect(studio.locator(".pose-status")).toHaveText(
+      "Robot is in the current room · exact position unavailable",
+    );
+    await expect(studio.locator(".robot-marker")).toBeHidden();
   });
 
   test("ends a stalled first image load with actionable state", async ({ page }) => {

--- a/tests/browser/ui.spec.mjs
+++ b/tests/browser/ui.spec.mjs
@@ -1370,7 +1370,7 @@ test.describe("map studio", () => {
     await page.route("**/live-pose", (route) => route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify({ position: [0.3, 0.3], source: "live_pose" }),
+      body: JSON.stringify({ position: [0.3, 0.3], source: "exact_pose" }),
     }));
     await page.route("**/rebuilding-delta?since=*", (route) => {
       deltaRequests += 1;
@@ -1391,7 +1391,7 @@ test.describe("map studio", () => {
     )).toBe("Complete retained room");
     await expect(studio.locator(".status")).toContainText("last complete map");
     await expect(studio.locator(".timeline-live")).toHaveAttribute("aria-pressed", "true");
-    await expect.poll(() => page.evaluate(() => window.__studio._robot?.source)).toBe("live_pose");
+    await expect.poll(() => page.evaluate(() => window.__studio._robot?.source)).toBe("exact_pose");
     expect(await page.evaluate(() => ({
       sceneUrl: window.__studio._sceneUrl,
       stableId: window.__studio._stableLiveSnapshotId,
@@ -2028,6 +2028,46 @@ test.describe("map studio", () => {
     expect(zoomRange.label).toBe(`${zoomRange.maximum}%`);
   });
 
+  test("shows room presence without inventing a precise robot marker", async ({ page }) => {
+    await installBrowserDoubles(page, { webgl: true });
+    let pose = { position: [0.15, 0.15], source: "current_area" };
+    await page.route("**/api/matic_robot/slam_entries", (route) => route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ entries: [{
+        entry_id: "synthetic-entry",
+        scene_url: "/room-presence-scene",
+        pose_url: "/room-presence-pose",
+        map_revision: 1,
+        map_complete: true,
+      }] }),
+    }));
+    await page.route("**/room-presence-scene", (route) => route.fulfill({
+      status: 200,
+      body: syntheticScene(),
+      headers: { "Content-Type": "application/octet-stream", ETag: '"room-presence"' },
+    }));
+    await page.route("**/room-presence-pose", (route) => route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(pose),
+    }));
+
+    const studio = await loadStudio(page);
+    await expect(studio.locator(".pose-status")).toBeVisible();
+    await expect(studio.locator(".pose-status")).toHaveText(
+      "Robot is in the current room · exact position unavailable",
+    );
+    await expect(studio.locator(".robot-marker")).toBeHidden();
+    expect(await page.evaluate(() => window.__studio._robot)).toBeUndefined();
+
+    pose = { position: [0.15, 0.15], source: "exact_pose" };
+    await page.evaluate(() => window.__studio._update(true));
+    await expect(studio.locator(".pose-status")).toBeHidden();
+    await expect.poll(() => page.evaluate(() => window.__studio._robot?.source))
+      .toBe("exact_pose");
+  });
+
   test("abandons a stalled catalog and continues from camera state", async ({ page }) => {
     await installBrowserDoubles(page, { webgl: true });
     await page.addInitScript(() => {
@@ -2149,7 +2189,7 @@ test.describe("map studio", () => {
         await route.fulfill({
           status: 200,
           contentType: "application/json",
-          body: JSON.stringify({ position: [0.15, 0.15], source: "alpha_pose" }),
+          body: JSON.stringify({ position: [0.15, 0.15], source: "exact_pose" }),
         });
       } catch (_error) {
         // The entry switch intentionally aborts the superseded request.
@@ -2158,7 +2198,7 @@ test.describe("map studio", () => {
     await page.route("**/pose-beta", (route) => route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify({ position: [0.3, 0.3], source: "beta_pose" }),
+      body: JSON.stringify({ position: [0.3, 0.3], source: "exact_pose" }),
     }));
     const studio = await loadStudio(page, {
       "camera.alpha_rooms": {
@@ -2193,7 +2233,10 @@ test.describe("map studio", () => {
     await expect.poll(() => page.evaluate(() =>
       window.__studio._scene.metadata.rooms[0].name,
     )).toBe("Beta room");
-    await expect.poll(() => page.evaluate(() => window.__studio._robot?.source)).toBe("beta_pose");
+    await expect.poll(() => page.evaluate(() => ({
+      source: window.__studio._robot?.source,
+      x: window.__studio._robot?.x,
+    }))).toEqual({ source: "exact_pose", x: 10 });
     expect(betaIfNoneMatch).toBeUndefined();
     expect(await page.evaluate(() =>
       window.__studio._entities("beta").rooms[0],

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1191,6 +1191,7 @@ async def test_camera_clamps_dimensions_and_renders_locally(hass) -> None:
     assert entity.extra_state_attributes == {
         "matic_entry_id": "entry",
         "robot_location_source": "exact_pose",
+        "source": "local_room_map",
     }
     assert entity._unrecorded_attributes == frozenset({"matic_entry_id"})
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1226,11 +1226,15 @@ async def test_photorealistic_camera_fetches_and_renders_local_tiles(hass) -> No
         "map_complete": True,
         "map_revision": 1,
         "map_floor_coherent": True,
+        "robot_location_source": "exact_pose",
         "source": "local_robot_slam",
         "scene_url": "/api/matic_robot/slam_scene/entry",
         "pose_url": "/api/matic_robot/slam_pose/entry",
     }
     assert entity._unrecorded_attributes == frozenset({"matic_entry_id"})
+
+    store.floor_plan_is_current.return_value = False
+    assert entity.extra_state_attributes["robot_location_source"] == "unavailable"
 
 
 async def test_photorealistic_camera_rechecks_cache_after_render_lock(hass) -> None:

--- a/tests/test_floor_plan.py
+++ b/tests/test_floor_plan.py
@@ -25,6 +25,7 @@ from custom_components.matic_robot.client.floor_plan import (
     pose_vector_paths,
     render_floor_plan,
     resolve_robot_map_position,
+    robot_location_source,
 )
 from custom_components.matic_robot.client.models import FloorPlan, RobotPose
 from tests.wire_builders import _field, _fixed32, _fixed64, _varint_field
@@ -135,7 +136,7 @@ def test_pose_vector_path_inspection_is_bounded_and_ignores_invalid_data() -> No
     assert pose_vector_paths(payload) == ()
 
 
-def test_robot_position_falls_back_to_the_current_room() -> None:
+def test_robot_position_requires_exact_coordinates_and_tracks_room_presence() -> None:
     floor_plan = decode_floor_plan(_floor_plan_payload())
 
     assert resolve_robot_map_position(floor_plan, RobotPose(2, 1, 0), "Test room") == (
@@ -143,11 +144,17 @@ def test_robot_position_falls_back_to_the_current_room() -> None:
         1,
         "exact_pose",
     )
-    fallback = resolve_robot_map_position(
-        floor_plan, RobotPose(float("nan"), 999, 0), "the  Test room"
+    invalid_pose = RobotPose(float("nan"), 999, 0)
+    assert (
+        resolve_robot_map_position(floor_plan, invalid_pose, "the  Test room") is None
     )
-    assert fallback is not None
-    assert fallback[2] == "current_area"
+    assert robot_location_source(floor_plan, invalid_pose, "the  Test room") == (
+        "current_area"
+    )
+    assert robot_location_source(floor_plan, RobotPose(2, 1, 0), None) == ("exact_pose")
+    assert robot_location_source(floor_plan, None, "Garage") == "unavailable"
+    assert robot_location_source(floor_plan, None, None) == "unavailable"
+    assert robot_location_source(None, None, "Test room") == "unavailable"
     assert resolve_robot_map_position(floor_plan, None, "Garage") is None
     assert resolve_robot_map_position(floor_plan, None, "   ") is None
     assert resolve_robot_map_position(None, None, "Test room") is None
@@ -160,7 +167,7 @@ def test_robot_position_falls_back_to_the_current_room() -> None:
     fallback_marker = render_floor_plan(
         floor_plan, None, "the Test room", width=256, height=256
     )
-    assert fallback_marker != without_marker
+    assert fallback_marker == without_marker
 
 
 def test_decode_rejects_plan_without_standard_partition() -> None:

--- a/tests/test_slam_scene.py
+++ b/tests/test_slam_scene.py
@@ -572,6 +572,7 @@ async def test_pose_view_returns_exact_fallback_and_unavailable_positions() -> N
     with patch("custom_components.matic_robot.slam_scene.monotonic", return_value=20.0):
         fallback = await MaticSlamPoseView().get(_request(fallback_hass), "entry")
     fallback_payload = json.loads(fallback.body)
+    assert fallback_payload["position"] is None
     assert fallback_payload["source"] == "current_area"
     assert fallback_payload["pose_freshness"] == "coordinator_fallback"
 

--- a/tests/test_vacuum_areas.py
+++ b/tests/test_vacuum_areas.py
@@ -1,7 +1,7 @@
 """Home Assistant Area mapping for local Matic room segments."""
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.components.vacuum import Segment
 
@@ -9,8 +9,11 @@ from custom_components.matic_robot.client.models import FloorPlan, RobotInfo, Ro
 from custom_components.matic_robot.entity import MaticEntity
 from custom_components.matic_robot.vacuum import (
     MaticVacuum,
+    _bounded_floor_catalogs,
+    _floor_scope,
     _matching_area_mapping,
     _segment_signature,
+    _segments_from_payload,
 )
 
 
@@ -127,6 +130,16 @@ def test_auto_mapping_writes_only_unconfigured_exact_matches() -> None:
     assert options["last_seen_segments"] == [
         {"id": "room-1", "name": "Kitchen", "group": "Current floor"}
     ]
+    scope = _floor_scope(entity.coordinator.data.floor_plan)
+    assert options["matic_floor_scope"] == scope
+    assert options["matic_floor_catalogs"] == {
+        scope: {
+            "area_mapping": {"kitchen": ["room-1"]},
+            "last_seen_segments": [
+                {"id": "room-1", "name": "Kitchen", "group": "Current floor"}
+            ],
+        }
+    }
 
     entity_registry.async_get.return_value = SimpleNamespace(
         options={"vacuum": {"area_mapping": {}}}
@@ -176,6 +189,32 @@ def test_auto_mapping_skips_unregistered_and_unmatched_states() -> None:
     entity_registry.async_update_entity_options.assert_not_called()
 
 
+def test_auto_mapping_waits_for_the_floor_catalog_swap() -> None:
+    """Do not overwrite a saved mapping while a new partition is activating."""
+    entity = _vacuum()
+    entity_registry = MagicMock()
+    entity_registry.async_get.return_value = SimpleNamespace(
+        options={"vacuum": {"matic_floor_scope": "different-floor"}}
+    )
+    area_registry = MagicMock()
+    area_registry.async_get_area_by_name.return_value = SimpleNamespace(id="kitchen")
+
+    with (
+        patch(
+            "custom_components.matic_robot.vacuum.er.async_get",
+            return_value=entity_registry,
+        ),
+        patch(
+            "custom_components.matic_robot.vacuum.ar.async_get",
+            return_value=area_registry,
+        ),
+    ):
+        entity._async_auto_map_rooms()
+
+    entity_registry.async_update_entity_options.assert_not_called()
+    area_registry.async_get_area_by_name.assert_not_called()
+
+
 def test_segment_change_check_requires_a_local_floor_plan() -> None:
     """Never raise a repair before the robot shares its room plan."""
     entity = _vacuum(with_floor_plan=False)
@@ -186,23 +225,197 @@ def test_segment_change_check_requires_a_local_floor_plan() -> None:
     entity.async_create_segments_issue.assert_not_called()
     assert entity._reported_segment_change is None
 
+    registered = _vacuum()
+    entity_registry = MagicMock()
+    entity_registry.async_get.return_value = None
+    with patch(
+        "custom_components.matic_robot.vacuum.er.async_get",
+        return_value=entity_registry,
+    ):
+        registered._async_check_segment_changes()
+    entity_registry.async_update_entity_options.assert_not_called()
+
+
+def test_segment_check_initializes_a_missing_catalog_for_a_known_floor() -> None:
+    entity = _vacuum()
+    scope = _floor_scope(entity.coordinator.data.floor_plan)
+    entity_entry = SimpleNamespace(options={"vacuum": {"matic_floor_scope": scope}})
+    entity_registry = MagicMock()
+    entity_registry.async_get.return_value = entity_entry
+
+    with patch(
+        "custom_components.matic_robot.vacuum.er.async_get",
+        return_value=entity_registry,
+    ):
+        entity._async_check_segment_changes()
+
+    updated = entity_registry.async_update_entity_options.call_args.args[2]
+    assert updated["last_seen_segments"] == [
+        {"id": "room-1", "name": "Kitchen", "group": "Current floor"}
+    ]
+    assert (
+        updated["matic_floor_catalogs"][scope]["last_seen_segments"]
+        == (updated["last_seen_segments"])
+    )
+
+
+def test_segment_option_parsing_is_defensive_and_catalogs_are_bounded() -> None:
+    assert _segments_from_payload(None) is None
+    assert _segments_from_payload(["invalid"]) is None
+    assert _segments_from_payload([{"id": 1, "name": "Room"}]) is None
+
+    catalogs = {f"scope-{index}": {"last_seen_segments": []} for index in range(13)}
+    catalogs["current"] = {"last_seen_segments": []}
+    bounded = _bounded_floor_catalogs(catalogs, "current")
+
+    assert len(bounded) == 12
+    assert "current" in bounded
+    assert "scope-0" not in bounded
+
 
 def test_segment_change_repair_is_deduplicated_and_resets() -> None:
     entity = _vacuum()
     entity.async_create_segments_issue = MagicMock()
-    old = [Segment("old", "Old room", "Current floor")]
+    scope = _floor_scope(entity.coordinator.data.floor_plan)
+    old_payload = [{"id": "old", "name": "Old room", "group": "Current floor"}]
+    entity_entry = SimpleNamespace(
+        options={
+            "vacuum": {
+                "last_seen_segments": old_payload,
+                "matic_floor_scope": scope,
+                "matic_floor_catalogs": {scope: {"last_seen_segments": old_payload}},
+            }
+        }
+    )
+    entity_registry = MagicMock()
+    entity_registry.async_get.return_value = entity_entry
 
-    with patch.object(
-        MaticVacuum, "last_seen_segments", new_callable=PropertyMock
-    ) as seen:
-        seen.return_value = old
+    with patch(
+        "custom_components.matic_robot.vacuum.er.async_get",
+        return_value=entity_registry,
+    ):
         entity._async_check_segment_changes()
         entity._async_check_segment_changes()
         entity.async_create_segments_issue.assert_called_once()
 
-        seen.return_value = entity._current_segments()
+        entity_entry.options["vacuum"]["last_seen_segments"] = [
+            {"id": "room-1", "name": "Kitchen", "group": "Current floor"}
+        ]
         entity._async_check_segment_changes()
         assert entity._reported_segment_change is None
+        updated = entity_registry.async_update_entity_options.call_args.args[2]
+        assert (
+            updated["matic_floor_catalogs"][scope]["last_seen_segments"]
+            == (updated["last_seen_segments"])
+        )
+
+
+def test_floor_swap_stores_and_restores_floor_specific_area_mapping() -> None:
+    """Expected partition changes swap catalogs without raising a Repair."""
+    entity = _vacuum()
+    entity.async_create_segments_issue = MagicMock()
+    current_plan = entity.coordinator.data.floor_plan
+    current_scope = _floor_scope(current_plan)
+    previous_plan = FloorPlan(
+        2,
+        "previous-partition",
+        b"previous-partition",
+        (_room("old-room", "Old room"),),
+    )
+    previous_scope = _floor_scope(previous_plan)
+    old_payload = [{"id": "old-room", "name": "Old room", "group": "Current floor"}]
+    old_mapping = {"old-area": ["old-room"]}
+    entity_entry = SimpleNamespace(
+        options={
+            "vacuum": {
+                "area_mapping": old_mapping,
+                "last_seen_segments": old_payload,
+                "matic_floor_scope": previous_scope,
+                "matic_floor_catalogs": {
+                    previous_scope: {
+                        "area_mapping": old_mapping,
+                        "last_seen_segments": old_payload,
+                    }
+                },
+            }
+        }
+    )
+    entity_registry = MagicMock()
+    entity_registry.async_get.return_value = entity_entry
+
+    with patch(
+        "custom_components.matic_robot.vacuum.er.async_get",
+        return_value=entity_registry,
+    ):
+        entity._async_check_segment_changes()
+
+        current_options = entity_registry.async_update_entity_options.call_args.args[2]
+        assert current_options["matic_floor_scope"] == current_scope
+        assert "area_mapping" not in current_options
+        entity.async_create_segments_issue.assert_not_called()
+
+        current_options["area_mapping"] = {"current-area": ["room-1"]}
+        current_options["matic_floor_catalogs"][current_scope] = {
+            "area_mapping": current_options["area_mapping"],
+            "last_seen_segments": current_options["last_seen_segments"],
+        }
+        entity_entry.options = {"vacuum": current_options}
+        entity.coordinator.data.floor_plan = previous_plan
+        entity_registry.async_update_entity_options.reset_mock()
+        entity._async_check_segment_changes()
+
+    restored = entity_registry.async_update_entity_options.call_args.args[2]
+    assert restored["matic_floor_scope"] == previous_scope
+    assert restored["area_mapping"] == old_mapping
+    assert restored["last_seen_segments"] == old_payload
+    entity.async_create_segments_issue.assert_not_called()
+
+
+def test_legacy_single_catalog_is_claimed_when_its_floor_returns() -> None:
+    """A pre-upgrade mapping survives first observing a different floor."""
+    entity = _vacuum()
+    entity.async_create_segments_issue = MagicMock()
+    home_plan = FloorPlan(
+        3,
+        "home-partition",
+        b"home-partition",
+        (_room("home-room", "Home room"),),
+    )
+    home_payload = [{"id": "home-room", "name": "Home room", "group": "Current floor"}]
+    home_mapping = {"home-area": ["home-room"]}
+    entity_entry = SimpleNamespace(
+        options={
+            "vacuum": {
+                "area_mapping": home_mapping,
+                "last_seen_segments": home_payload,
+            }
+        }
+    )
+    entity_registry = MagicMock()
+    entity_registry.async_get.return_value = entity_entry
+
+    with patch(
+        "custom_components.matic_robot.vacuum.er.async_get",
+        return_value=entity_registry,
+    ):
+        entity._async_check_segment_changes()
+        shed_options = entity_registry.async_update_entity_options.call_args.args[2]
+        assert shed_options["matic_unscoped_catalog"] == {
+            "area_mapping": home_mapping,
+            "last_seen_segments": home_payload,
+        }
+        assert "area_mapping" not in shed_options
+
+        entity_entry.options = {"vacuum": shed_options}
+        entity.coordinator.data.floor_plan = home_plan
+        entity_registry.async_update_entity_options.reset_mock()
+        entity._async_check_segment_changes()
+
+    restored = entity_registry.async_update_entity_options.call_args.args[2]
+    assert restored["matic_floor_scope"] == _floor_scope(home_plan)
+    assert restored["area_mapping"] == home_mapping
+    assert "matic_unscoped_catalog" not in restored
+    entity.async_create_segments_issue.assert_not_called()
 
 
 async def test_lifecycle_runs_area_mapping_and_change_checks() -> None:

--- a/tests/test_vacuum_areas.py
+++ b/tests/test_vacuum_areas.py
@@ -400,6 +400,62 @@ def test_floor_swap_stores_and_restores_floor_specific_area_mapping() -> None:
     entity.async_create_segments_issue.assert_not_called()
 
 
+def test_returning_to_changed_cataloged_floor_raises_repair() -> None:
+    """Revalidate a retained floor catalog against its current room topology."""
+    entity = _vacuum()
+    entity.async_create_segments_issue = MagicMock()
+    current_scope = _floor_scope(entity.coordinator.data.floor_plan)
+    previous_plan = FloorPlan(
+        2,
+        "previous-partition",
+        b"previous-partition",
+        (_room("old-room", "Old room"),),
+    )
+    previous_scope = _floor_scope(previous_plan)
+    previous_payload = [
+        {"id": "old-room", "name": "Old room", "group": "Current floor"}
+    ]
+    stale_current_payload = [
+        {"id": "room-1", "name": "Old kitchen", "group": "Current floor"}
+    ]
+    stale_mapping = {"kitchen": ["room-1"]}
+    entity_entry = SimpleNamespace(
+        options={
+            "vacuum": {
+                "last_seen_segments": previous_payload,
+                "matic_floor_scope": previous_scope,
+                "matic_floor_catalogs": {
+                    previous_scope: {"last_seen_segments": previous_payload},
+                    current_scope: {
+                        "area_mapping": stale_mapping,
+                        "last_seen_segments": stale_current_payload,
+                    },
+                },
+            }
+        }
+    )
+    entity_registry = MagicMock()
+    entity_registry.async_get.return_value = entity_entry
+    entity_registry.async_update_entity_options.side_effect = (
+        lambda _entity_id, domain, options: setattr(
+            entity_entry, "options", {domain: options}
+        )
+    )
+
+    with patch(
+        "custom_components.matic_robot.vacuum.er.async_get",
+        return_value=entity_registry,
+    ):
+        entity._async_check_segment_changes()
+        entity._async_check_segment_changes()
+
+    restored = entity_entry.options["vacuum"]
+    assert restored["matic_floor_scope"] == current_scope
+    assert restored["last_seen_segments"] == stale_current_payload
+    assert restored["area_mapping"] == stale_mapping
+    entity.async_create_segments_issue.assert_called_once()
+
+
 def test_new_floor_is_auto_mapped_in_the_same_idle_update() -> None:
     """Activate then exact-name map a floor without needing another refresh."""
     entity = _vacuum()

--- a/tests/test_vacuum_areas.py
+++ b/tests/test_vacuum_areas.py
@@ -454,6 +454,7 @@ def test_ambiguous_legacy_mapping_is_preserved_until_its_floor_returns() -> None
     """A pre-upgrade mismatch warns once without discarding the old mapping."""
     entity = _vacuum()
     entity.async_create_segments_issue = MagicMock()
+    shed_plan = entity.coordinator.data.floor_plan
     home_plan = FloorPlan(
         3,
         "home-partition",
@@ -498,10 +499,26 @@ def test_ambiguous_legacy_mapping_is_preserved_until_its_floor_returns() -> None
         entity_registry.async_update_entity_options.reset_mock()
         entity._async_check_segment_changes()
 
-    restored = entity_registry.async_update_entity_options.call_args.args[2]
-    assert restored["matic_floor_scope"] == _floor_scope(home_plan)
-    assert restored["area_mapping"] == home_mapping
-    assert "matic_unscoped_catalog" not in restored
+    restored_home = entity_registry.async_update_entity_options.call_args.args[2]
+    assert restored_home["matic_floor_scope"] == _floor_scope(home_plan)
+    assert restored_home["area_mapping"] == home_mapping
+    assert "matic_unscoped_catalog" not in restored_home
+
+    entity_entry.options = {"vacuum": restored_home}
+    entity.coordinator.data.floor_plan = shed_plan
+    entity_registry.async_update_entity_options.reset_mock()
+    with patch(
+        "custom_components.matic_robot.vacuum.er.async_get",
+        return_value=entity_registry,
+    ):
+        entity._async_check_segment_changes()
+
+    restored_shed = entity_registry.async_update_entity_options.call_args.args[2]
+    assert restored_shed["matic_floor_scope"] == shed_scope
+    assert restored_shed["last_seen_segments"] == [
+        {"id": "room-1", "name": "Kitchen", "group": "Current floor"}
+    ]
+    assert "area_mapping" not in restored_shed
     entity.async_create_segments_issue.assert_called_once()
 
 

--- a/tests/test_vacuum_areas.py
+++ b/tests/test_vacuum_areas.py
@@ -371,6 +371,56 @@ def test_floor_swap_stores_and_restores_floor_specific_area_mapping() -> None:
     entity.async_create_segments_issue.assert_not_called()
 
 
+def test_new_floor_is_auto_mapped_in_the_same_idle_update() -> None:
+    """Activate then exact-name map a floor without needing another refresh."""
+    entity = _vacuum()
+    previous_plan = FloorPlan(
+        2,
+        "previous-partition",
+        b"previous-partition",
+        (_room("old-room", "Old room"),),
+    )
+    old_payload = [{"id": "old-room", "name": "Old room", "group": "Current floor"}]
+    entity_entry = SimpleNamespace(
+        options={
+            "vacuum": {
+                "area_mapping": {"old-area": ["old-room"]},
+                "last_seen_segments": old_payload,
+                "matic_floor_scope": _floor_scope(previous_plan),
+            }
+        }
+    )
+    entity_registry = MagicMock()
+    entity_registry.async_get.return_value = entity_entry
+    entity_registry.async_update_entity_options.side_effect = (
+        lambda _entity_id, domain, options: setattr(
+            entity_entry, "options", {domain: options}
+        )
+    )
+    area_registry = MagicMock()
+    area_registry.async_get_area_by_name.return_value = SimpleNamespace(id="kitchen")
+
+    with (
+        patch(
+            "custom_components.matic_robot.vacuum.er.async_get",
+            return_value=entity_registry,
+        ),
+        patch(
+            "custom_components.matic_robot.vacuum.ar.async_get",
+            return_value=area_registry,
+        ),
+        patch.object(MaticEntity, "_handle_coordinator_update"),
+    ):
+        entity._handle_coordinator_update()
+
+    current_options = entity_entry.options["vacuum"]
+    assert entity_registry.async_update_entity_options.call_count == 2
+    assert current_options["matic_floor_scope"] == _floor_scope(
+        entity.coordinator.data.floor_plan
+    )
+    assert current_options["area_mapping"] == {"kitchen": ["room-1"]}
+
+
 def test_legacy_single_catalog_is_claimed_when_its_floor_returns() -> None:
     """A pre-upgrade mapping survives first observing a different floor."""
     entity = _vacuum()
@@ -420,18 +470,24 @@ def test_legacy_single_catalog_is_claimed_when_its_floor_returns() -> None:
 
 async def test_lifecycle_runs_area_mapping_and_change_checks() -> None:
     entity = _vacuum()
-    entity._async_auto_map_rooms = MagicMock()
-    entity._async_check_segment_changes = MagicMock()
+    calls: list[str] = []
+    entity._async_auto_map_rooms = MagicMock(side_effect=lambda: calls.append("map"))
+    entity._async_check_segment_changes = MagicMock(
+        side_effect=lambda: calls.append("segments")
+    )
     with patch.object(MaticEntity, "async_added_to_hass", AsyncMock()):
         await entity.async_added_to_hass()
 
+    assert calls == ["segments", "map"]
     entity._async_auto_map_rooms.assert_called_once()
     entity._async_check_segment_changes.assert_called_once()
 
+    calls.clear()
     entity._async_auto_map_rooms.reset_mock()
     entity._async_check_segment_changes.reset_mock()
     with patch.object(MaticEntity, "_handle_coordinator_update") as parent_update:
         entity._handle_coordinator_update()
+    assert calls == ["segments", "map"]
     entity._async_auto_map_rooms.assert_called_once()
     entity._async_check_segment_changes.assert_called_once()
     parent_update.assert_called_once()

--- a/tests/test_vacuum_areas.py
+++ b/tests/test_vacuum_areas.py
@@ -259,6 +259,35 @@ def test_segment_check_initializes_a_missing_catalog_for_a_known_floor() -> None
     )
 
 
+def test_matching_legacy_catalog_is_bound_to_the_current_floor() -> None:
+    entity = _vacuum()
+    current_payload = [{"id": "room-1", "name": "Kitchen", "group": "Current floor"}]
+    entity_entry = SimpleNamespace(
+        options={
+            "vacuum": {
+                "area_mapping": {"kitchen": ["room-1"]},
+                "last_seen_segments": current_payload,
+            }
+        }
+    )
+    entity_registry = MagicMock()
+    entity_registry.async_get.return_value = entity_entry
+
+    with patch(
+        "custom_components.matic_robot.vacuum.er.async_get",
+        return_value=entity_registry,
+    ):
+        entity._async_check_segment_changes()
+
+    updated = entity_registry.async_update_entity_options.call_args.args[2]
+    scope = _floor_scope(entity.coordinator.data.floor_plan)
+    assert updated["matic_floor_scope"] == scope
+    assert updated["area_mapping"] == {"kitchen": ["room-1"]}
+    assert (
+        updated["matic_floor_catalogs"][scope]["last_seen_segments"] == current_payload
+    )
+
+
 def test_segment_option_parsing_is_defensive_and_catalogs_are_bounded() -> None:
     assert _segments_from_payload(None) is None
     assert _segments_from_payload(["invalid"]) is None
@@ -421,8 +450,8 @@ def test_new_floor_is_auto_mapped_in_the_same_idle_update() -> None:
     assert current_options["area_mapping"] == {"kitchen": ["room-1"]}
 
 
-def test_legacy_single_catalog_is_claimed_when_its_floor_returns() -> None:
-    """A pre-upgrade mapping survives first observing a different floor."""
+def test_ambiguous_legacy_mapping_is_preserved_until_its_floor_returns() -> None:
+    """A pre-upgrade mismatch warns once without discarding the old mapping."""
     entity = _vacuum()
     entity.async_create_segments_issue = MagicMock()
     home_plan = FloorPlan(
@@ -454,7 +483,15 @@ def test_legacy_single_catalog_is_claimed_when_its_floor_returns() -> None:
             "area_mapping": home_mapping,
             "last_seen_segments": home_payload,
         }
-        assert "area_mapping" not in shed_options
+        assert shed_options["area_mapping"] == home_mapping
+        assert shed_options["last_seen_segments"] == home_payload
+        shed_scope = _floor_scope(entity.coordinator.data.floor_plan)
+        assert shed_options["matic_floor_catalogs"][shed_scope] == {
+            "last_seen_segments": [
+                {"id": "room-1", "name": "Kitchen", "group": "Current floor"}
+            ]
+        }
+        entity.async_create_segments_issue.assert_called_once()
 
         entity_entry.options = {"vacuum": shed_options}
         entity.coordinator.data.floor_plan = home_plan
@@ -465,7 +502,7 @@ def test_legacy_single_catalog_is_claimed_when_its_floor_returns() -> None:
     assert restored["matic_floor_scope"] == _floor_scope(home_plan)
     assert restored["area_mapping"] == home_mapping
     assert "matic_unscoped_catalog" not in restored
-    entity.async_create_segments_issue.assert_not_called()
+    entity.async_create_segments_issue.assert_called_once()
 
 
 async def test_lifecycle_runs_area_mapping_and_change_checks() -> None:


### PR DESCRIPTION
## Summary

- Draw the robot marker only when the integration has validated exact coordinates.
- Show a clear room-presence notice in 3D, room-map, and photo-only fallback when only the current room is known, and clear it for historical views.
- Keep Home Assistant room segments and Area mappings scoped to the active floor, so established floor swaps do not create Repairs.
- Revalidate a restored floor catalog, preserve Repairs for real room edits, and retain ambiguous pre-upgrade mappings until they can be safely matched.
- Distinguish room and photorealistic cameras explicitly so entity ordering cannot select the wrong map.

## Live reproduction

A real second map reproduced both defects on v0.3.12-rc1: the saved floor stayed read-only, but a short clean showed a stationary room-center marker when exact pose was unavailable, and the expected floor catalog swap repeatedly raised the core Vacuum segments-changed Repair. The robot was stopped afterward and read back ready with no error, session, managed plan, runner lock, stop fence, or reconciliation marker.

## Verification

- 1,104 Python tests; 100% coverage across 10,219 statements
- 50 browser tests
- Ruff and format
- strict MyPy
- public-tree privacy check
- HACS and Hassfest
- clean regular review on exact head 918338b

Related to #54. Keep the issue open until an RC2 built from the accepted commit passes the same real two-map workflow.