### PR TITLE
Fix stale map after restart

### DIFF
--- a/custom_components/matic_robot/__init__.py
+++ b/custom_components/matic_robot/__init__.py
@@ -304,6 +304,12 @@ def _register_slam_map_floor_plan_sync(
         identity = slam_map.mission_identity
         if identity is None or identity.mission_id is None:
             return
+        # A retained map is intentionally incoherent after a restart until
+        # both collection streams have supplied new pages. It is not a floor
+        # transition, so do not spend the bounded refresh budget or mark this
+        # identity attempted before live collection makes it actionable.
+        if not getattr(slam_map, "live_session_verified", True):
+            return
         if floor_plan is not None and slam_map.floor_plan_is_current(floor_plan):
             last_attempted_identity = None
             return

--- a/custom_components/matic_robot/__init__.py
+++ b/custom_components/matic_robot/__init__.py
@@ -271,16 +271,25 @@ def _register_slam_map_floor_plan_sync(
     last_attempted_identity: SlamMapIdentity | None = None
 
     async def _async_refresh_floor_plan(identity: SlamMapIdentity) -> None:
-        nonlocal refresh_in_progress
+        nonlocal refresh_in_progress, last_attempted_identity
         try:
             for round_ in range(FLOOR_PLAN_TRANSITION_REFRESH_ROUNDS):
                 for attempt in range(FLOOR_PLAN_TRANSITION_REFRESH_ATTEMPTS):
-                    if slam_map.mission_identity != identity:
+                    if slam_map.mission_identity != identity or not getattr(
+                        slam_map, "live_session_verified", True
+                    ):
                         # A newer verified mission arrived while the robot was
-                        # answering. The finally block schedules that mission's
-                        # own bounded recheck after this task releases its guard.
+                        # answering, or this mission lost its live proof. The
+                        # finally block schedules a fresh bounded recheck after
+                        # this task releases its guard.
+                        last_attempted_identity = None
                         return
                     await coordinator.async_request_floor_plan_refresh()
+                    if slam_map.mission_identity != identity or not getattr(
+                        slam_map, "live_session_verified", True
+                    ):
+                        last_attempted_identity = None
+                        return
                     floor_plan = coordinator.data.floor_plan
                     if floor_plan is not None and slam_map.floor_plan_is_current(
                         floor_plan
@@ -309,6 +318,7 @@ def _register_slam_map_floor_plan_sync(
         # transition, so do not spend the bounded refresh budget or mark this
         # identity attempted before live collection makes it actionable.
         if not getattr(slam_map, "live_session_verified", True):
+            last_attempted_identity = None
             return
         if floor_plan is not None and slam_map.floor_plan_is_current(floor_plan):
             last_attempted_identity = None

--- a/custom_components/matic_robot/camera.py
+++ b/custom_components/matic_robot/camera.py
@@ -38,6 +38,12 @@ def _floor_render_identity(store: SlamMapStore, data: RobotState) -> tuple[objec
     )
 
 
+def _map_session_verified(store: SlamMapStore, floor_plan_coherent: bool) -> bool:
+    """Return this process's live-map proof with a test-double fallback."""
+    verified = getattr(store, "live_session_verified", None)
+    return verified if isinstance(verified, bool) else floor_plan_coherent
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: MaticConfigEntry,
@@ -59,8 +65,12 @@ class MaticMapCamera(MaticEntity, Camera):
         MaticEntity.__init__(self, entry)
         self._attr_unique_id = f"{self.coordinator.data.info.serial_number}_map"
         self._store = entry.runtime_data.slam_map
-        self._published_floor_coherent = self._store.floor_plan_is_current(
+        floor_plan_coherent = self._store.floor_plan_is_current(
             self.coordinator.data.floor_plan
+        )
+        self._published_floor_coherent = floor_plan_coherent
+        self._published_session_verified = _map_session_verified(
+            self._store, floor_plan_coherent
         )
         self._cached_image_key: tuple[object, ...] | None = None
         self._cached_image: bytes | None = None
@@ -75,8 +85,12 @@ class MaticMapCamera(MaticEntity, Camera):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Publish coordinator state and remember its coherence classification."""
-        self._published_floor_coherent = self._store.floor_plan_is_current(
+        floor_plan_coherent = self._store.floor_plan_is_current(
             self.coordinator.data.floor_plan
+        )
+        self._published_floor_coherent = floor_plan_coherent
+        self._published_session_verified = _map_session_verified(
+            self._store, floor_plan_coherent
         )
         super()._handle_coordinator_update()
 
@@ -86,9 +100,14 @@ class MaticMapCamera(MaticEntity, Camera):
         floor_plan_coherent = self._store.floor_plan_is_current(
             self.coordinator.data.floor_plan
         )
-        if floor_plan_coherent == self._published_floor_coherent:
+        session_verified = _map_session_verified(self._store, floor_plan_coherent)
+        if (
+            floor_plan_coherent == self._published_floor_coherent
+            and session_verified == self._published_session_verified
+        ):
             return
         self._published_floor_coherent = floor_plan_coherent
+        self._published_session_verified = session_verified
         self.async_write_ha_state()
 
     async def async_camera_image(
@@ -147,8 +166,8 @@ class MaticMapCamera(MaticEntity, Camera):
         return {
             "matic_entry_id": self._config_entry.entry_id,
             "map_floor_coherent": floor_plan_coherent,
-            "map_session_verified": getattr(
-                self._store, "live_session_verified", floor_plan_coherent
+            "map_session_verified": _map_session_verified(
+                self._store, floor_plan_coherent
             ),
             "robot_location_source": robot_location_source(
                 data.floor_plan if floor_plan_coherent else None,
@@ -177,8 +196,12 @@ class MaticPhotorealisticMapCamera(MaticEntity, Camera):
             f"{self.coordinator.data.info.serial_number}_photorealistic_map"
         )
         self._store = entry.runtime_data.slam_map
-        self._published_floor_coherent = self._store.floor_plan_is_current(
+        floor_plan_coherent = self._store.floor_plan_is_current(
             self.coordinator.data.floor_plan
+        )
+        self._published_floor_coherent = floor_plan_coherent
+        self._published_session_verified = _map_session_verified(
+            self._store, floor_plan_coherent
         )
         self._cached_key: tuple[object, ...] | None = None
         self._cached_image: bytes | None = None
@@ -194,8 +217,12 @@ class MaticPhotorealisticMapCamera(MaticEntity, Camera):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Publish coordinator state and remember its coherence classification."""
-        self._published_floor_coherent = self._store.floor_plan_is_current(
+        floor_plan_coherent = self._store.floor_plan_is_current(
             self.coordinator.data.floor_plan
+        )
+        self._published_floor_coherent = floor_plan_coherent
+        self._published_session_verified = _map_session_verified(
+            self._store, floor_plan_coherent
         )
         super()._handle_coordinator_update()
 
@@ -205,9 +232,14 @@ class MaticPhotorealisticMapCamera(MaticEntity, Camera):
         floor_plan_coherent = self._store.floor_plan_is_current(
             self.coordinator.data.floor_plan
         )
-        if floor_plan_coherent == self._published_floor_coherent:
+        session_verified = _map_session_verified(self._store, floor_plan_coherent)
+        if (
+            floor_plan_coherent == self._published_floor_coherent
+            and session_verified == self._published_session_verified
+        ):
             return
         self._published_floor_coherent = floor_plan_coherent
+        self._published_session_verified = session_verified
         self._cached_key = None
         self._cached_image = None
         self.async_write_ha_state()
@@ -316,8 +348,8 @@ class MaticPhotorealisticMapCamera(MaticEntity, Camera):
             "map_complete": self._store.map_complete,
             "map_revision": self._store.revision,
             "map_floor_coherent": floor_plan_coherent,
-            "map_session_verified": getattr(
-                self._store, "live_session_verified", floor_plan_coherent
+            "map_session_verified": _map_session_verified(
+                self._store, floor_plan_coherent
             ),
             "robot_location_source": robot_location_source(
                 data.floor_plan if floor_plan_coherent else None,

--- a/custom_components/matic_robot/camera.py
+++ b/custom_components/matic_robot/camera.py
@@ -147,6 +147,9 @@ class MaticMapCamera(MaticEntity, Camera):
         return {
             "matic_entry_id": self._config_entry.entry_id,
             "map_floor_coherent": floor_plan_coherent,
+            "map_session_verified": getattr(
+                self._store, "live_session_verified", floor_plan_coherent
+            ),
             "robot_location_source": robot_location_source(
                 data.floor_plan if floor_plan_coherent else None,
                 data.pose,
@@ -217,7 +220,20 @@ class MaticPhotorealisticMapCamera(MaticEntity, Camera):
         requested_height = min(max(height or 1024, 256), MAX_CAMERA_DIMENSION)
         data = self.coordinator.data
         floor_plan_coherent = self._store.floor_plan_is_current(data.floor_plan)
-        key = (
+        if not floor_plan_coherent:
+            self._cached_key = None
+            self._cached_image = None
+            return await self.hass.async_add_executor_job(
+                partial(
+                    render_floor_plan,
+                    None,
+                    None,
+                    None,
+                    width=requested_width,
+                    height=requested_height,
+                )
+            )
+        key: tuple[object, ...] = (
             self._store.revision,
             id(data.floor_plan),
             floor_plan_coherent,
@@ -287,6 +303,9 @@ class MaticPhotorealisticMapCamera(MaticEntity, Camera):
             "map_complete": self._store.map_complete,
             "map_revision": self._store.revision,
             "map_floor_coherent": floor_plan_coherent,
+            "map_session_verified": getattr(
+                self._store, "live_session_verified", floor_plan_coherent
+            ),
             "robot_location_source": robot_location_source(
                 data.floor_plan if floor_plan_coherent else None,
                 data.pose,

--- a/custom_components/matic_robot/camera.py
+++ b/custom_components/matic_robot/camera.py
@@ -247,6 +247,19 @@ class MaticPhotorealisticMapCamera(MaticEntity, Camera):
         async with self._render_lock:
             data = self.coordinator.data
             floor_plan_coherent = self._store.floor_plan_is_current(data.floor_plan)
+            if not floor_plan_coherent:
+                self._cached_key = None
+                self._cached_image = None
+                return await self.hass.async_add_executor_job(
+                    partial(
+                        render_floor_plan,
+                        None,
+                        None,
+                        None,
+                        width=requested_width,
+                        height=requested_height,
+                    )
+                )
             render_floor_identity = _floor_render_identity(self._store, data)
             key = (
                 self._store.revision,

--- a/custom_components/matic_robot/matic_map_studio.js
+++ b/custom_components/matic_robot/matic_map_studio.js
@@ -2391,10 +2391,15 @@ class MaticMapStudio extends HTMLElement {
     if (canvas) canvas.hidden = true;
     if (overlays) overlays.hidden = true;
     if (image) image.hidden = true;
-    const message = this._localize(
-      "map_status_floor_transition",
-      "Floor transition detected · map paused until localization completes",
-    );
+    const message = state?.attributes?.map_session_verified === false
+      ? this._localize(
+        "map_status_session_revalidation",
+        "Checking the current map after restart · map paused until localization completes",
+      )
+      : this._localize(
+        "map_status_floor_transition",
+        "Floor transition detected · map paused until localization completes",
+      );
     this._setEmpty(message);
     this._setStatus(message, "warning");
     this._updateHealth(state);

--- a/custom_components/matic_robot/slam_history.py
+++ b/custom_components/matic_robot/slam_history.py
@@ -230,6 +230,9 @@ async def async_collect_slam_history(
             identity = slam_map.mission_identity
             entries = slam_map.entries()
             current_floor_plan = floor_plan()
+            # ``map_complete`` is false until both live collections have
+            # revalidated a persisted map for this process. Once complete,
+            # retain only a mission-correlated snapshot.
             if not _mission_matches_floor_plan(identity, current_floor_plan):
                 continue
             try:

--- a/custom_components/matic_robot/slam_map_store.py
+++ b/custom_components/matic_robot/slam_map_store.py
@@ -126,6 +126,12 @@ class SlamMapStore:
         self._revision = 0
         self._last_change = 0.0
         self._map_complete = False
+        # A restored private cache is useful as a bounded local checkpoint, but
+        # it is not proof that it describes the robot's location *after this
+        # integration session starts*.  Both live map collections must confirm
+        # the active mission before anything treats the cached scene as live.
+        self._live_photo_seen = False
+        self._live_structure_seen = False
         self._truncated = False
         self._dropped_photo_tiles = 0
         self._dropped_structure_tiles = 0
@@ -162,6 +168,8 @@ class SlamMapStore:
         self._revision = len(self._entries) + len(self._structure_entries)
         self._last_change = 0.0
         self._map_complete = not self._truncated and self._has_balanced_layers()
+        self._live_photo_seen = False
+        self._live_structure_seen = False
         if loaded.dirty:
             self._schedule_save()
         self._notify_listeners()
@@ -210,7 +218,8 @@ class SlamMapStore:
         key = _tile_key(tile)
         changed = target.get(key) != entry
         target[key] = entry
-        if not changed and not identity_changed:
+        live_session_confirmed = self._observe_live_layer(structural=structural)
+        if not changed and not identity_changed and not live_session_confirmed:
             return
         self._content_changed()
 
@@ -225,6 +234,11 @@ class SlamMapStore:
         mission_token = tile.mission_token
         if mission_token in self._retired_missions:
             return
+        # One live page from a new mission is enough to prove that the old
+        # mission may no longer be current.  Do not keep labelling it as the
+        # robot's live location while we wait for the independent layer needed
+        # to promote the replacement map.
+        self._invalidate_live_session()
         candidate = self._candidates.get(mission_token)
         if candidate is None:
             if len(self._candidates) >= MAX_CANDIDATE_MISSIONS:
@@ -270,6 +284,9 @@ class SlamMapStore:
         self._dropped_structure_tiles = candidate.dropped_structure_tiles
         self._invalid_tiles = 0
         self._candidates.pop(mission_token, None)
+        # Promotion itself requires live photographic and structural evidence.
+        self._live_photo_seen = True
+        self._live_structure_seen = True
         self._content_changed()
 
     def _retire_mission(self, mission_token: str) -> None:
@@ -300,6 +317,23 @@ class SlamMapStore:
         self._map_complete = False
         self._schedule_save()
         self._notify_listeners()
+
+    def _observe_live_layer(self, *, structural: bool) -> bool:
+        """Record one fresh collection layer and report first live proof."""
+        was_confirmed = self._live_photo_seen and self._live_structure_seen
+        if structural:
+            self._live_structure_seen = True
+        else:
+            self._live_photo_seen = True
+        return not was_confirmed and self._live_photo_seen and self._live_structure_seen
+
+    def _invalidate_live_session(self) -> None:
+        """Fail closed while a newly observed map mission is classified."""
+        if not (self._live_photo_seen or self._live_structure_seen):
+            return
+        self._live_photo_seen = False
+        self._live_structure_seen = False
+        self._content_changed()
 
     async def async_collect(self, client: MaticHermesClient) -> None:
         """Continuously collect photographic and structural map pages."""
@@ -392,7 +426,16 @@ class SlamMapStore:
     def floor_plan_is_current(self, floor_plan: FloorPlan | None) -> bool:
         """Return whether the active SLAM map and floor plan are correlated."""
         identity = self.mission_identity
-        return identity is not None and identity.matches_floor_plan(floor_plan)
+        return bool(
+            self.live_session_verified
+            and identity is not None
+            and identity.matches_floor_plan(floor_plan)
+        )
+
+    @property
+    def live_session_verified(self) -> bool:
+        """Return whether both live map collections confirmed this session."""
+        return self._live_photo_seen and self._live_structure_seen
 
     @property
     def structure_tile_count(self) -> int:
@@ -402,6 +445,8 @@ class SlamMapStore:
     @property
     def map_complete(self) -> bool:
         """Return whether both untruncated layers settled for the current mission."""
+        if not self.live_session_verified:
+            return False
         if self._truncated:
             return False
         if self._map_complete:
@@ -467,6 +512,8 @@ class SlamMapStore:
         self._candidates.clear()
         self._retired_missions.clear()
         self._candidate_generation = 0
+        self._live_photo_seen = False
+        self._live_structure_seen = False
         self._mission_token = None
         self._mission_id = None
         self._revision += 1

--- a/custom_components/matic_robot/slam_map_store.py
+++ b/custom_components/matic_robot/slam_map_store.py
@@ -218,7 +218,15 @@ class SlamMapStore:
         key = _tile_key(tile)
         changed = target.get(key) != entry
         target[key] = entry
-        live_session_confirmed = self._observe_live_layer(structural=structural)
+        # Once a different mission has been observed, delayed pages from the
+        # active token are evidence only for the cached map.  They cannot
+        # re-establish that it still represents the robot while a replacement
+        # mission is awaiting its independent layer.
+        if self._candidates:
+            self._invalidate_live_session()
+            live_session_confirmed = False
+        else:
+            live_session_confirmed = self._observe_live_layer(structural=structural)
         if not changed and not identity_changed and not live_session_confirmed:
             return
         self._content_changed()
@@ -262,7 +270,14 @@ class SlamMapStore:
         target = candidate.structure_entries if structural else candidate.entries
         target[_tile_key(tile)] = entry
         self._enforce_candidate_bounds(candidate)
-        if candidate.entries and candidate.structure_entries:
+        # A newer observed mission is authoritative until it is classified.
+        # Do not promote an older candidate merely because its delayed layer
+        # happened to arrive first.
+        if (
+            candidate.entries
+            and candidate.structure_entries
+            and candidate.generation == self._candidate_generation
+        ):
             self._promote_candidate(mission_token, candidate)
 
     def _promote_candidate(

--- a/custom_components/matic_robot/slam_map_store.py
+++ b/custom_components/matic_robot/slam_map_store.py
@@ -6,13 +6,16 @@ import asyncio
 import base64
 from collections import OrderedDict, defaultdict, deque
 from collections.abc import Callable, Mapping, Sequence
+from contextlib import suppress
 from dataclasses import dataclass
+from datetime import datetime
 from functools import partial
 from time import monotonic
 from typing import Any, Literal
 
 from google.protobuf.message import DecodeError
-from homeassistant.core import HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HassJob, HomeAssistant, callback
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.storage import Store
 
 from .client.api import MaticHermesClient
@@ -41,7 +44,7 @@ MAX_CANDIDATE_TILES_PER_LAYER = 128
 MAX_CANDIDATE_BYTES = 2 * 1024 * 1024
 MAX_RETIRED_MISSIONS = 8
 # A candidate needs pages from both independent subscriptions.  Allow three
-# normal retry intervals for those streams to converge, then discard a
+# normal retry intervals for those streams to converge, then classify a
 # one-sided candidate so it cannot hold the active map unavailable forever.
 CANDIDATE_CLASSIFICATION_SECONDS = STREAM_RETRY_SECONDS * 3
 
@@ -151,10 +154,14 @@ class SlamMapStore:
         self._candidates: OrderedDict[str, _MissionCandidate] = OrderedDict()
         self._retired_missions: deque[str] = deque(maxlen=MAX_RETIRED_MISSIONS)
         self._candidate_generation = 0
+        self._candidate_expiry_cancel: CALLBACK_TYPE | None = None
+        self._candidate_refresh_task: asyncio.Task[None] | None = None
+        self._collection_client: MaticHermesClient | None = None
         self._closed = False
 
     async def async_load(self) -> None:
         """Load and validate the robot-local tile cache."""
+        self._cancel_candidate_expiry()
         stored = await self._store.async_load() or {}
         loaded = await self._hass.async_add_executor_job(
             _decode_stored_snapshot, stored
@@ -293,8 +300,9 @@ class SlamMapStore:
             and self._candidate_can_promote(candidate)
         ):
             self._promote_candidate(mission_token, candidate)
+        self._schedule_candidate_expiry()
 
-    def _expire_incomplete_candidates(self) -> None:
+    def _expire_incomplete_candidates(self) -> bool:
         """Relax one-sided candidates after bounded classification.
 
         An alternative token invalidates the active map immediately, but a
@@ -311,6 +319,8 @@ class SlamMapStore:
                 relaxed = True
         if relaxed:
             self._promote_latest_complete_candidate()
+        self._schedule_candidate_expiry()
+        return relaxed
 
     def _has_blocking_candidate(self) -> bool:
         """Return whether an unclassified candidate still blocks active proof."""
@@ -336,6 +346,86 @@ class SlamMapStore:
                     best = mission_token, candidate
         if best is not None:
             self._promote_candidate(*best)
+
+    def _schedule_candidate_expiry(self) -> None:
+        """Schedule classification even while both map streams stay quiet."""
+        self._cancel_candidate_expiry()
+        if self._closed:
+            return
+        deadlines = [
+            candidate.first_seen_at + CANDIDATE_CLASSIFICATION_SECONDS
+            for candidate in self._candidates.values()
+            if candidate.blocks_active
+        ]
+        if not deadlines:
+            return
+        delay = max(0.0, min(deadlines) - monotonic())
+        self._candidate_expiry_cancel = async_call_later(
+            self._hass,
+            delay,
+            HassJob(
+                self._async_handle_candidate_expiry,
+                "matic_robot_map_candidate_expiry",
+                cancel_on_shutdown=True,
+            ),
+        )
+
+    def _cancel_candidate_expiry(self) -> None:
+        """Cancel the pending candidate-classification callback, if any."""
+        if self._candidate_expiry_cancel is not None:
+            self._candidate_expiry_cancel()
+            self._candidate_expiry_cancel = None
+
+    @callback
+    def _async_handle_candidate_expiry(self, _now: datetime) -> None:
+        """Classify a silent candidate and take fresh bounded map snapshots."""
+        self._candidate_expiry_cancel = None
+        if self._closed:
+            return
+        relaxed = self._expire_incomplete_candidates()
+        if relaxed and not self._has_blocking_candidate():
+            self._schedule_candidate_refresh()
+
+    def _schedule_candidate_refresh(self) -> None:
+        """Request fresh independent proof after a candidate expires."""
+        client = self._collection_client
+        task = self._candidate_refresh_task
+        if self._closed or client is None or (task is not None and not task.done()):
+            return
+        self._candidate_refresh_task = self._hass.async_create_task(
+            self._async_refresh_after_candidate_expiry(client),
+            "matic_robot_map_candidate_refresh",
+        )
+
+    async def _async_refresh_after_candidate_expiry(
+        self, client: MaticHermesClient
+    ) -> None:
+        """Read one page from each map collection without trusting cache state."""
+        try:
+            photo_entries, structure_entries = await asyncio.gather(
+                client.async_get_collection_entries("map_compressed_rgb", limit=1),
+                client.async_get_collection_entries("map_integrated", limit=1),
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            return
+        if self._closed:
+            return
+        for entry in photo_entries:
+            await self.async_add(entry)
+        for entry in structure_entries:
+            await self.async_add_structure(entry)
+
+    async def _async_cancel_candidate_refresh(self) -> None:
+        """Stop an in-flight bounded map refresh during entry teardown."""
+        task = self._candidate_refresh_task
+        self._candidate_refresh_task = None
+        if task is None or task.done():
+            return
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
 
     def _promote_candidate(
         self, mission_token: str, candidate: _MissionCandidate
@@ -409,10 +499,15 @@ class SlamMapStore:
 
     async def async_collect(self, client: MaticHermesClient) -> None:
         """Continuously collect photographic and structural map pages."""
-        await asyncio.gather(
-            self._async_collect_collection(client, "map_compressed_rgb", False),
-            self._async_collect_collection(client, "map_integrated", True),
-        )
+        self._collection_client = client
+        try:
+            await asyncio.gather(
+                self._async_collect_collection(client, "map_compressed_rgb", False),
+                self._async_collect_collection(client, "map_integrated", True),
+            )
+        finally:
+            if self._collection_client is client:
+                self._collection_client = None
 
     async def _async_collect_collection(
         self, client: MaticHermesClient, name: str, structural: bool
@@ -579,6 +674,9 @@ class SlamMapStore:
     async def async_remove(self) -> None:
         """Erase the private map cache when the robot entry is removed."""
         self._closed = True
+        self._cancel_candidate_expiry()
+        await self._async_cancel_candidate_refresh()
+        self._collection_client = None
         self._entries.clear()
         self._structure_entries.clear()
         self._candidates.clear()
@@ -603,6 +701,9 @@ class SlamMapStore:
         if self._closed:
             return
         self._closed = True
+        self._cancel_candidate_expiry()
+        await self._async_cancel_candidate_refresh()
+        self._collection_client = None
         data = await self._hass.async_add_executor_job(
             _serialize_snapshot,
             tuple(self._entries.values()),

--- a/custom_components/matic_robot/slam_map_store.py
+++ b/custom_components/matic_robot/slam_map_store.py
@@ -92,6 +92,7 @@ class _MissionCandidate:
     entries: dict[str, HermesCollectionEntry]
     structure_entries: dict[str, HermesCollectionEntry]
     mission_id: int | None
+    blocks_active: bool = True
     truncated: bool = False
     dropped_photo_tiles: int = 0
     dropped_structure_tiles: int = 0
@@ -228,7 +229,7 @@ class SlamMapStore:
         # active token are evidence only for the cached map.  They cannot
         # re-establish that it still represents the robot while a replacement
         # mission is awaiting its independent layer.
-        if self._candidates:
+        if self._has_blocking_candidate():
             self._invalidate_live_session()
             live_session_confirmed = False
         else:
@@ -248,11 +249,6 @@ class SlamMapStore:
         mission_token = tile.mission_token
         if mission_token in self._retired_missions:
             return
-        # One live page from a new mission is enough to prove that the old
-        # mission may no longer be current.  Do not keep labelling it as the
-        # robot's live location while we wait for the independent layer needed
-        # to promote the replacement map.
-        self._invalidate_live_session()
         candidate = self._candidates.get(mission_token)
         if candidate is None:
             if len(self._candidates) >= MAX_CANDIDATE_MISSIONS:
@@ -260,7 +256,11 @@ class SlamMapStore:
                 self._retire_mission(evicted_token)
             self._candidate_generation += 1
             candidate = _MissionCandidate(
-                self._candidate_generation, monotonic(), {}, {}, tile.mission_id
+                generation=self._candidate_generation,
+                first_seen_at=monotonic(),
+                entries={},
+                structure_entries={},
+                mission_id=tile.mission_id,
             )
             self._candidates[mission_token] = candidate
         else:
@@ -274,7 +274,15 @@ class SlamMapStore:
             if candidate.mission_id is None:
                 candidate.mission_id = tile.mission_id
         target = candidate.structure_entries if structural else candidate.entries
+        missing_layer = not target
         target[_tile_key(tile)] = entry
+        # A new candidate, or a late counterpart for an expired candidate,
+        # makes the active map unsafe until this candidate is classified.  A
+        # further page from an already-expired one-sided stream does not start
+        # another indefinite pause; its retained page remains available for a
+        # future independent counterpart instead.
+        if candidate.blocks_active or missing_layer:
+            self._invalidate_live_session()
         self._enforce_candidate_bounds(candidate)
         # A newer observed mission is authoritative until it is classified.
         # Do not promote an older candidate merely because its delayed layer
@@ -287,18 +295,22 @@ class SlamMapStore:
             self._promote_candidate(mission_token, candidate)
 
     def _expire_incomplete_candidates(self) -> None:
-        """Discard one-sided mission observations after bounded classification.
+        """Relax one-sided candidates after bounded classification.
 
         An alternative token invalidates the active map immediately, but a
         failed or skewed subscription must not keep the active map unavailable
-        forever.  Expiry deliberately does not retire the token: a later page
-        from that mission starts a new two-layer classification instead of
-        silently accepting an unproven replacement.
+        forever.  Retain its bounded early layer so a delayed independent
+        counterpart can still promote the candidate, but allow the active
+        mission to earn fresh two-layer proof in the meantime.
         """
         cutoff = monotonic() - CANDIDATE_CLASSIFICATION_SECONDS
-        for mission_token, candidate in tuple(self._candidates.items()):
-            if candidate.first_seen_at <= cutoff:
-                self._candidates.pop(mission_token)
+        for candidate in self._candidates.values():
+            if candidate.blocks_active and candidate.first_seen_at <= cutoff:
+                candidate.blocks_active = False
+
+    def _has_blocking_candidate(self) -> bool:
+        """Return whether an unclassified candidate still blocks active proof."""
+        return any(candidate.blocks_active for candidate in self._candidates.values())
 
     def _promote_candidate(
         self, mission_token: str, candidate: _MissionCandidate

--- a/custom_components/matic_robot/slam_map_store.py
+++ b/custom_components/matic_robot/slam_map_store.py
@@ -40,6 +40,10 @@ MAX_CANDIDATE_MISSIONS = 2
 MAX_CANDIDATE_TILES_PER_LAYER = 128
 MAX_CANDIDATE_BYTES = 2 * 1024 * 1024
 MAX_RETIRED_MISSIONS = 8
+# A candidate needs pages from both independent subscriptions.  Allow three
+# normal retry intervals for those streams to converge, then discard a
+# one-sided candidate so it cannot hold the active map unavailable forever.
+CANDIDATE_CLASSIFICATION_SECONDS = STREAM_RETRY_SECONDS * 3
 
 MapHealthState = Literal[
     "empty", "collecting", "incomplete", "ready", "truncated", "degraded"
@@ -84,6 +88,7 @@ class _MissionCandidate:
     """Bounded pages waiting for cross-layer mission confirmation."""
 
     generation: int
+    first_seen_at: float
     entries: dict[str, HermesCollectionEntry]
     structure_entries: dict[str, HermesCollectionEntry]
     mission_id: int | None
@@ -198,6 +203,7 @@ class SlamMapStore:
         """Cache an active page or stage a cross-layer mission candidate."""
         if self._closed:
             return
+        self._expire_incomplete_candidates()
         mission_token = tile.mission_token
         if self._mission_token is None:
             self._mission_token = mission_token
@@ -254,7 +260,7 @@ class SlamMapStore:
                 self._retire_mission(evicted_token)
             self._candidate_generation += 1
             candidate = _MissionCandidate(
-                self._candidate_generation, {}, {}, tile.mission_id
+                self._candidate_generation, monotonic(), {}, {}, tile.mission_id
             )
             self._candidates[mission_token] = candidate
         else:
@@ -279,6 +285,20 @@ class SlamMapStore:
             and candidate.generation == self._candidate_generation
         ):
             self._promote_candidate(mission_token, candidate)
+
+    def _expire_incomplete_candidates(self) -> None:
+        """Discard one-sided mission observations after bounded classification.
+
+        An alternative token invalidates the active map immediately, but a
+        failed or skewed subscription must not keep the active map unavailable
+        forever.  Expiry deliberately does not retire the token: a later page
+        from that mission starts a new two-layer classification instead of
+        silently accepting an unproven replacement.
+        """
+        cutoff = monotonic() - CANDIDATE_CLASSIFICATION_SECONDS
+        for mission_token, candidate in tuple(self._candidates.items()):
+            if candidate.first_seen_at <= cutoff:
+                self._candidates.pop(mission_token)
 
     def _promote_candidate(
         self, mission_token: str, candidate: _MissionCandidate

--- a/custom_components/matic_robot/slam_map_store.py
+++ b/custom_components/matic_robot/slam_map_store.py
@@ -290,7 +290,7 @@ class SlamMapStore:
         if (
             candidate.entries
             and candidate.structure_entries
-            and candidate.generation == self._candidate_generation
+            and self._candidate_can_promote(candidate)
         ):
             self._promote_candidate(mission_token, candidate)
 
@@ -304,13 +304,38 @@ class SlamMapStore:
         mission to earn fresh two-layer proof in the meantime.
         """
         cutoff = monotonic() - CANDIDATE_CLASSIFICATION_SECONDS
+        relaxed = False
         for candidate in self._candidates.values():
             if candidate.blocks_active and candidate.first_seen_at <= cutoff:
                 candidate.blocks_active = False
+                relaxed = True
+        if relaxed:
+            self._promote_latest_complete_candidate()
 
     def _has_blocking_candidate(self) -> bool:
         """Return whether an unclassified candidate still blocks active proof."""
         return any(candidate.blocks_active for candidate in self._candidates.values())
+
+    def _candidate_can_promote(self, candidate: _MissionCandidate) -> bool:
+        """Return whether no newer unclassified candidate outranks ``candidate``."""
+        return not any(
+            pending.blocks_active and pending.generation > candidate.generation
+            for pending in self._candidates.values()
+        )
+
+    def _promote_latest_complete_candidate(self) -> None:
+        """Promote the best complete candidate after a newer one is classified."""
+        best: tuple[str, _MissionCandidate] | None = None
+        for mission_token, candidate in self._candidates.items():
+            if (
+                candidate.entries
+                and candidate.structure_entries
+                and self._candidate_can_promote(candidate)
+            ):
+                if best is None or candidate.generation > best[1].generation:
+                    best = mission_token, candidate
+        if best is not None:
+            self._promote_candidate(*best)
 
     def _promote_candidate(
         self, mission_token: str, candidate: _MissionCandidate

--- a/custom_components/matic_robot/slam_map_store.py
+++ b/custom_components/matic_robot/slam_map_store.py
@@ -456,10 +456,16 @@ class SlamMapStore:
             return
         if self._closed:
             return
-        for entry in photo_entries:
-            await self.async_add(entry)
-        for entry in structure_entries:
-            await self.async_add_structure(entry)
+        try:
+            for entry in photo_entries:
+                await self.async_add(entry)
+            for entry in structure_entries:
+                await self.async_add_structure(entry)
+        except DecodeError:
+            self._record_invalid()
+            self._notify_listeners()
+            self._schedule_candidate_refresh_retry()
+            return
         if self._needs_candidate_refresh():
             self._schedule_candidate_refresh_retry()
         else:

--- a/custom_components/matic_robot/slam_map_store.py
+++ b/custom_components/matic_robot/slam_map_store.py
@@ -454,7 +454,7 @@ class SlamMapStore:
         except Exception:
             self._schedule_candidate_refresh_retry()
             return
-        if self._closed:
+        if self._closed or not self._needs_candidate_refresh():
             return
         try:
             for entry in photo_entries:

--- a/custom_components/matic_robot/slam_map_store.py
+++ b/custom_components/matic_robot/slam_map_store.py
@@ -47,6 +47,7 @@ MAX_RETIRED_MISSIONS = 8
 # normal retry intervals for those streams to converge, then classify a
 # one-sided candidate so it cannot hold the active map unavailable forever.
 CANDIDATE_CLASSIFICATION_SECONDS = STREAM_RETRY_SECONDS * 3
+CANDIDATE_REFRESH_RETRY_SECONDS = STREAM_RETRY_SECONDS
 
 MapHealthState = Literal[
     "empty", "collecting", "incomplete", "ready", "truncated", "degraded"
@@ -155,6 +156,7 @@ class SlamMapStore:
         self._retired_missions: deque[str] = deque(maxlen=MAX_RETIRED_MISSIONS)
         self._candidate_generation = 0
         self._candidate_expiry_cancel: CALLBACK_TYPE | None = None
+        self._candidate_refresh_retry_cancel: CALLBACK_TYPE | None = None
         self._candidate_refresh_task: asyncio.Task[None] | None = None
         self._collection_client: MaticHermesClient | None = None
         self._closed = False
@@ -162,6 +164,7 @@ class SlamMapStore:
     async def async_load(self) -> None:
         """Load and validate the robot-local tile cache."""
         self._cancel_candidate_expiry()
+        self._cancel_candidate_refresh_retry()
         stored = await self._store.async_load() or {}
         loaded = await self._hass.async_add_executor_job(
             _decode_stored_snapshot, stored
@@ -241,6 +244,8 @@ class SlamMapStore:
             live_session_confirmed = False
         else:
             live_session_confirmed = self._observe_live_layer(structural=structural)
+        if live_session_confirmed:
+            self._cancel_candidate_refresh_retry()
         if not changed and not identity_changed and not live_session_confirmed:
             return
         self._content_changed()
@@ -289,6 +294,7 @@ class SlamMapStore:
         # another indefinite pause; its retained page remains available for a
         # future independent counterpart instead.
         if candidate.blocks_active or missing_layer:
+            self._cancel_candidate_refresh_retry()
             self._invalidate_live_session()
         self._enforce_candidate_bounds(candidate)
         # A newer observed mission is authoritative until it is classified.
@@ -397,6 +403,43 @@ class SlamMapStore:
             "matic_robot_map_candidate_refresh",
         )
 
+    def _needs_candidate_refresh(self) -> bool:
+        """Return whether expired candidates still need fresh active-map proof."""
+        return bool(
+            not self._closed
+            and self._candidates
+            and not self._has_blocking_candidate()
+            and not self.live_session_verified
+        )
+
+    def _schedule_candidate_refresh_retry(self) -> None:
+        """Retry bounded map revalidation after a transient snapshot failure."""
+        self._cancel_candidate_refresh_retry()
+        if not self._needs_candidate_refresh():
+            return
+        self._candidate_refresh_retry_cancel = async_call_later(
+            self._hass,
+            CANDIDATE_REFRESH_RETRY_SECONDS,
+            HassJob(
+                self._async_handle_candidate_refresh_retry,
+                "matic_robot_map_candidate_refresh_retry",
+                cancel_on_shutdown=True,
+            ),
+        )
+
+    def _cancel_candidate_refresh_retry(self) -> None:
+        """Cancel the pending candidate-refresh retry, if any."""
+        if self._candidate_refresh_retry_cancel is not None:
+            self._candidate_refresh_retry_cancel()
+            self._candidate_refresh_retry_cancel = None
+
+    @callback
+    def _async_handle_candidate_refresh_retry(self, _now: datetime) -> None:
+        """Retry only while no live proof or newer candidate has arrived."""
+        self._candidate_refresh_retry_cancel = None
+        if self._needs_candidate_refresh():
+            self._schedule_candidate_refresh()
+
     async def _async_refresh_after_candidate_expiry(
         self, client: MaticHermesClient
     ) -> None:
@@ -409,6 +452,7 @@ class SlamMapStore:
         except asyncio.CancelledError:
             raise
         except Exception:
+            self._schedule_candidate_refresh_retry()
             return
         if self._closed:
             return
@@ -416,6 +460,10 @@ class SlamMapStore:
             await self.async_add(entry)
         for entry in structure_entries:
             await self.async_add_structure(entry)
+        if self._needs_candidate_refresh():
+            self._schedule_candidate_refresh_retry()
+        else:
+            self._cancel_candidate_refresh_retry()
 
     async def _async_cancel_candidate_refresh(self) -> None:
         """Stop an in-flight bounded map refresh during entry teardown."""
@@ -431,6 +479,7 @@ class SlamMapStore:
         self, mission_token: str, candidate: _MissionCandidate
     ) -> None:
         """Atomically replace the active mission after cross-layer evidence."""
+        self._cancel_candidate_refresh_retry()
         if self._mission_token is not None:
             self._retire_mission(self._mission_token)
         for token, pending in tuple(self._candidates.items()):
@@ -675,6 +724,7 @@ class SlamMapStore:
         """Erase the private map cache when the robot entry is removed."""
         self._closed = True
         self._cancel_candidate_expiry()
+        self._cancel_candidate_refresh_retry()
         await self._async_cancel_candidate_refresh()
         self._collection_client = None
         self._entries.clear()
@@ -702,6 +752,7 @@ class SlamMapStore:
             return
         self._closed = True
         self._cancel_candidate_expiry()
+        self._cancel_candidate_refresh_retry()
         await self._async_cancel_candidate_refresh()
         self._collection_client = None
         data = await self._hass.async_add_executor_job(

--- a/custom_components/matic_robot/slam_map_store.py
+++ b/custom_components/matic_robot/slam_map_store.py
@@ -326,6 +326,14 @@ class SlamMapStore:
         if relaxed:
             self._promote_latest_complete_candidate()
         self._schedule_candidate_expiry()
+        # This method also runs synchronously while processing a newly
+        # received page.  If that page crosses the classification deadline
+        # before the timer callback runs, schedule the same bounded
+        # revalidation the timer path would have requested.  Otherwise a
+        # quiet counterpart stream could leave live map state unavailable
+        # indefinitely after the candidate has been relaxed.
+        if relaxed and not self._has_blocking_candidate():
+            self._schedule_candidate_refresh()
         return relaxed
 
     def _has_blocking_candidate(self) -> bool:

--- a/custom_components/matic_robot/slam_scene.py
+++ b/custom_components/matic_robot/slam_scene.py
@@ -213,6 +213,12 @@ class MaticSlamSceneView(HomeAssistantView):
                 or _runtime_for_entry(hass, entry_id) is not runtime
             ):
                 return None
+            # A concurrent encoder can populate this cache while this request
+            # waits for the lock. Check the live session before returning that
+            # newly available payload, not only before entering the lock.
+            if not bool(getattr(runtime.slam_map, "live_session_verified", True)):
+                self.clear_entry(entry_id)
+                return None
             cached = self._cache.get(entry_id)
             if cached is not None and cached is not queued_after:
                 return cached

--- a/custom_components/matic_robot/slam_scene.py
+++ b/custom_components/matic_robot/slam_scene.py
@@ -415,6 +415,14 @@ class MaticSlamDeltaView(HomeAssistantView):
                     revision=current.revision,
                 )
             )
+        if (
+            _runtime_for_entry(hass, entry_id) is not runtime
+            or not bool(getattr(runtime.slam_map, "live_session_verified", True))
+            or self._scene_view.current_revision(entry_id, runtime) != current.revision
+        ):
+            return web.Response(
+                status=HTTPStatus.NOT_FOUND, headers=PRIVATE_NO_STORE_HEADERS
+            )
         if delta is None:
             return web.Response(
                 body=current.payload,

--- a/custom_components/matic_robot/slam_scene.py
+++ b/custom_components/matic_robot/slam_scene.py
@@ -223,7 +223,10 @@ class MaticSlamSceneView(HomeAssistantView):
                 if cached is not None and cached.key == key:
                     return cached
                 entries = runtime.slam_map.entries()
-                floor_plan_coherent = _mission_matches_floor_plan(identity, floor_plan)
+                # A matching persisted mission is not enough after a restart.
+                # The map store admits room overlays only after both live map
+                # collections reconfirm that mission for this session.
+                floor_plan_coherent = runtime.slam_map.floor_plan_is_current(floor_plan)
                 try:
                     encoded = await hass.async_add_executor_job(
                         partial(
@@ -687,6 +690,11 @@ class MaticSlamCatalogView(HomeAssistantView):
                     if self._scene_view is not None
                     else runtime.slam_map.revision,
                     "map_floor_coherent": floor_plan_coherent,
+                    "map_session_verified": getattr(
+                        runtime.slam_map,
+                        "live_session_verified",
+                        floor_plan_coherent,
+                    ),
                     "map_health": health.state,
                     "map_complete": health.complete,
                     "map_truncated": health.truncated,
@@ -975,12 +983,6 @@ def _scene_snapshot_key(runtime: MaticRuntimeData) -> tuple[object, ...]:
         runtime.slam_map.mission_identity,
         runtime.coordinator.data.floor_plan,
     )
-
-
-def _mission_matches_floor_plan(
-    identity: SlamMapIdentity | None, floor_plan: FloorPlan | None
-) -> bool:
-    return identity is not None and identity.matches_floor_plan(floor_plan)
 
 
 def _header_bool(value: bool) -> str:

--- a/custom_components/matic_robot/slam_scene.py
+++ b/custom_components/matic_robot/slam_scene.py
@@ -197,6 +197,9 @@ class MaticSlamSceneView(HomeAssistantView):
     ) -> _CachedScene | None:
         """Encode or return the current coherent scene snapshot."""
         data = runtime.coordinator.data
+        if not bool(getattr(runtime.slam_map, "live_session_verified", True)):
+            self.clear_entry(entry_id)
+            return None
         epoch = self._epochs.get(entry_id, 0)
         key = _scene_snapshot_key(runtime)
         cached = self._cache.get(entry_id)
@@ -219,13 +222,13 @@ class MaticSlamSceneView(HomeAssistantView):
                 identity = runtime.slam_map.mission_identity
                 floor_plan = data.floor_plan
                 key = (map_revision, identity, floor_plan)
+                if not bool(getattr(runtime.slam_map, "live_session_verified", True)):
+                    self.clear_entry(entry_id)
+                    return None
                 cached = self._cache.get(entry_id)
                 if cached is not None and cached.key == key:
                     return cached
                 entries = runtime.slam_map.entries()
-                # A matching persisted mission is not enough after a restart.
-                # The map store admits room overlays only after both live map
-                # collections reconfirm that mission for this session.
                 floor_plan_coherent = runtime.slam_map.floor_plan_is_current(floor_plan)
                 try:
                     encoded = await hass.async_add_executor_job(

--- a/custom_components/matic_robot/strings.json
+++ b/custom_components/matic_robot/strings.json
@@ -165,6 +165,7 @@
     "map_status_building_scene": "Building local map · {points} points",
     "map_status_full_scene": "{points} points · {sampling}",
     "map_status_floor_transition": "Floor transition detected · map paused until localization completes",
+    "map_status_session_revalidation": "Checking the current map after restart · map paused until localization completes",
     "map_status_historical": "Map captured {time}",
     "map_status_history_unavailable": "This map checkpoint is unavailable",
     "map_status_loading_data": "Loading local 3D data…",

--- a/custom_components/matic_robot/translations/en.json
+++ b/custom_components/matic_robot/translations/en.json
@@ -165,6 +165,7 @@
     "map_status_building_scene": "Building local map · {points} points",
     "map_status_full_scene": "{points} points · {sampling}",
     "map_status_floor_transition": "Floor transition detected · map paused until localization completes",
+    "map_status_session_revalidation": "Checking the current map after restart · map paused until localization completes",
     "map_status_historical": "Map captured {time}",
     "map_status_history_unavailable": "This map checkpoint is unavailable",
     "map_status_loading_data": "Loading local 3D data…",

--- a/tests/browser/ui.spec.mjs
+++ b/tests/browser/ui.spec.mjs
@@ -1564,6 +1564,63 @@ test.describe("map studio", () => {
     expect(previousFloorRequests).toBe(0);
   });
 
+  test("withholds a restored map until this Home Assistant session revalidates it", async ({ page }) => {
+    await installBrowserDoubles(page, { webgl: true });
+    let sceneRequests = 0;
+    let historyRequests = 0;
+    await page.route("**/api/matic_robot/slam_entries", (route) => route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ entries: [{
+        entry_id: "synthetic-entry",
+        scene_url: "/restored-scene",
+        history_url: "/restored-history",
+        history_count: 1,
+        map_revision: 2,
+        map_complete: false,
+        map_floor_coherent: false,
+        map_session_verified: false,
+      }] }),
+    }));
+    await page.route("**/restored-scene", (route) => {
+      sceneRequests += 1;
+      return route.fulfill({
+        status: 200,
+        body: syntheticScene("Restored room", 16),
+        headers: { "Content-Type": "application/vnd.matic.slam-scene" },
+      });
+    });
+    await page.route("**/restored-history", (route) => {
+      historyRequests += 1;
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ live_available: false, snapshots: [], floors: [] }),
+      });
+    });
+
+    const studio = await loadStudio(page);
+
+    await expect(studio.locator(".status")).toContainText(
+      "Checking the current map after restart",
+    );
+    await expect(studio.locator(".status")).not.toContainText(
+      "Floor transition detected",
+    );
+    await expect(studio.locator(".scene-canvas")).toBeHidden();
+    await expect(studio.locator(".empty")).toContainText(
+      "map paused until localization completes",
+    );
+    await expect(studio.locator(".floor-select").locator("option").first()).toHaveText(
+      "Live map · locating robot",
+    );
+    await expect(
+      studio.locator(".floor-select").locator("option").first(),
+    ).toHaveAttribute("disabled", "");
+    expect(sceneRequests).toBe(0);
+    expect(historyRequests).toBe(0);
+  });
+
   test("does not resurface an in-flight live scene after a floor transition", async ({ page }) => {
     await installBrowserDoubles(page, { webgl: true });
     let releaseScene;

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1454,6 +1454,42 @@ async def test_photorealistic_camera_rechecks_cache_after_render_lock(hass) -> N
     assert await task == b"finished-by-first-request"
 
 
+async def test_photorealistic_camera_rechecks_coherence_after_render_lock(
+    hass,
+) -> None:
+    entry = _entry()
+    store = entry.runtime_data.slam_map
+    entity = camera.MaticPhotorealisticMapCamera(entry)
+    entity.hass = hass
+    store.floor_plan_is_current.side_effect = (True, False)
+    await entity._render_lock.acquire()
+
+    with (
+        patch(
+            "custom_components.matic_robot.camera._render_photorealistic_entries"
+        ) as render,
+        patch(
+            "custom_components.matic_robot.camera.render_floor_plan",
+            return_value=b"map-unavailable",
+        ) as unavailable_render,
+    ):
+        task = hass.async_create_task(entity.async_camera_image())
+        await asyncio.sleep(0)
+        entity._render_lock.release()
+        assert await task == b"map-unavailable"
+
+    render.assert_not_called()
+    unavailable_render.assert_called_once_with(
+        None,
+        None,
+        None,
+        width=1024,
+        height=1024,
+    )
+    assert entity._cached_key is None
+    assert entity._cached_image is None
+
+
 def test_photorealistic_camera_decodes_both_layers_for_renderer() -> None:
     from tests.test_slam_map import synthetic_slam_entry, synthetic_structure_entry
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1225,6 +1225,7 @@ async def test_camera_clamps_dimensions_and_renders_locally(hass) -> None:
     assert entity.extra_state_attributes == {
         "matic_entry_id": "entry",
         "map_floor_coherent": True,
+        "map_session_verified": True,
         "robot_location_source": "exact_pose",
         "source": "local_room_map",
     }
@@ -1270,6 +1271,7 @@ async def test_camera_clamps_dimensions_and_renders_locally(hass) -> None:
     assert entity.extra_state_attributes == {
         "matic_entry_id": "entry",
         "map_floor_coherent": False,
+        "map_session_verified": False,
         "robot_location_source": "unavailable",
         "source": "local_room_map",
     }
@@ -1330,6 +1332,7 @@ async def test_photorealistic_camera_fetches_and_renders_local_tiles(hass) -> No
         "map_complete": True,
         "map_revision": 1,
         "map_floor_coherent": True,
+        "map_session_verified": True,
         "robot_location_source": "exact_pose",
         "source": "local_robot_slam",
         "scene_url": "/api/matic_robot/slam_scene/entry",
@@ -1357,6 +1360,40 @@ async def test_photorealistic_camera_fetches_and_renders_local_tiles(hass) -> No
     update_state.assert_called_once_with()
 
     assert entity.extra_state_attributes["robot_location_source"] == "unavailable"
+
+
+async def test_photorealistic_camera_withholds_a_restored_map_before_revalidation(
+    hass,
+) -> None:
+    entry = _entry()
+    store = entry.runtime_data.slam_map
+    store.floor_plan_is_current.return_value = False
+    store.entries.return_value = (HermesCollectionEntry(b"key", b"value"),)
+    store.structure_entries.return_value = (HermesCollectionEntry(b"key", b"value"),)
+    entity = camera.MaticPhotorealisticMapCamera(entry)
+    entity.hass = hass
+
+    with (
+        patch(
+            "custom_components.matic_robot.camera._render_photorealistic_entries"
+        ) as render,
+        patch(
+            "custom_components.matic_robot.camera.render_floor_plan",
+            return_value=b"map-unavailable",
+        ) as unavailable_render,
+    ):
+        assert await entity.async_camera_image() == b"map-unavailable"
+
+    render.assert_not_called()
+    unavailable_render.assert_called_once_with(
+        None,
+        None,
+        None,
+        width=1024,
+        height=1024,
+    )
+    assert entity._cached_key is None
+    assert entity._cached_image is None
 
 
 async def test_photorealistic_camera_discards_render_when_floor_changes(hass) -> None:

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1490,6 +1490,25 @@ async def test_photorealistic_camera_rechecks_coherence_after_render_lock(
     assert entity._cached_image is None
 
 
+async def test_camera_publishes_session_changes_without_a_floor_change(hass) -> None:
+    entry = _entry()
+    store = entry.runtime_data.slam_map
+    store.floor_plan_is_current.return_value = False
+    store.live_session_verified = False
+    entity = camera.MaticMapCamera(entry)
+    entity.hass = hass
+
+    with patch.object(entity, "async_write_ha_state") as write_state:
+        await entity.async_added_to_hass()
+        store.live_session_verified = True
+        entity._async_handle_store_update()
+        entity._async_handle_store_update()
+
+    assert write_state.call_count == 1
+    assert entity._published_floor_coherent is False
+    assert entity._published_session_verified is True
+
+
 def test_photorealistic_camera_decodes_both_layers_for_renderer() -> None:
     from tests.test_slam_map import synthetic_slam_entry, synthetic_structure_entry
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -142,6 +142,51 @@ async def test_slam_map_mission_change_refreshes_the_cached_floor_plan(hass) -> 
     assert len(scheduled) == 1
 
 
+async def test_slam_map_sync_waits_for_live_session_revalidation(hass) -> None:
+    entry = _entry()
+    remove_listener = MagicMock()
+    scheduled: list[object] = []
+    entry.async_create_background_task.side_effect = lambda _hass, target, _name: (
+        scheduled.append(target)
+    )
+    floor_plan = FloorPlan(42, "synthetic-partition", b"partition", ())
+    listener: object | None = None
+
+    def add_listener(candidate):
+        nonlocal listener
+        listener = candidate
+        return remove_listener
+
+    slam_map = SimpleNamespace(
+        floor_plan_is_current=MagicMock(return_value=False),
+        async_add_listener=add_listener,
+        mission_identity=SlamMapIdentity("00" * 32, 43),
+        live_session_verified=False,
+    )
+
+    async def refresh_floor_plan() -> None:
+        slam_map.floor_plan_is_current.return_value = True
+
+    coordinator = SimpleNamespace(
+        data=SimpleNamespace(floor_plan=floor_plan),
+        async_request_floor_plan_refresh=AsyncMock(side_effect=refresh_floor_plan),
+    )
+
+    _register_slam_map_floor_plan_sync(hass, entry, slam_map, coordinator)
+
+    assert callable(listener)
+    assert not scheduled
+    coordinator.async_request_floor_plan_refresh.assert_not_awaited()
+
+    slam_map.live_session_verified = True
+    listener()
+    assert len(scheduled) == 1
+    await scheduled[0]
+
+    coordinator.async_request_floor_plan_refresh.assert_awaited_once()
+    entry.async_on_unload.assert_called_once_with(remove_listener)
+
+
 async def test_slam_map_transition_rechecks_a_newer_mission_after_refresh(hass) -> None:
     entry = _entry()
     remove_listener = MagicMock()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -241,6 +241,105 @@ async def test_slam_map_transition_rechecks_a_newer_mission_after_refresh(hass) 
     assert coordinator.async_request_floor_plan_refresh.await_count == 2
 
 
+async def test_slam_map_transition_drops_an_already_invalid_refresh(hass) -> None:
+    """A queued refresh must not spend its budget after live proof is lost."""
+    entry = _entry()
+    remove_listener = MagicMock()
+    scheduled: list[object] = []
+    entry.async_create_background_task.side_effect = lambda _hass, target, _name: (
+        scheduled.append(target)
+    )
+    identity = SlamMapIdentity("00" * 32, 43)
+    coordinator = SimpleNamespace(
+        data=SimpleNamespace(
+            floor_plan=FloorPlan(42, "synthetic-partition", b"partition", ())
+        ),
+        async_request_floor_plan_refresh=AsyncMock(),
+    )
+    listener: object | None = None
+
+    def add_listener(candidate):
+        nonlocal listener
+        listener = candidate
+        return remove_listener
+
+    slam_map = SimpleNamespace(
+        floor_plan_is_current=MagicMock(return_value=False),
+        async_add_listener=add_listener,
+        mission_identity=identity,
+        live_session_verified=True,
+    )
+
+    _register_slam_map_floor_plan_sync(hass, entry, slam_map, coordinator)
+    assert callable(listener)
+    slam_map.live_session_verified = False
+    await scheduled[0]
+
+    coordinator.async_request_floor_plan_refresh.assert_not_awaited()
+    slam_map.live_session_verified = True
+    listener()
+    assert len(scheduled) == 2
+    scheduled[1].close()
+
+
+async def test_slam_map_transition_retries_after_live_proof_is_interrupted(
+    hass,
+) -> None:
+    """A same-identity map refresh gets a new bounded budget after invalidation."""
+    entry = _entry()
+    remove_listener = MagicMock()
+    scheduled: list[object] = []
+    entry.async_create_background_task.side_effect = lambda _hass, target, _name: (
+        scheduled.append(target)
+    )
+    refresh_started = asyncio.Event()
+    release_refresh = asyncio.Event()
+
+    async def refresh_floor_plan() -> None:
+        refresh_started.set()
+        await release_refresh.wait()
+
+    identity = SlamMapIdentity("00" * 32, 43)
+    coordinator = SimpleNamespace(
+        data=SimpleNamespace(
+            floor_plan=FloorPlan(42, "synthetic-partition", b"partition", ())
+        ),
+        async_request_floor_plan_refresh=AsyncMock(side_effect=refresh_floor_plan),
+    )
+    listener: object | None = None
+
+    def add_listener(candidate):
+        nonlocal listener
+        listener = candidate
+        return remove_listener
+
+    slam_map = SimpleNamespace(
+        floor_plan_is_current=MagicMock(return_value=False),
+        async_add_listener=add_listener,
+        mission_identity=identity,
+        live_session_verified=True,
+    )
+
+    _register_slam_map_floor_plan_sync(hass, entry, slam_map, coordinator)
+    assert callable(listener)
+    first = asyncio.create_task(scheduled[0])
+    await refresh_started.wait()
+    slam_map.live_session_verified = False
+    listener()
+    release_refresh.set()
+    await first
+
+    assert coordinator.async_request_floor_plan_refresh.await_count == 1
+    assert len(scheduled) == 1
+    slam_map.live_session_verified = True
+    listener()
+    assert len(scheduled) == 2
+    slam_map.floor_plan_is_current.return_value = True
+    await scheduled[1]
+
+    assert coordinator.async_request_floor_plan_refresh.await_count == 2
+
+
 async def test_slam_map_transition_retries_a_delayed_floor_plan_once(hass) -> None:
     entry = _entry()
     remove_listener = MagicMock()

--- a/tests/test_slam_map_store.py
+++ b/tests/test_slam_map_store.py
@@ -17,6 +17,7 @@ from custom_components.matic_robot import slam_map_store as slam_map_store_modul
 from custom_components.matic_robot.client.exceptions import CannotConnectError
 from custom_components.matic_robot.client.models import FloorPlan, HermesCollectionEntry
 from custom_components.matic_robot.slam_map_store import (
+    CANDIDATE_CLASSIFICATION_SECONDS,
     MAX_HEALTH_COUNTER,
     SlamMapStore,
     _bounded_count,
@@ -156,6 +157,37 @@ async def test_slam_map_store_does_not_revalidate_old_mission_while_pending(
 
     assert store.floor_plan_is_current(second_plan)
     assert not store.floor_plan_is_current(first_plan)
+
+
+async def test_slam_map_store_expires_one_sided_candidate_before_recovery(
+    hass,
+) -> None:
+    """A failed replacement subscription cannot permanently pause the map."""
+    active_plan = FloorPlan(0x1234ABCD, "active", b"active", ())
+    store = SlamMapStore(hass, "expired-candidate-entry")
+    await store.async_add(synthetic_slam_entry())
+    await store.async_add_structure(synthetic_structure_entry())
+    assert store.floor_plan_is_current(active_plan)
+
+    candidate = synthetic_slam_entry(mission_id=2)
+    with patch(
+        "custom_components.matic_robot.slam_map_store.monotonic", return_value=0
+    ):
+        candidate_token = (await store.async_add(candidate)).mission_token
+    assert not store.live_session_verified
+
+    with patch(
+        "custom_components.matic_robot.slam_map_store.monotonic",
+        return_value=CANDIDATE_CLASSIFICATION_SECONDS + 1,
+    ):
+        await store.async_add(synthetic_slam_entry(page_x=8))
+        assert not store.live_session_verified
+        await store.async_add_structure(synthetic_structure_entry(page_x=8))
+
+    assert store.live_session_verified
+    assert store.floor_plan_is_current(active_plan)
+    assert candidate_token not in store._candidates
+    assert candidate_token not in store._retired_missions
 
 
 async def test_slam_map_store_waits_for_the_newest_pending_mission(hass) -> None:

--- a/tests/test_slam_map_store.py
+++ b/tests/test_slam_map_store.py
@@ -376,6 +376,32 @@ async def test_slam_map_store_retries_an_empty_silent_expiry_refresh(hass) -> No
     await store.async_shutdown()
 
 
+async def test_slam_map_store_retries_a_malformed_silent_expiry_refresh(hass) -> None:
+    """Malformed bounded entries retain fail-closed state and retry later."""
+    store = SlamMapStore(hass, "malformed-silent-candidate-expiry-entry")
+    await store.async_add(synthetic_slam_entry())
+    await store.async_add_structure(synthetic_structure_entry())
+    candidate_token = (
+        await store.async_add(synthetic_slam_entry(mission_id=2))
+    ).mission_token
+    store._candidates[candidate_token].blocks_active = False
+    client = SimpleNamespace(
+        async_get_collection_entries=AsyncMock(
+            side_effect=(
+                (HermesCollectionEntry(b"bad", b"bad"),),
+                (synthetic_structure_entry(page_x=8),),
+            )
+        )
+    )
+
+    await store._async_refresh_after_candidate_expiry(client)
+
+    assert not store.live_session_verified
+    assert store.health.invalid_tiles == 1
+    assert store._candidate_refresh_retry_cancel is not None
+    await store.async_shutdown()
+
+
 async def test_slam_map_store_shutdown_cancels_candidate_snapshot(hass) -> None:
     """Unload cancels a timed map snapshot before persisting private cache data."""
     store = SlamMapStore(hass, "cancel-silent-candidate-expiry-entry")

--- a/tests/test_slam_map_store.py
+++ b/tests/test_slam_map_store.py
@@ -291,6 +291,48 @@ async def test_slam_map_store_revalidates_after_silent_candidate_expiry(hass) ->
     ]
 
 
+async def test_slam_map_store_revalidates_after_page_driven_candidate_expiry(
+    hass,
+) -> None:
+    """A late active page schedules proof when it expires a candidate."""
+    active_plan = FloorPlan(0x1234ABCD, "active", b"active", ())
+    store = SlamMapStore(hass, "page-driven-candidate-expiry-entry")
+    await store.async_add(synthetic_slam_entry())
+    await store.async_add_structure(synthetic_structure_entry())
+    assert store.floor_plan_is_current(active_plan)
+
+    candidate_token = (
+        await store.async_add(synthetic_slam_entry(mission_id=2))
+    ).mission_token
+    store._candidates[candidate_token].first_seen_at = (
+        slam_map_store_module.monotonic() - CANDIDATE_CLASSIFICATION_SECONDS
+    )
+
+    async def snapshot(name: str, *, limit: int):
+        assert limit == 1
+        if name == "map_compressed_rgb":
+            return (synthetic_slam_entry(page_x=8),)
+        assert name == "map_integrated"
+        return (synthetic_structure_entry(page_x=8),)
+
+    client = SimpleNamespace(
+        async_get_collection_entries=AsyncMock(side_effect=snapshot)
+    )
+    store._collection_client = client
+
+    # This arrival relaxes the expired candidate before its scheduled timer
+    # callback executes.  It supplies only one active layer, so the bounded
+    # read is required to regain live proof.
+    await store.async_add(synthetic_slam_entry(page_x=8))
+    await hass.async_block_till_done()
+
+    assert store.floor_plan_is_current(active_plan)
+    assert client.async_get_collection_entries.await_args_list == [
+        call("map_compressed_rgb", limit=1),
+        call("map_integrated", limit=1),
+    ]
+
+
 async def test_slam_map_store_discards_refresh_after_live_revalidation(hass) -> None:
     """A slow expired-candidate read cannot override newer active proof."""
     active_plan = FloorPlan(0x1234ABCD, "active", b"active", ())

--- a/tests/test_slam_map_store.py
+++ b/tests/test_slam_map_store.py
@@ -291,6 +291,51 @@ async def test_slam_map_store_revalidates_after_silent_candidate_expiry(hass) ->
     ]
 
 
+async def test_slam_map_store_discards_refresh_after_live_revalidation(hass) -> None:
+    """A slow expired-candidate read cannot override newer active proof."""
+    active_plan = FloorPlan(0x1234ABCD, "active", b"active", ())
+    store = SlamMapStore(hass, "discard-stale-candidate-refresh-entry")
+    await store.async_add(synthetic_slam_entry())
+    await store.async_add_structure(synthetic_structure_entry())
+    active_token = store.decoded_tiles()[0].mission_token
+    candidate = synthetic_slam_entry(mission_id=2)
+    candidate_token = (await store.async_add(candidate)).mission_token
+    store._candidates[candidate_token].blocks_active = False
+    started = asyncio.Event()
+    release = asyncio.Event()
+    calls = 0
+
+    async def snapshot(name: str, *, limit: int):
+        nonlocal calls
+        assert limit == 1
+        calls += 1
+        if calls == 2:
+            started.set()
+        await release.wait()
+        if name == "map_compressed_rgb":
+            return (candidate,)
+        assert name == "map_integrated"
+        return (synthetic_structure_entry(mission_id=2),)
+
+    refresh = asyncio.create_task(
+        store._async_refresh_after_candidate_expiry(
+            SimpleNamespace(
+                async_get_collection_entries=AsyncMock(side_effect=snapshot)
+            )
+        )
+    )
+    await started.wait()
+    await store.async_add(synthetic_slam_entry(page_x=8))
+    await store.async_add_structure(synthetic_structure_entry(page_x=8))
+    assert store.floor_plan_is_current(active_plan)
+    release.set()
+    await refresh
+
+    assert store.decoded_tiles()[0].mission_token == active_token
+    assert candidate_token in store._candidates
+    await store.async_shutdown()
+
+
 async def test_slam_map_store_silent_expiry_refresh_fails_closed(hass) -> None:
     """A timed snapshot failure cannot reactivate the retained map."""
     store = SlamMapStore(hass, "failed-silent-candidate-expiry-entry")

--- a/tests/test_slam_map_store.py
+++ b/tests/test_slam_map_store.py
@@ -130,6 +130,54 @@ async def test_slam_map_store_pauses_live_use_on_a_pending_new_mission(hass) -> 
     assert not store.floor_plan_is_current(first_plan)
 
 
+async def test_slam_map_store_does_not_revalidate_old_mission_while_pending(
+    hass,
+) -> None:
+    """Delayed old pages cannot make a pending replacement map live again."""
+    first_plan = FloorPlan(0x1234ABCD, "first", b"first", ())
+    second_plan = FloorPlan(2, "second", b"second", ())
+    store = SlamMapStore(hass, "delayed-old-mission-entry")
+    await store.async_add(synthetic_slam_entry())
+    await store.async_add_structure(synthetic_structure_entry())
+    assert store.floor_plan_is_current(first_plan)
+
+    # A new photographic layer invalidates the old map before the matching
+    # structure layer arrives.  In-flight pages from the old token must not
+    # make its cached map appear live during that interval.
+    await store.async_add(synthetic_slam_entry(mission_id=2))
+    await store.async_add(synthetic_slam_entry(page_x=8))
+    await store.async_add_structure(synthetic_structure_entry(page_x=8))
+
+    assert not store.live_session_verified
+    assert not store.floor_plan_is_current(first_plan)
+    assert not store.floor_plan_is_current(second_plan)
+
+    await store.async_add_structure(synthetic_structure_entry(mission_id=2))
+
+    assert store.floor_plan_is_current(second_plan)
+    assert not store.floor_plan_is_current(first_plan)
+
+
+async def test_slam_map_store_waits_for_the_newest_pending_mission(hass) -> None:
+    """A later mission signal prevents an older candidate from promotion."""
+    store = SlamMapStore(hass, "newest-pending-mission-entry")
+    await store.async_add(synthetic_slam_entry(mission=b"active"))
+    await store.async_add_structure(synthetic_structure_entry(mission=b"active"))
+    active_token = store.decoded_tiles()[0].mission_token
+
+    await store.async_add(synthetic_slam_entry(mission=b"older"))
+    await store.async_add(synthetic_slam_entry(mission=b"newer"))
+    await store.async_add_structure(synthetic_structure_entry(mission=b"older"))
+
+    assert store.decoded_tiles()[0].mission_token == active_token
+    assert not store.live_session_verified
+
+    await store.async_add_structure(synthetic_structure_entry(mission=b"newer"))
+
+    assert store.decoded_tiles()[0].mission_token != active_token
+    assert store.live_session_verified
+
+
 async def test_slam_map_store_fails_closed_on_inconsistent_mission_ids(hass) -> None:
     store = SlamMapStore(hass, "mission-identity-entry")
     assert store.mission_identity is None

--- a/tests/test_slam_map_store.py
+++ b/tests/test_slam_map_store.py
@@ -6,9 +6,10 @@ import asyncio
 import base64
 from collections import defaultdict
 from dataclasses import replace
+from datetime import datetime
 from threading import get_ident
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, call, patch
 
 import pytest
 from google.protobuf.message import DecodeError
@@ -254,6 +255,114 @@ async def test_slam_map_store_reconsiders_a_complete_candidate_after_expiry(
 
     assert store.live_session_verified
     assert store.floor_plan_is_current(complete_plan)
+
+
+async def test_slam_map_store_revalidates_after_silent_candidate_expiry(hass) -> None:
+    """A timer takes bounded fresh reads when map subscriptions stay quiet."""
+    active_plan = FloorPlan(0x1234ABCD, "active", b"active", ())
+    store = SlamMapStore(hass, "silent-candidate-expiry-entry")
+    await store.async_add(synthetic_slam_entry())
+    await store.async_add_structure(synthetic_structure_entry())
+    assert store.floor_plan_is_current(active_plan)
+
+    async def snapshot(name: str, *, limit: int):
+        assert limit == 1
+        if name == "map_compressed_rgb":
+            return (synthetic_slam_entry(page_x=8),)
+        assert name == "map_integrated"
+        return (synthetic_structure_entry(page_x=8),)
+
+    client = SimpleNamespace(
+        async_get_collection_entries=AsyncMock(side_effect=snapshot)
+    )
+    store._collection_client = client
+    with patch(
+        "custom_components.matic_robot.slam_map_store.CANDIDATE_CLASSIFICATION_SECONDS",
+        0,
+    ):
+        await store.async_add(synthetic_slam_entry(mission_id=2))
+        await asyncio.sleep(0)
+        await hass.async_block_till_done()
+
+    assert store.floor_plan_is_current(active_plan)
+    assert client.async_get_collection_entries.await_args_list == [
+        call("map_compressed_rgb", limit=1),
+        call("map_integrated", limit=1),
+    ]
+
+
+async def test_slam_map_store_silent_expiry_refresh_fails_closed(hass) -> None:
+    """A timed snapshot failure cannot reactivate the retained map."""
+    store = SlamMapStore(hass, "failed-silent-candidate-expiry-entry")
+    await store.async_add(synthetic_slam_entry())
+    await store.async_add_structure(synthetic_structure_entry())
+    assert store.live_session_verified
+
+    client = SimpleNamespace(
+        async_get_collection_entries=AsyncMock(
+            side_effect=CannotConnectError("synthetic snapshot failure")
+        )
+    )
+    store._collection_client = client
+    with patch(
+        "custom_components.matic_robot.slam_map_store.CANDIDATE_CLASSIFICATION_SECONDS",
+        0,
+    ):
+        await store.async_add(synthetic_slam_entry(mission_id=2))
+        await asyncio.sleep(0)
+        await hass.async_block_till_done()
+
+    assert not store.live_session_verified
+
+
+async def test_slam_map_store_shutdown_cancels_candidate_snapshot(hass) -> None:
+    """Unload cancels a timed map snapshot before persisting private cache data."""
+    store = SlamMapStore(hass, "cancel-silent-candidate-expiry-entry")
+    await store.async_add(synthetic_slam_entry())
+    await store.async_add_structure(synthetic_structure_entry())
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def snapshot(_name: str, *, limit: int):
+        assert limit == 1
+        started.set()
+        await release.wait()
+        return ()
+
+    store._collection_client = SimpleNamespace(
+        async_get_collection_entries=AsyncMock(side_effect=snapshot)
+    )
+    with patch(
+        "custom_components.matic_robot.slam_map_store.CANDIDATE_CLASSIFICATION_SECONDS",
+        0,
+    ):
+        await store.async_add(synthetic_slam_entry(mission_id=2))
+        await asyncio.sleep(0)
+        await started.wait()
+        task = store._candidate_refresh_task
+        assert task is not None
+        assert not task.done()
+        await store.async_shutdown()
+
+    assert task.cancelled()
+    assert store._candidate_expiry_cancel is None
+
+
+async def test_slam_map_store_candidate_expiry_ignores_a_closed_store(hass) -> None:
+    """Timer and refresh callbacks cannot mutate an unloaded integration."""
+    store = SlamMapStore(hass, "closed-silent-candidate-expiry-entry")
+    client = SimpleNamespace(async_get_collection_entries=AsyncMock(return_value=()))
+    store._closed = True
+
+    store._schedule_candidate_expiry()
+    store._async_handle_candidate_expiry(datetime.now())
+    store._schedule_candidate_refresh()
+    await store._async_refresh_after_candidate_expiry(client)
+
+    assert client.async_get_collection_entries.await_args_list == [
+        call("map_compressed_rgb", limit=1),
+        call("map_integrated", limit=1),
+    ]
 
 
 async def test_slam_map_store_waits_for_the_newest_pending_mission(hass) -> None:

--- a/tests/test_slam_map_store.py
+++ b/tests/test_slam_map_store.py
@@ -223,6 +223,39 @@ async def test_slam_map_store_promotes_a_late_candidate_counterpart(hass) -> Non
     assert candidate_token not in store._candidates
 
 
+async def test_slam_map_store_reconsiders_a_complete_candidate_after_expiry(
+    hass,
+) -> None:
+    """A newer one-sided candidate cannot permanently reject an older pair."""
+    active_plan = FloorPlan(0x1234ABCD, "active", b"active", ())
+    complete_plan = FloorPlan(2, "complete", b"complete", ())
+    store = SlamMapStore(hass, "reconsider-complete-candidate-entry")
+    await store.async_add(synthetic_slam_entry())
+    await store.async_add_structure(synthetic_structure_entry())
+    assert store.floor_plan_is_current(active_plan)
+
+    with patch(
+        "custom_components.matic_robot.slam_map_store.monotonic", return_value=0
+    ):
+        await store.async_add(synthetic_slam_entry(mission_id=2))
+        await store.async_add(synthetic_slam_entry(mission_id=3))
+        await store.async_add_structure(synthetic_structure_entry(mission_id=2))
+
+    assert not store.live_session_verified
+
+    with patch(
+        "custom_components.matic_robot.slam_map_store.monotonic",
+        return_value=CANDIDATE_CLASSIFICATION_SECONDS + 1,
+    ):
+        # This active-map page causes expiry to classify the newer one-sided
+        # candidate.  The retained, fully corroborated candidate must then
+        # become eligible before old active data can re-establish itself.
+        await store.async_add(synthetic_slam_entry(page_x=8))
+
+    assert store.live_session_verified
+    assert store.floor_plan_is_current(complete_plan)
+
+
 async def test_slam_map_store_waits_for_the_newest_pending_mission(hass) -> None:
     """A later mission signal prevents an older candidate from promotion."""
     store = SlamMapStore(hass, "newest-pending-mission-entry")

--- a/tests/test_slam_map_store.py
+++ b/tests/test_slam_map_store.py
@@ -313,6 +313,67 @@ async def test_slam_map_store_silent_expiry_refresh_fails_closed(hass) -> None:
         await hass.async_block_till_done()
 
     assert not store.live_session_verified
+    assert store._candidate_refresh_retry_cancel is not None
+    await store.async_shutdown()
+
+
+async def test_slam_map_store_retries_a_failed_silent_expiry_refresh(hass) -> None:
+    """A transient revalidation failure retries without trusting cached tiles."""
+    active_plan = FloorPlan(0x1234ABCD, "active", b"active", ())
+    store = SlamMapStore(hass, "retry-silent-candidate-expiry-entry")
+    await store.async_add(synthetic_slam_entry())
+    await store.async_add_structure(synthetic_structure_entry())
+    calls = 0
+
+    async def snapshot(name: str, *, limit: int):
+        nonlocal calls
+        assert limit == 1
+        calls += 1
+        if calls <= 2:
+            raise CannotConnectError("synthetic transient snapshot failure")
+        if name == "map_compressed_rgb":
+            return (synthetic_slam_entry(page_x=8),)
+        assert name == "map_integrated"
+        return (synthetic_structure_entry(page_x=8),)
+
+    store._collection_client = SimpleNamespace(
+        async_get_collection_entries=AsyncMock(side_effect=snapshot)
+    )
+    with (
+        patch(
+            "custom_components.matic_robot.slam_map_store.CANDIDATE_CLASSIFICATION_SECONDS",
+            0,
+        ),
+        patch(
+            "custom_components.matic_robot.slam_map_store.CANDIDATE_REFRESH_RETRY_SECONDS",
+            0,
+        ),
+    ):
+        await store.async_add(synthetic_slam_entry(mission_id=2))
+        await asyncio.sleep(0)
+        await hass.async_block_till_done()
+
+    assert calls == 4
+    assert store.floor_plan_is_current(active_plan)
+    assert store._candidate_refresh_retry_cancel is None
+
+
+async def test_slam_map_store_retries_an_empty_silent_expiry_refresh(hass) -> None:
+    """An empty bounded read is insufficient to revalidate the active map."""
+    store = SlamMapStore(hass, "empty-silent-candidate-expiry-entry")
+    await store.async_add(synthetic_slam_entry())
+    await store.async_add_structure(synthetic_structure_entry())
+    candidate_token = (
+        await store.async_add(synthetic_slam_entry(mission_id=2))
+    ).mission_token
+    store._candidates[candidate_token].blocks_active = False
+    client = SimpleNamespace(async_get_collection_entries=AsyncMock(return_value=()))
+
+    await store._async_refresh_after_candidate_expiry(client)
+
+    assert not store.live_session_verified
+    assert store._candidate_refresh_retry_cancel is not None
+    await store.async_shutdown()
 
 
 async def test_slam_map_store_shutdown_cancels_candidate_snapshot(hass) -> None:
@@ -357,6 +418,8 @@ async def test_slam_map_store_candidate_expiry_ignores_a_closed_store(hass) -> N
     store._schedule_candidate_expiry()
     store._async_handle_candidate_expiry(datetime.now())
     store._schedule_candidate_refresh()
+    store._schedule_candidate_refresh_retry()
+    store._async_handle_candidate_refresh_retry(datetime.now())
     await store._async_refresh_after_candidate_expiry(client)
 
     assert client.async_get_collection_entries.await_args_list == [

--- a/tests/test_slam_map_store.py
+++ b/tests/test_slam_map_store.py
@@ -186,8 +186,41 @@ async def test_slam_map_store_expires_one_sided_candidate_before_recovery(
 
     assert store.live_session_verified
     assert store.floor_plan_is_current(active_plan)
-    assert candidate_token not in store._candidates
+    assert candidate_token in store._candidates
+    assert not store._candidates[candidate_token].blocks_active
     assert candidate_token not in store._retired_missions
+
+
+async def test_slam_map_store_promotes_a_late_candidate_counterpart(hass) -> None:
+    """Expiry keeps the early candidate layer for a delayed subscription."""
+    active_plan = FloorPlan(0x1234ABCD, "active", b"active", ())
+    candidate_plan = FloorPlan(2, "candidate", b"candidate", ())
+    store = SlamMapStore(hass, "late-candidate-counterpart-entry")
+    await store.async_add(synthetic_slam_entry())
+    await store.async_add_structure(synthetic_structure_entry())
+    assert store.floor_plan_is_current(active_plan)
+
+    with patch(
+        "custom_components.matic_robot.slam_map_store.monotonic", return_value=0
+    ):
+        candidate_token = (
+            await store.async_add(synthetic_slam_entry(mission_id=2))
+        ).mission_token
+
+    with patch(
+        "custom_components.matic_robot.slam_map_store.monotonic",
+        return_value=CANDIDATE_CLASSIFICATION_SECONDS + 1,
+    ):
+        await store.async_add(synthetic_slam_entry(page_x=8))
+        await store.async_add_structure(synthetic_structure_entry(page_x=8))
+        assert store.floor_plan_is_current(active_plan)
+        assert not store._candidates[candidate_token].blocks_active
+
+        await store.async_add_structure(synthetic_structure_entry(mission_id=2))
+
+    assert store.live_session_verified
+    assert store.floor_plan_is_current(candidate_plan)
+    assert candidate_token not in store._candidates
 
 
 async def test_slam_map_store_waits_for_the_newest_pending_mission(hass) -> None:

--- a/tests/test_slam_map_store.py
+++ b/tests/test_slam_map_store.py
@@ -42,13 +42,17 @@ async def test_slam_map_store_round_trips_replaces_and_removes(hass) -> None:
     assert store.decoded_tiles() == (tile,)
     assert store.mission_identity is not None
     assert store.mission_identity.mission_id == 0x1234ABCD
+    assert not store.floor_plan_is_current(
+        FloorPlan(0x1234ABCD, "partition", b"partition", ())
+    )
+    await store.async_add_structure(synthetic_structure_entry())
     assert store.floor_plan_is_current(
         FloorPlan(0x1234ABCD, "partition", b"partition", ())
     )
     assert not store.floor_plan_is_current(FloorPlan(2, "partition", b"partition", ()))
 
     await store.async_add(entry)
-    assert store.revision == 1
+    assert store.revision == 2
 
     restored = SlamMapStore(hass, "synthetic-entry")
     await restored.async_load()
@@ -75,6 +79,55 @@ async def test_slam_map_store_round_trips_replaces_and_removes(hass) -> None:
     empty = SlamMapStore(hass, "synthetic-entry")
     await empty.async_load()
     assert empty.tile_count == 0
+
+
+async def test_slam_map_store_revalidates_a_persisted_map_before_live_use(hass) -> None:
+    """A restart must not advertise a retained map as the robot's live map."""
+    floor_plan = FloorPlan(0x1234ABCD, "partition", b"partition", ())
+    photo = synthetic_slam_entry()
+    structure = synthetic_structure_entry()
+    store = SlamMapStore(hass, "restart-provenance-entry")
+    await store.async_load()
+
+    with patch("custom_components.matic_robot.slam_map_store.SAVE_DELAY_SECONDS", 0):
+        await store.async_add(photo)
+        await store.async_add_structure(structure)
+    await asyncio.sleep(0)
+    await hass.async_block_till_done()
+    assert store.floor_plan_is_current(floor_plan)
+
+    restored = SlamMapStore(hass, "restart-provenance-entry")
+    await restored.async_load()
+    restored_revision = restored.revision
+    assert restored.mission_identity == store.mission_identity
+    assert restored.map_complete is False
+    assert not restored.floor_plan_is_current(floor_plan)
+
+    await restored.async_add(photo)
+    assert not restored.floor_plan_is_current(floor_plan)
+    await restored.async_add_structure(structure)
+
+    assert restored.floor_plan_is_current(floor_plan)
+    assert restored.revision == restored_revision + 1
+
+
+async def test_slam_map_store_pauses_live_use_on_a_pending_new_mission(hass) -> None:
+    """One new live layer hides the old floor until the replacement is proven."""
+    first_plan = FloorPlan(0x1234ABCD, "first", b"first", ())
+    second_plan = FloorPlan(2, "second", b"second", ())
+    store = SlamMapStore(hass, "pending-mission-entry")
+    await store.async_add(synthetic_slam_entry())
+    await store.async_add_structure(synthetic_structure_entry())
+    assert store.floor_plan_is_current(first_plan)
+
+    await store.async_add(synthetic_slam_entry(mission_id=2))
+
+    assert not store.floor_plan_is_current(first_plan)
+    assert not store.floor_plan_is_current(second_plan)
+    await store.async_add_structure(synthetic_structure_entry(mission_id=2))
+
+    assert store.floor_plan_is_current(second_plan)
+    assert not store.floor_plan_is_current(first_plan)
 
 
 async def test_slam_map_store_fails_closed_on_inconsistent_mission_ids(hass) -> None:

--- a/tests/test_slam_scene.py
+++ b/tests/test_slam_scene.py
@@ -30,6 +30,7 @@ from custom_components.matic_robot.client.models import (
 )
 from custom_components.matic_robot.client.slam_map import decode_slam_tile
 from custom_components.matic_robot.const import DOMAIN
+from custom_components.matic_robot.slam_delta import encode_slam_scene_delta
 from custom_components.matic_robot.slam_map_store import SlamMapIdentity
 from custom_components.matic_robot.slam_scene import (
     AREAS_API_URL,
@@ -1267,6 +1268,33 @@ async def test_delta_view_streams_revision_change_and_full_fallback() -> None:
     assert fallback.status == HTTPStatus.OK
     assert fallback.content_type == "application/vnd.matic.slam-scene"
     assert fallback.body.startswith(b"MATIC3D\x00")
+
+
+async def test_delta_view_discards_delta_after_live_session_invalidates() -> None:
+    """A transition during delta encoding cannot publish retained map bytes."""
+    runtime = _runtime()
+    runtime.slam_map.live_session_verified = True
+    hass = _hass(_entry(runtime))
+    scene_view = MaticSlamSceneView()
+    assert (await scene_view.get(_request(hass), "entry")).status == HTTPStatus.OK
+    runtime.slam_map.revision = 8
+    runtime.slam_map.entries.return_value = (
+        synthetic_slam_entry(page_x=0, page_y=0, surface_height=8),
+    )
+
+    async def invalidate_after_delta(target):
+        result = target()
+        if getattr(target, "func", None) is encode_slam_scene_delta:
+            runtime.slam_map.live_session_verified = False
+        return result
+
+    hass.async_add_executor_job.side_effect = invalidate_after_delta
+
+    response = await MaticSlamDeltaView(scene_view).get(
+        _request(hass, path="/?since=7"), "entry"
+    )
+
+    assert response.status == HTTPStatus.NOT_FOUND
 
 
 async def test_delta_view_waits_bounds_query_and_handles_unload() -> None:

--- a/tests/test_slam_scene.py
+++ b/tests/test_slam_scene.py
@@ -742,6 +742,7 @@ async def test_scene_and_catalog_require_admin_and_loaded_catalog_entries() -> N
                 "history_floor_count": 0,
                 "map_revision": 7,
                 "map_floor_coherent": True,
+                "map_session_verified": True,
                 "map_health": "ready",
                 "map_complete": True,
                 "map_truncated": False,

--- a/tests/test_slam_scene.py
+++ b/tests/test_slam_scene.py
@@ -560,6 +560,61 @@ async def test_scene_view_rechecks_live_session_after_waiting_for_the_encode_loc
     hass.async_add_executor_job.assert_not_awaited()
 
 
+async def test_scene_view_rechecks_live_session_before_returning_waiter_cache() -> None:
+    """A cache completed by another waiter cannot outlive map verification."""
+    runtime = _runtime()
+    hass = _hass(_entry(runtime))
+    view = MaticSlamSceneView()
+
+    assert (await view.get(_request(hass), "entry")).status == HTTPStatus.OK
+    completed_scene = view._cache.pop("entry")
+    lock = view._locks["entry"]
+    await lock.acquire()
+
+    task = asyncio.create_task(view.get(_request(hass), "entry"))
+    await asyncio.sleep(0)
+    # Simulate the lock holder completing an encode while this request waits.
+    view._cache["entry"] = completed_scene
+    runtime.slam_map.live_session_verified = False
+    lock.release()
+
+    response = await task
+
+    assert response.status == HTTPStatus.NOT_FOUND
+    assert not view._cache
+
+
+async def test_scene_view_rechecks_live_session_before_encoding() -> None:
+    """A session change after lock acquisition prevents a new scene encode."""
+    runtime = _runtime()
+    hass = _hass(_entry(runtime))
+    view = MaticSlamSceneView()
+    original_map = runtime.slam_map
+
+    class _SessionVerificationFlip:
+        """Expose a transition between the pre-lock and pre-encode checks."""
+
+        def __init__(self) -> None:
+            self.checks = 0
+
+        @property
+        def live_session_verified(self) -> bool:
+            self.checks += 1
+            return self.checks < 3
+
+        def __getattr__(self, name: str):
+            return getattr(original_map, name)
+
+    runtime.slam_map = _SessionVerificationFlip()
+
+    response = await view.get(_request(hass), "entry")
+
+    assert response.status == HTTPStatus.NOT_FOUND
+    assert runtime.slam_map.checks == 3
+    assert not view._cache
+    hass.async_add_executor_job.assert_not_awaited()
+
+
 @pytest.mark.parametrize(
     "entry",
     [

--- a/tests/test_slam_scene.py
+++ b/tests/test_slam_scene.py
@@ -522,6 +522,44 @@ async def test_scene_view_returns_conflict_until_photo_pages_exist() -> None:
     )
 
 
+async def test_scene_view_withholds_a_cached_scene_until_map_is_live_again() -> None:
+    runtime = _runtime()
+    hass = _hass(_entry(runtime))
+    view = MaticSlamSceneView()
+
+    assert (await view.get(_request(hass), "entry")).status == HTTPStatus.OK
+    runtime.slam_map.live_session_verified = False
+
+    response = await view.get(_request(hass), "entry")
+
+    assert response.status == HTTPStatus.NOT_FOUND
+    assert not view._cache
+    assert not view._versions
+    assert hass.async_add_executor_job.await_count == 1
+
+
+async def test_scene_view_rechecks_live_session_after_waiting_for_the_encode_lock() -> (
+    None
+):
+    runtime = _runtime()
+    hass = _hass(_entry(runtime))
+    view = MaticSlamSceneView()
+    lock = asyncio.Lock()
+    view._locks["entry"] = lock
+    await lock.acquire()
+
+    task = asyncio.create_task(view.get(_request(hass), "entry"))
+    await asyncio.sleep(0)
+    runtime.slam_map.live_session_verified = False
+    lock.release()
+
+    response = await task
+
+    assert response.status == HTTPStatus.NOT_FOUND
+    assert not view._cache
+    hass.async_add_executor_job.assert_not_awaited()
+
+
 @pytest.mark.parametrize(
     "entry",
     [


### PR DESCRIPTION
Fixes the stale map displayed after a Home Assistant restart.

The integration now waits for live map data from the robot before showing a restored map, location, history, or map controls. It also pauses the map while a new location is being confirmed.

Tests: browser UI, full unit suite (100% coverage), lint, type checks, privacy check, and package validation.

Final v0.3.12 remains on hold pending real two-location acceptance.