### PR TITLE
Fix floor plan refresh after map transition

### DIFF
--- a/custom_components/matic_robot/__init__.py
+++ b/custom_components/matic_robot/__init__.py
@@ -61,6 +61,8 @@ _LOGGER = logging.getLogger(__name__)
 
 FLOOR_PLAN_TRANSITION_REFRESH_ATTEMPTS = 2
 FLOOR_PLAN_TRANSITION_REFRESH_RETRY_SECONDS = 2
+FLOOR_PLAN_TRANSITION_REFRESH_ROUNDS = 2
+FLOOR_PLAN_TRANSITION_REFRESH_BACKOFF_SECONDS = 5
 
 
 @dataclass(slots=True)
@@ -271,20 +273,27 @@ def _register_slam_map_floor_plan_sync(
     async def _async_refresh_floor_plan(identity: SlamMapIdentity) -> None:
         nonlocal refresh_in_progress
         try:
-            for attempt in range(FLOOR_PLAN_TRANSITION_REFRESH_ATTEMPTS):
-                await coordinator.async_request_floor_plan_refresh()
-                floor_plan = coordinator.data.floor_plan
-                if floor_plan is not None and slam_map.floor_plan_is_current(
-                    floor_plan
-                ):
-                    return
-                if slam_map.mission_identity != identity:
-                    # A newer verified mission arrived while the robot was
-                    # answering. The finally block schedules that mission's
-                    # own bounded recheck after this task releases its guard.
-                    return
-                if attempt + 1 < FLOOR_PLAN_TRANSITION_REFRESH_ATTEMPTS:
-                    await asyncio.sleep(FLOOR_PLAN_TRANSITION_REFRESH_RETRY_SECONDS)
+            for round_ in range(FLOOR_PLAN_TRANSITION_REFRESH_ROUNDS):
+                for attempt in range(FLOOR_PLAN_TRANSITION_REFRESH_ATTEMPTS):
+                    if slam_map.mission_identity != identity:
+                        # A newer verified mission arrived while the robot was
+                        # answering. The finally block schedules that mission's
+                        # own bounded recheck after this task releases its guard.
+                        return
+                    await coordinator.async_request_floor_plan_refresh()
+                    floor_plan = coordinator.data.floor_plan
+                    if floor_plan is not None and slam_map.floor_plan_is_current(
+                        floor_plan
+                    ):
+                        return
+                    if attempt + 1 < FLOOR_PLAN_TRANSITION_REFRESH_ATTEMPTS:
+                        await asyncio.sleep(FLOOR_PLAN_TRANSITION_REFRESH_RETRY_SECONDS)
+                # A floor-plan response can trail the verified SLAM mission.
+                # Retry it once after a short bounded backoff instead of
+                # leaving an otherwise-localized map stale for the normal
+                # fifteen-minute cache interval.
+                if round_ + 1 < FLOOR_PLAN_TRANSITION_REFRESH_ROUNDS:
+                    await asyncio.sleep(FLOOR_PLAN_TRANSITION_REFRESH_BACKOFF_SECONDS)
         finally:
             refresh_in_progress = False
             _async_sync_floor_plan()

--- a/custom_components/matic_robot/__init__.py
+++ b/custom_components/matic_robot/__init__.py
@@ -302,9 +302,9 @@ def _register_slam_map_floor_plan_sync(
         nonlocal refresh_in_progress, last_attempted_identity
         floor_plan = coordinator.data.floor_plan
         identity = slam_map.mission_identity
-        if floor_plan is None or identity is None:
+        if identity is None:
             return
-        if slam_map.floor_plan_is_current(floor_plan):
+        if floor_plan is not None and slam_map.floor_plan_is_current(floor_plan):
             last_attempted_identity = None
             return
         # A busy SLAM stream can publish many pages before the floor-plan

--- a/custom_components/matic_robot/__init__.py
+++ b/custom_components/matic_robot/__init__.py
@@ -53,11 +53,14 @@ from .slam_history import (
     SlamHistoryStore,
     async_collect_slam_history,
 )
-from .slam_map_store import SlamMapStore
+from .slam_map_store import SlamMapIdentity, SlamMapStore
 
 __all__ = ["async_migrate_entry"]
 
 _LOGGER = logging.getLogger(__name__)
+
+FLOOR_PLAN_TRANSITION_REFRESH_ATTEMPTS = 2
+FLOOR_PLAN_TRANSITION_REFRESH_RETRY_SECONDS = 2
 
 
 @dataclass(slots=True)
@@ -263,27 +266,45 @@ def _register_slam_map_floor_plan_sync(
     the next periodic map poll.
     """
     refresh_in_progress = False
+    last_attempted_identity: SlamMapIdentity | None = None
 
-    async def _async_refresh_floor_plan() -> None:
+    async def _async_refresh_floor_plan(identity: SlamMapIdentity) -> None:
         nonlocal refresh_in_progress
         try:
-            await coordinator.async_request_floor_plan_refresh()
+            for attempt in range(FLOOR_PLAN_TRANSITION_REFRESH_ATTEMPTS):
+                await coordinator.async_request_floor_plan_refresh()
+                floor_plan = coordinator.data.floor_plan
+                if floor_plan is not None and slam_map.floor_plan_is_current(
+                    floor_plan
+                ):
+                    return
+                if slam_map.mission_identity != identity:
+                    # A newer verified mission arrived while the robot was
+                    # answering. The finally block schedules that mission's
+                    # own bounded recheck after this task releases its guard.
+                    return
+                if attempt + 1 < FLOOR_PLAN_TRANSITION_REFRESH_ATTEMPTS:
+                    await asyncio.sleep(FLOOR_PLAN_TRANSITION_REFRESH_RETRY_SECONDS)
         finally:
             refresh_in_progress = False
+            _async_sync_floor_plan()
 
     def _async_sync_floor_plan() -> None:
-        nonlocal refresh_in_progress
+        nonlocal refresh_in_progress, last_attempted_identity
         floor_plan = coordinator.data.floor_plan
-        if (
-            refresh_in_progress
-            or floor_plan is None
-            or slam_map.floor_plan_is_current(floor_plan)
-        ):
+        identity = slam_map.mission_identity
+        if floor_plan is None or identity is None:
+            return
+        if slam_map.floor_plan_is_current(floor_plan):
+            last_attempted_identity = None
+            return
+        if refresh_in_progress or identity == last_attempted_identity:
             return
         refresh_in_progress = True
+        last_attempted_identity = identity
         entry.async_create_background_task(
             hass,
-            _async_refresh_floor_plan(),
+            _async_refresh_floor_plan(identity),
             f"{DOMAIN} current floor map refresh",
         )
 

--- a/custom_components/matic_robot/__init__.py
+++ b/custom_components/matic_robot/__init__.py
@@ -168,6 +168,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: MaticConfigEntry) -> boo
             plans,
             serial_number,
         )
+        _register_slam_map_floor_plan_sync(hass, entry, slam_map, coordinator)
         entry.async_create_background_task(
             hass,
             slam_map.async_collect(client),
@@ -245,6 +246,48 @@ async def async_setup_entry(hass: HomeAssistant, entry: MaticConfigEntry) -> boo
         client.close()
         raise
     return True
+
+
+def _register_slam_map_floor_plan_sync(
+    hass: HomeAssistant,
+    entry: MaticConfigEntry,
+    slam_map: SlamMapStore,
+    coordinator: MaticCoordinator,
+) -> None:
+    """Refresh a cached floor plan when both map layers prove a new mission.
+
+    The map store switches missions only after photographic and structural
+    evidence agree.  That is the safe point to bypass the normal slow
+    floor-plan cache: without it, a robot that has already localized on a
+    different mapped floor can remain falsely marked as transitioning until
+    the next periodic map poll.
+    """
+    refresh_in_progress = False
+
+    async def _async_refresh_floor_plan() -> None:
+        nonlocal refresh_in_progress
+        try:
+            await coordinator.async_request_floor_plan_refresh()
+        finally:
+            refresh_in_progress = False
+
+    def _async_sync_floor_plan() -> None:
+        nonlocal refresh_in_progress
+        floor_plan = coordinator.data.floor_plan
+        if (
+            refresh_in_progress
+            or floor_plan is None
+            or slam_map.floor_plan_is_current(floor_plan)
+        ):
+            return
+        refresh_in_progress = True
+        entry.async_create_background_task(
+            hass,
+            _async_refresh_floor_plan(),
+            f"{DOMAIN} current floor map refresh",
+        )
+
+    entry.async_on_unload(slam_map.async_add_listener(_async_sync_floor_plan))
 
 
 def _register_native_history_sync(

--- a/custom_components/matic_robot/__init__.py
+++ b/custom_components/matic_robot/__init__.py
@@ -302,7 +302,7 @@ def _register_slam_map_floor_plan_sync(
         nonlocal refresh_in_progress, last_attempted_identity
         floor_plan = coordinator.data.floor_plan
         identity = slam_map.mission_identity
-        if identity is None:
+        if identity is None or identity.mission_id is None:
             return
         if floor_plan is not None and slam_map.floor_plan_is_current(floor_plan):
             last_attempted_identity = None

--- a/custom_components/matic_robot/__init__.py
+++ b/custom_components/matic_robot/__init__.py
@@ -298,6 +298,9 @@ def _register_slam_map_floor_plan_sync(
         if slam_map.floor_plan_is_current(floor_plan):
             last_attempted_identity = None
             return
+        # A busy SLAM stream can publish many pages before the floor-plan
+        # endpoint catches up. Each verified mission gets one bounded refresh
+        # sequence, rather than one coordinator refresh per page.
         if refresh_in_progress or identity == last_attempted_identity:
             return
         refresh_in_progress = True
@@ -309,6 +312,7 @@ def _register_slam_map_floor_plan_sync(
         )
 
     entry.async_on_unload(slam_map.async_add_listener(_async_sync_floor_plan))
+    _async_sync_floor_plan()
 
 
 def _register_native_history_sync(

--- a/custom_components/matic_robot/coordinator.py
+++ b/custom_components/matic_robot/coordinator.py
@@ -419,6 +419,17 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
         self._force_full_refresh = True
         await self.async_request_refresh()
 
+    async def async_request_floor_plan_refresh(self) -> None:
+        """Refresh the active floor plan after a verified SLAM mission change.
+
+        A robot can localize onto another mapped floor between normal map
+        polling intervals.  Keep the other slow reads cached, but do not keep
+        a prior floor plan long enough to make a newly observed SLAM mission
+        look like an unresolved transition.
+        """
+        self._map_refresh_due = 0.0
+        await self.async_request_refresh()
+
     async def _async_capture_firmware_snapshot(
         self,
         tracker: FirmwareTracker,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -403,6 +403,27 @@ async def test_coordinator_caches_slow_reads_and_can_force_them(hass) -> None:
     assert client.async_get_telemetry.await_count == 2
 
 
+async def test_coordinator_refreshes_floor_plan_without_invalidating_telemetry(
+    hass,
+) -> None:
+    client = _client()
+    client.async_get_floor_plan.return_value = FloorPlan(1, "partition", b"", ())
+    coordinator = _coordinator(hass, client)
+
+    await coordinator._async_update_data()
+    await coordinator._async_update_data()
+    assert client.async_get_floor_plan.await_count == 1
+    assert client.async_get_telemetry.await_count == 1
+
+    coordinator.async_request_refresh = AsyncMock()
+    await coordinator.async_request_floor_plan_refresh()
+    coordinator.async_request_refresh.assert_awaited_once()
+    await coordinator._async_update_data()
+
+    assert client.async_get_floor_plan.await_count == 2
+    assert client.async_get_telemetry.await_count == 1
+
+
 async def test_slow_refresh_failure_retains_last_good_values(hass) -> None:
     client = _client()
     coordinator = _coordinator(hass, client)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -12,6 +12,8 @@ from homeassistant.components import frontend
 from homeassistant.exceptions import ConfigEntryAuthFailed
 
 from custom_components.matic_robot import (
+    FLOOR_PLAN_TRANSITION_REFRESH_BACKOFF_SECONDS,
+    FLOOR_PLAN_TRANSITION_REFRESH_RETRY_SECONDS,
     _async_resume_native_reconciliation,
     _floor_plan_supports_area_binding,
     _register_native_history_sync,
@@ -125,7 +127,7 @@ async def test_slam_map_mission_change_refreshes_the_cached_floor_plan(hass) -> 
         listener()
         assert len(scheduled) == 1
         await scheduled[0]
-        assert coordinator.async_request_floor_plan_refresh.await_count == 2
+        assert coordinator.async_request_floor_plan_refresh.await_count == 4
         entry.async_on_unload.assert_called_once_with(remove_listener)
 
     listener()
@@ -192,6 +194,50 @@ async def test_slam_map_transition_rechecks_a_newer_mission_after_refresh(hass) 
         await scheduled[1]
 
     assert coordinator.async_request_floor_plan_refresh.await_count == 2
+
+
+async def test_slam_map_transition_retries_a_delayed_floor_plan_once(hass) -> None:
+    entry = _entry()
+    remove_listener = MagicMock()
+    scheduled: list[object] = []
+    entry.async_create_background_task.side_effect = lambda _hass, target, _name: (
+        scheduled.append(target)
+    )
+    floor_plan = FloorPlan(42, "synthetic-partition", b"partition", ())
+    slam_map = SimpleNamespace(
+        floor_plan_is_current=MagicMock(return_value=False),
+        mission_identity=SlamMapIdentity("00" * 32, 43),
+    )
+
+    async def refresh_floor_plan() -> None:
+        if coordinator.async_request_floor_plan_refresh.await_count == 3:
+            slam_map.floor_plan_is_current.return_value = True
+
+    coordinator = SimpleNamespace(
+        data=SimpleNamespace(floor_plan=floor_plan),
+        async_request_floor_plan_refresh=AsyncMock(side_effect=refresh_floor_plan),
+    )
+    listener: object | None = None
+
+    def add_listener(candidate):
+        nonlocal listener
+        listener = candidate
+        return remove_listener
+
+    slam_map.async_add_listener = add_listener
+
+    with patch(
+        "custom_components.matic_robot.asyncio.sleep", new_callable=AsyncMock
+    ) as sleep:
+        _register_slam_map_floor_plan_sync(hass, entry, slam_map, coordinator)
+        assert callable(listener)
+        await scheduled[0]
+
+    assert coordinator.async_request_floor_plan_refresh.await_count == 3
+    assert sleep.await_args_list == [
+        ((FLOOR_PLAN_TRANSITION_REFRESH_RETRY_SECONDS,), {}),
+        ((FLOOR_PLAN_TRANSITION_REFRESH_BACKOFF_SECONDS,), {}),
+    ]
 
 
 async def test_native_reconciliation_recovery_is_lifecycle_bound() -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -120,6 +120,7 @@ async def test_slam_map_mission_change_refreshes_the_cached_floor_plan(hass) -> 
     with patch("custom_components.matic_robot.asyncio.sleep", new_callable=AsyncMock):
         _register_slam_map_floor_plan_sync(hass, entry, slam_map, coordinator)
         assert callable(listener)
+        assert len(scheduled) == 1
         listener()
         listener()
         assert len(scheduled) == 1
@@ -564,6 +565,7 @@ async def test_setup_refreshes_before_forwarding_platforms(
         async_shutdown=AsyncMock(),
         async_add_listener=MagicMock(return_value=map_unsubscribe),
         floor_plan_is_current=MagicMock(return_value=True),
+        mission_identity=None,
     )
     slam_history = SimpleNamespace(
         async_load=AsyncMock(),

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -45,6 +45,7 @@ from custom_components.matic_robot.plans import (
     AreaBindingUpgradeResult,
     CleaningPlanManager,
 )
+from custom_components.matic_robot.slam_map_store import SlamMapIdentity
 
 
 def _entry() -> SimpleNamespace:
@@ -113,20 +114,83 @@ async def test_slam_map_mission_change_refreshes_the_cached_floor_plan(hass) -> 
     slam_map = SimpleNamespace(
         floor_plan_is_current=MagicMock(return_value=False),
         async_add_listener=add_listener,
+        mission_identity=SlamMapIdentity("00" * 32, 43),
     )
 
-    _register_slam_map_floor_plan_sync(hass, entry, slam_map, coordinator)
-    assert callable(listener)
-    listener()
+    with patch("custom_components.matic_robot.asyncio.sleep", new_callable=AsyncMock):
+        _register_slam_map_floor_plan_sync(hass, entry, slam_map, coordinator)
+        assert callable(listener)
+        listener()
+        listener()
+        assert len(scheduled) == 1
+        await scheduled[0]
+        assert coordinator.async_request_floor_plan_refresh.await_count == 2
+        entry.async_on_unload.assert_called_once_with(remove_listener)
+
     listener()
     assert len(scheduled) == 1
-    await scheduled[0]
-    coordinator.async_request_floor_plan_refresh.assert_awaited_once()
-    entry.async_on_unload.assert_called_once_with(remove_listener)
-
     slam_map.floor_plan_is_current.return_value = True
     listener()
     assert len(scheduled) == 1
+
+    slam_map.floor_plan_is_current.return_value = False
+    slam_map.mission_identity = None
+    listener()
+    assert len(scheduled) == 1
+
+
+async def test_slam_map_transition_rechecks_a_newer_mission_after_refresh(hass) -> None:
+    entry = _entry()
+    remove_listener = MagicMock()
+    scheduled: list[object] = []
+    entry.async_create_background_task.side_effect = lambda _hass, target, _name: (
+        scheduled.append(target)
+    )
+    first_request_started = asyncio.Event()
+    release_first_request = asyncio.Event()
+
+    async def refresh_floor_plan() -> None:
+        if not first_request_started.is_set():
+            first_request_started.set()
+            await release_first_request.wait()
+
+    first_identity = SlamMapIdentity("00" * 32, 43)
+    second_identity = SlamMapIdentity("11" * 32, 44)
+    coordinator = SimpleNamespace(
+        data=SimpleNamespace(
+            floor_plan=FloorPlan(42, "synthetic-partition", b"partition", ())
+        ),
+        async_request_floor_plan_refresh=AsyncMock(side_effect=refresh_floor_plan),
+    )
+    listener: object | None = None
+
+    def add_listener(candidate):
+        nonlocal listener
+        listener = candidate
+        return remove_listener
+
+    slam_map = SimpleNamespace(
+        floor_plan_is_current=MagicMock(return_value=False),
+        async_add_listener=add_listener,
+        mission_identity=first_identity,
+    )
+
+    with patch("custom_components.matic_robot.asyncio.sleep", new_callable=AsyncMock):
+        _register_slam_map_floor_plan_sync(hass, entry, slam_map, coordinator)
+        assert callable(listener)
+        listener()
+        first_task = asyncio.create_task(scheduled[0])
+        await first_request_started.wait()
+        slam_map.mission_identity = second_identity
+        listener()
+        release_first_request.set()
+        await first_task
+        assert len(scheduled) == 2
+
+        slam_map.floor_plan_is_current.return_value = True
+        await scheduled[1]
+
+    assert coordinator.async_request_floor_plan_refresh.await_count == 2
 
 
 async def test_native_reconciliation_recovery_is_lifecycle_bound() -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -15,6 +15,7 @@ from custom_components.matic_robot import (
     _async_resume_native_reconciliation,
     _floor_plan_supports_area_binding,
     _register_native_history_sync,
+    _register_slam_map_floor_plan_sync,
     _schedule_native_reconciliation_recovery,
     async_remove_entry,
     async_setup,
@@ -88,6 +89,44 @@ def test_floor_plan_area_binding_support_requires_usable_geometry() -> None:
             ),
         )
     )
+
+
+async def test_slam_map_mission_change_refreshes_the_cached_floor_plan(hass) -> None:
+    entry = _entry()
+    remove_listener = MagicMock()
+    scheduled: list[object] = []
+    entry.async_create_background_task.side_effect = lambda _hass, target, _name: (
+        scheduled.append(target)
+    )
+    floor_plan = FloorPlan(42, "synthetic-partition", b"partition", ())
+    coordinator = SimpleNamespace(
+        data=SimpleNamespace(floor_plan=floor_plan),
+        async_request_floor_plan_refresh=AsyncMock(),
+    )
+    listener: object | None = None
+
+    def add_listener(candidate):
+        nonlocal listener
+        listener = candidate
+        return remove_listener
+
+    slam_map = SimpleNamespace(
+        floor_plan_is_current=MagicMock(return_value=False),
+        async_add_listener=add_listener,
+    )
+
+    _register_slam_map_floor_plan_sync(hass, entry, slam_map, coordinator)
+    assert callable(listener)
+    listener()
+    listener()
+    assert len(scheduled) == 1
+    await scheduled[0]
+    coordinator.async_request_floor_plan_refresh.assert_awaited_once()
+    entry.async_on_unload.assert_called_once_with(remove_listener)
+
+    slam_map.floor_plan_is_current.return_value = True
+    listener()
+    assert len(scheduled) == 1
 
 
 async def test_native_reconciliation_recovery_is_lifecycle_bound() -> None:
@@ -454,10 +493,13 @@ async def test_setup_refreshes_before_forwarding_platforms(
             target.close()
 
     entry.async_create_background_task.side_effect = capture_setup_tasks
+    map_unsubscribe = MagicMock()
     slam_map = SimpleNamespace(
         async_load=AsyncMock(),
         async_collect=MagicMock(),
         async_shutdown=AsyncMock(),
+        async_add_listener=MagicMock(return_value=map_unsubscribe),
+        floor_plan_is_current=MagicMock(return_value=True),
     )
     slam_history = SimpleNamespace(
         async_load=AsyncMock(),
@@ -517,6 +559,7 @@ async def test_setup_refreshes_before_forwarding_platforms(
     assert entry.runtime_data.slam_map is slam_map
     assert entry.runtime_data.slam_history is slam_history
     slam_map.async_load.assert_awaited_once()
+    slam_map.async_add_listener.assert_called_once()
     slam_history.async_load.assert_awaited_once()
     slam_map.async_collect.assert_called_once_with(client)
     collect_history.assert_called_once()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -240,6 +240,45 @@ async def test_slam_map_transition_retries_a_delayed_floor_plan_once(hass) -> No
     ]
 
 
+async def test_slam_map_transition_refreshes_a_missing_cached_floor_plan(hass) -> None:
+    entry = _entry()
+    remove_listener = MagicMock()
+    scheduled: list[object] = []
+    entry.async_create_background_task.side_effect = lambda _hass, target, _name: (
+        scheduled.append(target)
+    )
+    floor_plan = FloorPlan(42, "synthetic-partition", b"partition", ())
+    coordinator = SimpleNamespace(
+        data=SimpleNamespace(floor_plan=None),
+        async_request_floor_plan_refresh=AsyncMock(),
+    )
+    listener: object | None = None
+
+    def add_listener(candidate):
+        nonlocal listener
+        listener = candidate
+        return remove_listener
+
+    slam_map = SimpleNamespace(
+        floor_plan_is_current=MagicMock(return_value=True),
+        async_add_listener=add_listener,
+        mission_identity=SlamMapIdentity("00" * 32, 43),
+    )
+
+    async def refresh_floor_plan() -> None:
+        coordinator.data.floor_plan = floor_plan
+
+    coordinator.async_request_floor_plan_refresh.side_effect = refresh_floor_plan
+
+    _register_slam_map_floor_plan_sync(hass, entry, slam_map, coordinator)
+    assert callable(listener)
+    assert len(scheduled) == 1
+    await scheduled[0]
+
+    coordinator.async_request_floor_plan_refresh.assert_awaited_once()
+    slam_map.floor_plan_is_current.assert_called_with(floor_plan)
+
+
 async def test_native_reconciliation_recovery_is_lifecycle_bound() -> None:
     pending = {
         "plan_id": "away",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -279,6 +279,32 @@ async def test_slam_map_transition_refreshes_a_missing_cached_floor_plan(hass) -
     slam_map.floor_plan_is_current.assert_called_with(floor_plan)
 
 
+async def test_slam_map_transition_ignores_an_opaque_mission_identity(hass) -> None:
+    entry = _entry()
+    remove_listener = MagicMock()
+    scheduled: list[object] = []
+    entry.async_create_background_task.side_effect = lambda _hass, target, _name: (
+        scheduled.append(target)
+    )
+    floor_plan = FloorPlan(42, "synthetic-partition", b"partition", ())
+    coordinator = SimpleNamespace(
+        data=SimpleNamespace(floor_plan=floor_plan),
+        async_request_floor_plan_refresh=AsyncMock(),
+    )
+
+    slam_map = SimpleNamespace(
+        floor_plan_is_current=MagicMock(return_value=False),
+        async_add_listener=lambda _candidate: remove_listener,
+        mission_identity=SlamMapIdentity("00" * 32, None),
+    )
+
+    _register_slam_map_floor_plan_sync(hass, entry, slam_map, coordinator)
+
+    assert not scheduled
+    coordinator.async_request_floor_plan_refresh.assert_not_awaited()
+    slam_map.floor_plan_is_current.assert_not_called()
+
+
 async def test_native_reconciliation_recovery_is_lifecycle_bound() -> None:
     pending = {
         "plan_id": "away",


### PR DESCRIPTION
## Summary
- refresh the cached active floor plan when both local SLAM layers confirm a new mission
- preserve slow telemetry caching and fail-closed floor coherence
- cover the mission-change refresh path and integration lifecycle

## Validation
- targeted map, scene, entity, vacuum, coordinator, and setup tests
- Ruff, mypy, and public-tree privacy check