### PR TITLE
Prepare v0.4 floor recovery and intelligent-stop fixes

### DIFF
--- a/custom_components/matic_robot/__init__.py
+++ b/custom_components/matic_robot/__init__.py
@@ -299,7 +299,9 @@ def _register_slam_map_floor_plan_sync(
                         # this task releases its guard.
                         last_attempted_identity = None
                         return
-                    await coordinator.async_request_floor_plan_refresh()
+                    await coordinator.async_request_floor_plan_refresh(
+                        identity.mission_id
+                    )
                     if slam_map.mission_identity != identity or not getattr(
                         slam_map, "live_session_verified", True
                     ):
@@ -337,7 +339,7 @@ def _register_slam_map_floor_plan_sync(
                     floor_plan
                 ):
                     return
-                await coordinator.async_request_floor_plan_refresh()
+                await coordinator.async_request_floor_plan_refresh(identity.mission_id)
                 if slam_map.mission_identity != identity or not getattr(
                     slam_map, "live_session_verified", True
                 ):

--- a/custom_components/matic_robot/client/api.py
+++ b/custom_components/matic_robot/client/api.py
@@ -586,9 +586,8 @@ class MaticHermesClient(AbstractAsyncContextManager["MaticHermesClient"]):
             # therefore represents the currently displayed mission.
             mission_state = mission_states[-1]
             coverage_ids = {plan.mission_id for plan in floor_plans}
-            if coverage_ids != {
-                floor.mission_id for floor in mission_state.mapped_floors
-            }:
+            canonical_ids = {floor.mission_id for floor in mission_state.mapped_floors}
+            if not canonical_ids or not canonical_ids.issubset(coverage_ids):
                 raise DecodeError(
                     "coverage plan and canonical floor identities disagree"
                 )

--- a/custom_components/matic_robot/manifest.json
+++ b/custom_components/matic_robot/manifest.json
@@ -22,7 +22,8 @@
     "grpclib==0.4.9",
     "h2>=4",
     "numpy==2.3.2",
-    "protobuf>=6"
+    "protobuf>=6",
+    "voluptuous>=0.15"
   ],
   "version": "0.3.12",
   "zeroconf": [

--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -1745,7 +1745,7 @@ def _active_elapsed_seconds(active: Mapping[str, Any], now: datetime) -> int:
             segment_elapsed = (now - parsed).total_seconds()
             if math.isfinite(segment_elapsed):
                 elapsed += max(0.0, segment_elapsed)
-    return max(0, round(elapsed))
+    return max(0, math.floor(elapsed))
 
 
 def _duration_history(record: Mapping[str, Any]) -> list[int]:
@@ -1833,7 +1833,7 @@ def _estimated_progress(active: object, expected: object) -> int | None:
     if not isinstance(active, Mapping):
         return None
     elapsed = _active_elapsed_seconds(active, dt_util.utcnow())
-    return max(0, min(100, round((elapsed / expected) * 100)))
+    return max(0, min(100, math.floor((elapsed / expected) * 100)))
 
 
 def resolve_room_reference(

--- a/custom_components/matic_robot/stop_return.py
+++ b/custom_components/matic_robot/stop_return.py
@@ -30,6 +30,10 @@ from .plans import OEM_STOP_FENCE_SECONDS, CleaningPlanManager
 
 DOCK_SETTLE_POLL_SECONDS = 3
 DOCK_SETTLE_TIMEOUT_SECONDS = OEM_STOP_FENCE_SECONDS
+# Coordinator state can still show the pre-STOP task for one refresh. Keep
+# that stale edge from abandoning the settlement watcher, but stop waiting if
+# cleaning or pause persists long enough to be replacement work.
+DOCK_SETTLE_TRANSITION_GRACE_SECONDS = 60
 
 SETTLED_STATE = "idle"
 HOMEWARD_STATES = frozenset({"docked", "returning"})
@@ -58,17 +62,30 @@ async def async_dock_when_stop_settles(
     entity_id: str,
 ) -> bool:
     """Dock once the stopped task ends and report whether DOCK was sent."""
-    deadline = monotonic() + DOCK_SETTLE_TIMEOUT_SECONDS
+    started = monotonic()
+    deadline = started + DOCK_SETTLE_TIMEOUT_SECONDS
+    transition_grace_deadline = min(
+        deadline, started + DOCK_SETTLE_TRANSITION_GRACE_SECONDS
+    )
+    settled_state_observed = False
     while True:
         if not manager.stop_pending(serial_number):
             return False
+        now = monotonic()
+        refresh_transition = False
         state = hass.states.get(entity_id)
         if state is not None:
             if state.state in HOMEWARD_STATES:
                 return False
             if state.state in REPLACEMENT_STATES:
-                return False
-            if state.state == SETTLED_STATE:
+                # The first state read commonly still reflects the task that
+                # accepted STOP. Refresh through that bounded transition edge;
+                # a later or persistent cleaning state is replacement motion.
+                if settled_state_observed or now >= transition_grace_deadline:
+                    return False
+                refresh_transition = True
+            elif state.state == SETTLED_STATE:
+                settled_state_observed = True
                 try:
                     active = await client.async_has_active_cleaning_session()
                 except MaticError as err:
@@ -88,9 +105,11 @@ async def async_dock_when_stop_settles(
                         return False
                     await refresh()
                     return True
-        if monotonic() >= deadline:
+        if now >= deadline:
             return False
         await asyncio.sleep(DOCK_SETTLE_POLL_SECONDS)
+        if refresh_transition:
+            await refresh()
 
 
 def schedule_dock_after_stop(

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -352,8 +352,10 @@ least three successful runs. A stop below the configured threshold remains
 immediate; at or above it, the current room completes and the robot docks: the
 next leg is never dispatched, and inside a leg the managed STOP is sent at the
 observed room boundary so later rooms remain due. Until a confident compatible duration exists,
-enabling the policy means the current room finishes. Set the threshold to `0%`
-to always finish it. This is a time-based estimate, not a measured area
+enabling the policy means the current room finishes. At a configured boundary
+the estimate rounds down, so progress just below the threshold still stops
+immediately while the exact threshold finishes the room. Set the threshold to
+`0%` to always finish it. This is a time-based estimate, not a measured area
 percentage; pauses, recharge, and other delays can reduce its accuracy.
 
 Use **Run all — top to bottom** when every selected room should always clean in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
   "Pillow>=11",
   "numpy==2.3.2",
   "protobuf>=6",
+  "voluptuous>=0.15",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_api_paths.py
+++ b/tests/test_api_paths.py
@@ -1372,6 +1372,33 @@ async def test_multi_floor_read_selects_the_verified_active_mission(
     )
 
 
+async def test_multi_floor_read_ignores_unreferenced_coverage_partitions(
+    monkeypatch,
+) -> None:
+    client = MaticHermesClient("robot.invalid", 16320)
+    stale = FloorPlan(21, "stale", b"stale", ())
+    active = FloorPlan(42, "active", b"active", ())
+    active_floor = MappedFloor(42, "Main", "1" * 64)
+    client.async_get_property = AsyncMock(return_value=b"coverage")
+    client.async_get_tracked_collection_entries = AsyncMock(
+        return_value=(HermesCollectionEntry(b"state", b"state"),)
+    )
+    monkeypatch.setattr(
+        "custom_components.matic_robot.client.api.decode_floor_plans",
+        lambda _payload: (stale, active),
+    )
+    monkeypatch.setattr(
+        "custom_components.matic_robot.client.api.decode_mission_client_state",
+        lambda _payload: MissionClientState(active_floor, (active_floor,)),
+    )
+
+    selected = await client.async_get_floor_plan()
+
+    assert selected.mission_id == 42
+    assert selected.floor_label == "Main"
+    assert selected.mapped_floors == (active_floor,)
+
+
 async def test_multi_floor_read_prefers_verified_live_map_mission(
     monkeypatch,
 ) -> None:
@@ -1466,7 +1493,10 @@ async def test_single_floor_read_needs_no_mission_catalog(monkeypatch) -> None:
             (HermesCollectionEntry(b"", b"state"),),
             MissionClientState(
                 MappedFloor(42, "Main", "1" * 64),
-                (MappedFloor(42, "Main", "1" * 64),),
+                (
+                    MappedFloor(42, "Main", "1" * 64),
+                    MappedFloor(126, "Other", "3" * 64),
+                ),
             ),
             "canonical floor identities disagree",
         ),

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -179,6 +179,10 @@ async def test_slam_map_transition_recovers_after_fast_retry_budget(hass) -> Non
         await scheduled[0]
 
     assert coordinator.async_request_floor_plan_refresh.await_count == 6
+    assert all(
+        request.args == (43,)
+        for request in coordinator.async_request_floor_plan_refresh.await_args_list
+    )
     assert sleep.await_args_list == [
         ((FLOOR_PLAN_TRANSITION_REFRESH_RETRY_SECONDS,), {}),
         ((FLOOR_PLAN_TRANSITION_REFRESH_BACKOFF_SECONDS,), {}),
@@ -335,7 +339,7 @@ async def test_slam_map_sync_waits_for_live_session_revalidation(hass) -> None:
     assert len(scheduled) == 1
     await scheduled[0]
 
-    coordinator.async_request_floor_plan_refresh.assert_awaited_once()
+    coordinator.async_request_floor_plan_refresh.assert_awaited_once_with(43)
     entry.async_on_unload.assert_called_once_with(remove_listener)
 
 
@@ -571,7 +575,7 @@ async def test_slam_map_transition_refreshes_a_missing_cached_floor_plan(hass) -
     assert len(scheduled) == 1
     await scheduled[0]
 
-    coordinator.async_request_floor_plan_refresh.assert_awaited_once()
+    coordinator.async_request_floor_plan_refresh.assert_awaited_once_with(43)
     slam_map.floor_plan_is_current.assert_called_with(floor_plan)
 
 

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -5064,3 +5064,48 @@ def test_entry_lookup_rejects_missing_registry_entry() -> None:
         pytest.raises(ServiceValidationError, match="unavailable"),
     ):
         _entry_for_entity(SimpleNamespace(), "vacuum.matic")
+
+
+async def test_finish_room_threshold_never_rounds_progress_up(hass) -> None:
+    """Just-below progress stops now; the exact threshold finishes the room."""
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    room = _room("Kitchen", "room-kitchen")
+    await manager.async_save_plan(
+        "serial",
+        "away",
+        {
+            "name": "Away",
+            "finish_current_room": True,
+            "finish_current_room_threshold": 50,
+            "rooms": [],
+        },
+    )
+    for _ in range(3):
+        manager.prepare_run("serial")
+        await manager.async_mark_started("serial", "away", room)
+        await manager.async_mark_completed("serial", "away", room, duration_seconds=100)
+
+    lock = manager.lock("serial")
+    await lock.acquire()
+    try:
+        manager.prepare_run("serial")
+        await manager.async_mark_started("serial", "away", room)
+        active = manager._data["robots"]["serial"]["active_plan"]
+        active["active_elapsed_seconds"] = 49.9
+        active["active_segment_started"] = None
+
+        assert manager.request_stop("serial") == PlanStopDecision("immediate", 49, 50)
+        assert manager.cancellation_event("serial").is_set()
+
+        manager.prepare_run("serial")
+        await manager.async_mark_started("serial", "away", room)
+        active = manager._data["robots"]["serial"]["active_plan"]
+        active["active_elapsed_seconds"] = 50.0
+        active["active_segment_started"] = None
+
+        assert manager.request_stop("serial") == PlanStopDecision("after_room", 50, 50)
+        assert manager.finish_room_event("serial").is_set()
+        assert not manager.cancellation_event("serial").is_set()
+    finally:
+        lock.release()

--- a/tests/test_stop_return.py
+++ b/tests/test_stop_return.py
@@ -78,12 +78,51 @@ async def test_skips_when_the_robot_is_already_home_or_heading_there(
 
 
 @pytest.mark.parametrize("state", ["cleaning", "paused"])
-async def test_skips_when_new_work_replaced_the_stop(hass, state: str) -> None:
+async def test_skips_when_new_work_replaced_the_stop(
+    hass, state: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(stop_return, "DOCK_SETTLE_TRANSITION_GRACE_SECONDS", 0)
     hass.states.async_set(ENTITY, state, {})
     client = _client(session=False)
 
     assert await _run(hass, client, _manager()) is False
     client.async_send_user_command.assert_not_awaited()
+
+
+@pytest.mark.parametrize("state", ["cleaning", "paused"])
+async def test_refreshes_past_the_stale_pre_stop_state_before_docking(
+    hass, state: str
+) -> None:
+    """The accepted STOP can settle before the coordinator leaves cleaning."""
+    hass.states.async_set(ENTITY, state, {})
+    client = _client(session=False)
+
+    def settle_state() -> None:
+        hass.states.async_set(ENTITY, "idle", {})
+
+    refresh = AsyncMock(side_effect=settle_state)
+
+    assert await _run(hass, client, _manager(), refresh) is True
+    client.async_send_user_command.assert_awaited_once_with(UserCommand.DOCK)
+    assert refresh.await_count == 2
+
+
+async def test_abandons_when_new_work_starts_after_stop_settlement(hass) -> None:
+    """A post-settlement cleaning edge belongs to replacement motion."""
+    hass.states.async_set(ENTITY, "idle", {})
+    client = _client(session=True)
+
+    async def start_replacement() -> bool:
+        hass.states.async_set(ENTITY, "cleaning", {})
+        return True
+
+    client.async_has_active_cleaning_session = AsyncMock(side_effect=start_replacement)
+    refresh = AsyncMock()
+
+    assert await _run(hass, client, _manager(), refresh) is False
+    client.async_has_active_cleaning_session.assert_awaited_once()
+    client.async_send_user_command.assert_not_awaited()
+    refresh.assert_not_awaited()
 
 
 async def test_skips_when_the_stop_fence_was_cleared(hass) -> None:


### PR DESCRIPTION
## v0.4 runtime scope

### Floor-plan recovery and Home Assistant 2026.9 compatibility

- tolerate unrelated stale coverage-plan partitions while still requiring every canonical mapped floor identity to be present
- carry the verified live SLAM mission ID through both rapid and long-running floor-plan recovery reads
- keep multi-floor selection fail-closed when the verified mission does not identify exactly one canonical floor
- declare the integration's direct `voluptuous` dependency explicitly so packaged and fresh installations remain self-contained

### Intelligent rotation stop, return, and finish threshold

- keep the post-STOP settlement watcher alive through the coordinator's brief stale `cleaning` or `paused` state
- actively refresh only during that bounded transition edge, then send `DOCK` once the robot is idle and its native active-session property is false
- abandon automatic docking when replacement work persists or begins after settlement, and avoid duplicate docking when the robot is already returning or docked
- round active cleaning time and estimated progress down so progress below the configured threshold cannot be promoted across the boundary
- preserve exact-threshold finish behavior, `0%` always-finish behavior, compatible-duration learning, and exclusion of paused/recharge time

Fixes #65
Fixes #71

## Validation

The combined branch was built from the previously validated floor-recovery head and published only after:

- targeted API and SLAM synchronization suite: 22 passed on the floor-recovery change
- focused stop-return and plan-manager suites: 142 passed
- full Python suite: 1,197 passed with 100% coverage (10,926 statements, 0 missing)
- Ruff lint and formatting: passed
- strict mypy: passed for 49 source files
- public-tree privacy validation: passed
- source distribution and wheel builds: passed
- release-artifact validation: passed
- isolated fresh-install import: passed
- HACS, hassfest, Chromium, and WebKit passed on the preceding floor-recovery head; exact-head hosted Test, Validate, and Browser UI workflows are rerunning after the combined commit

## Release boundary

This PR contains the runtime fixes intended for v0.4 but does not bump the version, create a tag, publish a release, or enable automatic merge. Final acceptance should cover the reported v172 floor-recovery case and the real geofence stop/finish paths described in the handoff comment before the release commit is cut.
