### PR TITLE
Keep floor-plan recovery alive after transition burst

### DIFF
--- a/custom_components/matic_robot/__init__.py
+++ b/custom_components/matic_robot/__init__.py
@@ -63,6 +63,8 @@ FLOOR_PLAN_TRANSITION_REFRESH_ATTEMPTS = 2
 FLOOR_PLAN_TRANSITION_REFRESH_RETRY_SECONDS = 2
 FLOOR_PLAN_TRANSITION_REFRESH_ROUNDS = 2
 FLOOR_PLAN_TRANSITION_REFRESH_BACKOFF_SECONDS = 5
+FLOOR_PLAN_TRANSITION_RECOVERY_INITIAL_SECONDS = 30
+FLOOR_PLAN_TRANSITION_RECOVERY_MAX_SECONDS = 300
 
 
 @dataclass(slots=True)
@@ -303,6 +305,40 @@ def _register_slam_map_floor_plan_sync(
                 # fifteen-minute cache interval.
                 if round_ + 1 < FLOOR_PLAN_TRANSITION_REFRESH_ROUNDS:
                     await asyncio.sleep(FLOOR_PLAN_TRANSITION_REFRESH_BACKOFF_SECONDS)
+
+            # Some robots keep returning the previous floor plan for longer
+            # than the fast transition burst above. Keep the map fail-closed,
+            # but continue one low-frequency read at a bounded exponential
+            # backoff so a verified live mission cannot remain stranded until
+            # an unrelated identity or restart changes the state.
+            recovery_delay = FLOOR_PLAN_TRANSITION_RECOVERY_INITIAL_SECONDS
+            while True:
+                await asyncio.sleep(recovery_delay)
+                if slam_map.mission_identity != identity or not getattr(
+                    slam_map, "live_session_verified", True
+                ):
+                    last_attempted_identity = None
+                    return
+                floor_plan = coordinator.data.floor_plan
+                if floor_plan is not None and slam_map.floor_plan_is_current(
+                    floor_plan
+                ):
+                    return
+                await coordinator.async_request_floor_plan_refresh()
+                if slam_map.mission_identity != identity or not getattr(
+                    slam_map, "live_session_verified", True
+                ):
+                    last_attempted_identity = None
+                    return
+                floor_plan = coordinator.data.floor_plan
+                if floor_plan is not None and slam_map.floor_plan_is_current(
+                    floor_plan
+                ):
+                    return
+                recovery_delay = min(
+                    recovery_delay * 2,
+                    FLOOR_PLAN_TRANSITION_RECOVERY_MAX_SECONDS,
+                )
         finally:
             refresh_in_progress = False
             _async_sync_floor_plan()
@@ -324,8 +360,8 @@ def _register_slam_map_floor_plan_sync(
             last_attempted_identity = None
             return
         # A busy SLAM stream can publish many pages before the floor-plan
-        # endpoint catches up. Each verified mission gets one bounded refresh
-        # sequence, rather than one coordinator refresh per page.
+        # endpoint catches up. Keep one recovery task per verified mission,
+        # rather than one coordinator refresh per page.
         if refresh_in_progress or identity == last_attempted_identity:
             return
         refresh_in_progress = True

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -12,6 +12,7 @@ from homeassistant.components import frontend
 from homeassistant.exceptions import ConfigEntryAuthFailed
 
 from custom_components.matic_robot import (
+    FLOOR_PLAN_TRANSITION_RECOVERY_INITIAL_SECONDS,
     FLOOR_PLAN_TRANSITION_REFRESH_BACKOFF_SECONDS,
     FLOOR_PLAN_TRANSITION_REFRESH_RETRY_SECONDS,
     _async_resume_native_reconciliation,
@@ -102,9 +103,14 @@ async def test_slam_map_mission_change_refreshes_the_cached_floor_plan(hass) -> 
         scheduled.append(target)
     )
     floor_plan = FloorPlan(42, "synthetic-partition", b"partition", ())
+
+    async def refresh_floor_plan() -> None:
+        if coordinator.async_request_floor_plan_refresh.await_count == 4:
+            slam_map.floor_plan_is_current.return_value = True
+
     coordinator = SimpleNamespace(
         data=SimpleNamespace(floor_plan=floor_plan),
-        async_request_floor_plan_refresh=AsyncMock(),
+        async_request_floor_plan_refresh=AsyncMock(side_effect=refresh_floor_plan),
     )
     listener: object | None = None
 
@@ -140,6 +146,152 @@ async def test_slam_map_mission_change_refreshes_the_cached_floor_plan(hass) -> 
     slam_map.mission_identity = None
     listener()
     assert len(scheduled) == 1
+
+
+async def test_slam_map_transition_recovers_after_fast_retry_budget(hass) -> None:
+    """A verified mission keeps retrying if the floor plan stays stale."""
+    entry = _entry()
+    remove_listener = MagicMock()
+    scheduled: list[object] = []
+    entry.async_create_background_task.side_effect = lambda _hass, target, _name: (
+        scheduled.append(target)
+    )
+    floor_plan = FloorPlan(42, "synthetic-partition", b"partition", ())
+    slam_map = SimpleNamespace(
+        floor_plan_is_current=MagicMock(return_value=False),
+        mission_identity=SlamMapIdentity("00" * 32, 43),
+        async_add_listener=MagicMock(return_value=remove_listener),
+    )
+
+    async def refresh_floor_plan() -> None:
+        if coordinator.async_request_floor_plan_refresh.await_count == 6:
+            slam_map.floor_plan_is_current.return_value = True
+
+    coordinator = SimpleNamespace(
+        data=SimpleNamespace(floor_plan=floor_plan),
+        async_request_floor_plan_refresh=AsyncMock(side_effect=refresh_floor_plan),
+    )
+
+    with patch(
+        "custom_components.matic_robot.asyncio.sleep", new_callable=AsyncMock
+    ) as sleep:
+        _register_slam_map_floor_plan_sync(hass, entry, slam_map, coordinator)
+        await scheduled[0]
+
+    assert coordinator.async_request_floor_plan_refresh.await_count == 6
+    assert sleep.await_args_list == [
+        ((FLOOR_PLAN_TRANSITION_REFRESH_RETRY_SECONDS,), {}),
+        ((FLOOR_PLAN_TRANSITION_REFRESH_BACKOFF_SECONDS,), {}),
+        ((FLOOR_PLAN_TRANSITION_REFRESH_RETRY_SECONDS,), {}),
+        ((FLOOR_PLAN_TRANSITION_RECOVERY_INITIAL_SECONDS,), {}),
+        ((FLOOR_PLAN_TRANSITION_RECOVERY_INITIAL_SECONDS * 2,), {}),
+    ]
+
+
+async def test_slam_map_transition_drops_changed_identity_during_recovery_wait(
+    hass,
+) -> None:
+    """A newer mission replaces a sleeping same-identity recovery task."""
+    entry = _entry()
+    scheduled: list[object] = []
+    entry.async_create_background_task.side_effect = lambda _hass, target, _name: (
+        scheduled.append(target)
+    )
+    first_identity = SlamMapIdentity("00" * 32, 43)
+    second_identity = SlamMapIdentity("11" * 32, 44)
+    slam_map = SimpleNamespace(
+        floor_plan_is_current=MagicMock(return_value=False),
+        mission_identity=first_identity,
+        async_add_listener=MagicMock(return_value=MagicMock()),
+    )
+    coordinator = SimpleNamespace(
+        data=SimpleNamespace(
+            floor_plan=FloorPlan(42, "synthetic-partition", b"partition", ())
+        ),
+        async_request_floor_plan_refresh=AsyncMock(),
+    )
+
+    async def sleep(delay: int) -> None:
+        if delay == FLOOR_PLAN_TRANSITION_RECOVERY_INITIAL_SECONDS:
+            slam_map.mission_identity = second_identity
+
+    with patch("custom_components.matic_robot.asyncio.sleep", side_effect=sleep):
+        _register_slam_map_floor_plan_sync(hass, entry, slam_map, coordinator)
+        await scheduled[0]
+
+    assert coordinator.async_request_floor_plan_refresh.await_count == 4
+    assert len(scheduled) == 2
+    scheduled[1].close()
+
+
+async def test_slam_map_transition_observes_coherence_during_recovery_wait(
+    hass,
+) -> None:
+    """A normal coordinator update can settle recovery without another read."""
+    entry = _entry()
+    scheduled: list[object] = []
+    entry.async_create_background_task.side_effect = lambda _hass, target, _name: (
+        scheduled.append(target)
+    )
+    slam_map = SimpleNamespace(
+        floor_plan_is_current=MagicMock(return_value=False),
+        mission_identity=SlamMapIdentity("00" * 32, 43),
+        async_add_listener=MagicMock(return_value=MagicMock()),
+    )
+    coordinator = SimpleNamespace(
+        data=SimpleNamespace(
+            floor_plan=FloorPlan(42, "synthetic-partition", b"partition", ())
+        ),
+        async_request_floor_plan_refresh=AsyncMock(),
+    )
+
+    async def sleep(delay: int) -> None:
+        if delay == FLOOR_PLAN_TRANSITION_RECOVERY_INITIAL_SECONDS:
+            slam_map.floor_plan_is_current.return_value = True
+
+    with patch("custom_components.matic_robot.asyncio.sleep", side_effect=sleep):
+        _register_slam_map_floor_plan_sync(hass, entry, slam_map, coordinator)
+        await scheduled[0]
+
+    assert coordinator.async_request_floor_plan_refresh.await_count == 4
+    assert len(scheduled) == 1
+
+
+async def test_slam_map_transition_drops_changed_identity_during_recovery_read(
+    hass,
+) -> None:
+    """A response for an obsolete recovery mission is never accepted."""
+    entry = _entry()
+    scheduled: list[object] = []
+    entry.async_create_background_task.side_effect = lambda _hass, target, _name: (
+        scheduled.append(target)
+    )
+    first_identity = SlamMapIdentity("00" * 32, 43)
+    second_identity = SlamMapIdentity("11" * 32, 44)
+    slam_map = SimpleNamespace(
+        floor_plan_is_current=MagicMock(return_value=False),
+        mission_identity=first_identity,
+        async_add_listener=MagicMock(return_value=MagicMock()),
+    )
+
+    async def refresh_floor_plan() -> None:
+        if coordinator.async_request_floor_plan_refresh.await_count == 5:
+            slam_map.mission_identity = second_identity
+
+    coordinator = SimpleNamespace(
+        data=SimpleNamespace(
+            floor_plan=FloorPlan(42, "synthetic-partition", b"partition", ())
+        ),
+        async_request_floor_plan_refresh=AsyncMock(side_effect=refresh_floor_plan),
+    )
+
+    with patch("custom_components.matic_robot.asyncio.sleep", new_callable=AsyncMock):
+        _register_slam_map_floor_plan_sync(hass, entry, slam_map, coordinator)
+        await scheduled[0]
+
+    assert coordinator.async_request_floor_plan_refresh.await_count == 5
+    assert len(scheduled) == 2
+    scheduled[1].close()
 
 
 async def test_slam_map_sync_waits_for_live_session_revalidation(hass) -> None:


### PR DESCRIPTION
## Summary
- keep verified floor transitions fail-closed after the fast refresh burst
- retry stale floor-plan identity at bounded exponential intervals until it converges
- abandon obsolete recovery immediately when the live mission or session changes
- cover delayed convergence and transition race exits

## Verification
- 1,148 tests passed with 100% coverage
- Ruff check and format check
- mypy strict
- public-tree privacy check
- 61 Playwright browser tests

Fixes the RC7 live case where both map streams were complete and verified but the floor-plan identity remained stale after the one bounded refresh sequence.