### PR TITLE
Fix Home Assistant LLM platform no-op

### DIFF
--- a/custom_components/matic_robot/llm.py
+++ b/custom_components/matic_robot/llm.py
@@ -464,15 +464,17 @@ class MaticGetRecentEventsTool(_MaticTool):
 @callback
 def async_get_tools(
     hass: HomeAssistant, llm_context: llm.LLMContext, api_id: str
-) -> list[llm.Tool]:
+) -> None:
     """Contribute no tools to another API's aggregated tool platform.
 
     Home Assistant 2026.8 and later lazily imports every integration's
     ``llm.py`` as a tool platform. Matic owns a dedicated API registered below,
-    so its tools must not also be merged into Assist or another API.
+    so its tools must not also be merged into Assist or another API. Returning
+    ``None`` is the platform contract for an API that contributes no tools;
+    returning an empty list is not a valid platform result.
     """
     del hass, llm_context, api_id
-    return []
+    return None
 
 
 @callback

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -43,7 +43,7 @@ from custom_components.matic_robot.plans import CleaningRoom
 
 def test_llm_platform_does_not_duplicate_the_dedicated_api() -> None:
     """Home Assistant 2026.8 can safely discover this module as a platform."""
-    assert async_get_tools(MagicMock(), MagicMock(), "assist") == []
+    assert async_get_tools(MagicMock(), MagicMock(), "assist") is None
 
 
 def _state(*, name: str = "Synthetic Robot", floor_plan: FloorPlan | None = None):


### PR DESCRIPTION
## Summary
- return the Home Assistant platform no-contribution value instead of an invalid empty list
- add a regression test for the 2026.8 platform loading path

## Validation
- pytest --cov=custom_components/matic_robot --cov-report=term-missing (1,111 passed, 100%)
- ruff check .
- ruff format --check .
- mypy custom_components/matic_robot
- python scripts/check_public_tree.py
- python -m build --sdist --wheel, release-artifact validation, and fresh-install validation

This is a prerelease-blocking compatibility fix. Live robot acceptance remains pending installation of the next RC.