### PR TITLE
Use original commit for review threads

### DIFF
--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -314,7 +314,10 @@ jobs:
                    | select(.replyTo == null)
                    | select((((.pullRequestReview.databaseId // -1) | tostring) as $review_id
                        | ($review_ids | index($review_id))) != null)
-                   | select((.commit.oid // .originalCommit.oid // "") == $head)
+                   # GitHub moves `commit` to the latest diff position after a
+                   # later push. The original commit identifies the reviewed
+                   # head that produced this finding, so it must win here.
+                   | select((.originalCommit.oid // .commit.oid // "") == $head)
                    | {id: (.pullRequestReview.databaseId | tostring),
                       active: (($thread.isResolved | not) and ($thread.isOutdated | not))}]
                   | group_by(.id)

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -103,6 +103,7 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "availability_notice) | not" in review_gate
     assert 'source == "issue_comment"' in review_gate
     assert "total_count" in review_gate
+    assert '(.originalCommit.oid // .commit.oid // "") == $head' in review_gate
     assert "latest_regular_issue_comment_at" in review_gate
     assert "latest_regular_review_invalidation_at" in review_gate
     assert "latest_finding_at" in review_gate


### PR DESCRIPTION
Fixes review-gate classification after a PR is updated.

GitHub moves an inline comment’s current commit pointer as later commits change the diff. The gate now uses the original commit when available, so prior-head findings stay historical while unresolved current-head findings still block.

Tests: release packaging policy, lint, type checks, and privacy check.