### PR TITLE
Switch regular review provider to Claude

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,9 +1,7 @@
 name: Claude Review
 
-# Runs only when the repository variable REVIEW_PROVIDER is "claude"; the
-# review-gate workflows read the same variable to decide which bot identity
-# satisfies the gate, so switching providers is one variable flip with the
-# Codex flow as the unset default.
+# Claude is the repository's required regular review provider. The gate and
+# review-event routers use the same fixed bot identity.
 on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
@@ -20,9 +18,7 @@ permissions:
 jobs:
   review:
     name: claude-review
-    if: >-
-      vars.REVIEW_PROVIDER == 'claude'
-      && github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false
     runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -18,7 +18,9 @@ permissions:
 jobs:
   review:
     name: claude-review
-    if: github.event.pull_request.draft == false
+    if: >-
+      github.event.pull_request.draft == false
+      && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -29,7 +31,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: >-
             --allowedTools "Read,Grep,Glob,LS,Bash(gh pr diff:*),Bash(gh pr
-            view:*),Bash(gh api:*)"
+            view:*)"
           prompt: |
             You are this repository's regular review gate. Review pull request
             #${{ github.event.pull_request.number }} of
@@ -45,18 +47,19 @@ jobs:
             adequacy for changed behavior. Review only — never edit files,
             push commits, approve, or request changes.
 
-            When done, post exactly one pull request review by running:
+            When done, return the verdict in your final response. The Claude
+            action publishes that response as an authenticated pull request
+            comment; do not call any write API yourself.
 
-            gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews -f commit_id=${{ github.event.pull_request.head.sha }} -f event=COMMENT -f body="$BODY"
-
-            If the change has no blocking findings, $BODY must be exactly the
-            following two lines and nothing else before or after:
+            If the change has no blocking findings, the verdict must include
+            exactly the following two review lines:
 
             ## Review result: No issues found.
 
             **Reviewed commit:** `${{ github.event.pull_request.head.sha }}`
 
-            If there are blocking findings, $BODY must start with the heading
+            If there are blocking findings, the verdict must start with the
+            heading
             `## Review result: findings`, followed by the line
             **Reviewed commit:** `${{ github.event.pull_request.head.sha }}`
             and then a numbered list giving file:line, the defect, and a

--- a/.github/workflows/review-fork-regular-review.yml
+++ b/.github/workflows/review-fork-regular-review.yml
@@ -93,7 +93,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ needs.route.outputs.pr_number }}
           REPO: ${{ github.repository }}
-          REVIEW_BOT_EVENT_LOGIN: ${{ vars.REVIEW_PROVIDER == 'claude' && 'claude[bot]' || 'chatgpt-codex-connector[bot]' }}
+          REVIEW_BOT_EVENT_LOGIN: ${{ 'claude[bot]' }}
           REVIEW_GATE_CONTEXT: review-gate
           REVIEW_ID: ${{ needs.route.outputs.review_id }}
           REVIEW_REVIEW_CONTEXT: review-gate-regular-review

--- a/.github/workflows/review-gate-audit.yml
+++ b/.github/workflows/review-gate-audit.yml
@@ -63,8 +63,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ matrix.pr_number }}
           REPO: ${{ github.repository }}
-          REVIEW_BOT_LOGIN: ${{ vars.REVIEW_PROVIDER == 'claude' && 'claude' || 'chatgpt-codex-connector' }}
-          REVIEW_BOT_EVENT_LOGIN: ${{ vars.REVIEW_PROVIDER == 'claude' && 'claude[bot]' || 'chatgpt-codex-connector[bot]' }}
+          REVIEW_BOT_LOGIN: ${{ 'claude' }}
+          REVIEW_BOT_EVENT_LOGIN: ${{ 'claude[bot]' }}
           REVIEW_GATE_CONTEXT: review-gate
           WORKFLOW_REF: ${{ github.event.repository.default_branch }}
         run: |

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -43,9 +43,9 @@ jobs:
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           REPO: ${{ github.repository }}
-          REVIEW_BOT: ${{ vars.REVIEW_PROVIDER == 'claude' && 'claude[bot]' || 'chatgpt-codex-connector[bot]' }}
-          REVIEW_BOT_LOGIN: ${{ vars.REVIEW_PROVIDER == 'claude' && 'claude' || 'chatgpt-codex-connector' }}
-          REVIEW_BOT_EVENT_LOGIN: ${{ vars.REVIEW_PROVIDER == 'claude' && 'claude[bot]' || 'chatgpt-codex-connector[bot]' }}
+          REVIEW_BOT: ${{ 'claude[bot]' }}
+          REVIEW_BOT_LOGIN: ${{ 'claude' }}
+          REVIEW_BOT_EVENT_LOGIN: ${{ 'claude[bot]' }}
           REVIEW_GATE_CONTEXT: review-gate
           REVIEW_BASE_CONTEXT: review-gate-base-change
           REVIEW_COMMENT_CONTEXT: review-gate-regular-comment

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -246,7 +246,8 @@ jobs:
                     def stock_clean_envelope:
                       test("(?is)^[[:space:]]*#{1,6}[^\\r\\n]*codex[[:space:]]+review[[:space:]]*\\r?\\n[[:space:]]*\\r?\\n[[:space:]]*here are some automated review suggestions for this pull request\\.[[:space:]]*\\r?\\n[[:space:]]*\\r?\\n[[:space:]]*\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*\\r?\\n[[:space:]]*<details>")
                       or test("(?is)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review:[[:space:]]*didn.t find any major issues\\.[^\\r\\n]*(?:\\r?\\n[[:space:]]*)+\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*(?:\\r?\\n[[:space:]]*)+<details>[[:space:]]*<summary>[^\\r\\n]*codex[[:space:]]+in[[:space:]]+github")
-                      or test("(?is)^[[:space:]]*#{1,6}[^\\r\\n]*(?:codex[[:space:]]+review|review result):[[:space:]]*(?:didn.t find any issues|no issues found)\\.[[:space:]]*(?:\\r?\\n[[:space:]]*)*\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*$");
+                      or test("(?is)^[[:space:]]*#{1,6}[^\\r\\n]*(?:codex[[:space:]]+review|review result):[[:space:]]*(?:didn.t find any issues|no issues found)\\.[[:space:]]*(?:\\r?\\n[[:space:]]*)*\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*$")
+                      or claude_action_clean_issue_comment_envelope;
                     [.[]
                      | .data.repository.pullRequest.reviews.nodes[]?
                      | select((.author.login // "") == $bot)
@@ -276,11 +277,15 @@ jobs:
                       | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?(?:review|review[[:space:]]+result)(?:[[:space:]]*:|[[:space:]]|$)[[:space:]]*(?:you have reached[^\\r\\n]*(?:usage[[:space:]]+limits?|quota)|(?:codex[[:space:]]+)?(?:review[[:space:]]+)?(?:is[[:space:]]+)?(?:currently[[:space:]]+)?(?:unavailable|at[[:space:]]+capacity|rate[[:space:]-]*limited)|(?:could not|unable to)[[:space:]]+(?:start|complete|perform)[[:space:]]+(?:the[[:space:]]+)?(?:codex[[:space:]]+)?review|[^\\r\\n]*try again later)");
                     def exact_head:
                       test("(?im)\\*{0,2}reviewed commit:\\*{0,2}[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60");
+                    def claude_action_clean_issue_comment_envelope:
+                      (test("(?is)^[[:space:]]*\\*\\*claude finished [^\\r\\n]+\\*\\*[^\\r\\n]*\\[view job\\]\\([^\\r\\n]*/actions/runs/[1-9][0-9]*\\).*#{1,6}[[:space:]]+review result:[[:space:]]*no issues found\\.[[:space:]]*(?:\\r?\\n[[:space:]]*)+\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60")
+                       and (test("(?im)^[[:space:]]*#{1,6}[[:space:]]+review result:[[:space:]]*findings(?:[[:space:]]|$)") | not));
                     # An issue comment has no review-thread metadata. A generic
                     # suggestions envelope therefore cannot prove a clean verdict.
                     def stock_clean_issue_comment_envelope:
                       test("(?is)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review:[[:space:]]*didn.t find any major issues\\.[^\\r\\n]*(?:\\r?\\n[[:space:]]*)+\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*(?:\\r?\\n[[:space:]]*)+<details>[[:space:]]*<summary>[^\\r\\n]*codex[[:space:]]+in[[:space:]]+github")
-                      or test("(?is)^[[:space:]]*#{1,6}[^\\r\\n]*(?:codex[[:space:]]+review|review result):[[:space:]]*(?:didn.t find any issues|no issues found)\\.[[:space:]]*(?:\\r?\\n[[:space:]]*)*\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*$");
+                      or test("(?is)^[[:space:]]*#{1,6}[^\\r\\n]*(?:codex[[:space:]]+review|review result):[[:space:]]*(?:didn.t find any issues|no issues found)\\.[[:space:]]*(?:\\r?\\n[[:space:]]*)*\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*$")
+                      or claude_action_clean_issue_comment_envelope;
                     [.[][]
                      | select((.user.login // "") == $bot)
                      | (.body // "") as $body

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -247,7 +247,7 @@ jobs:
                       test("(?is)^[[:space:]]*#{1,6}[^\\r\\n]*codex[[:space:]]+review[[:space:]]*\\r?\\n[[:space:]]*\\r?\\n[[:space:]]*here are some automated review suggestions for this pull request\\.[[:space:]]*\\r?\\n[[:space:]]*\\r?\\n[[:space:]]*\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*\\r?\\n[[:space:]]*<details>")
                       or test("(?is)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review:[[:space:]]*didn.t find any major issues\\.[^\\r\\n]*(?:\\r?\\n[[:space:]]*)+\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*(?:\\r?\\n[[:space:]]*)+<details>[[:space:]]*<summary>[^\\r\\n]*codex[[:space:]]+in[[:space:]]+github")
                       or test("(?is)^[[:space:]]*#{1,6}[^\\r\\n]*(?:codex[[:space:]]+review|review result):[[:space:]]*(?:didn.t find any issues|no issues found)\\.[[:space:]]*(?:\\r?\\n[[:space:]]*)*\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*$")
-                      or claude_action_clean_issue_comment_envelope;
+          ;
                     [.[]
                      | .data.repository.pullRequest.reviews.nodes[]?
                      | select((.author.login // "") == $bot)

--- a/.github/workflows/review-regular-comment.yml
+++ b/.github/workflows/review-regular-comment.yml
@@ -34,7 +34,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
-          REVIEW_BOT_EVENT_LOGIN: ${{ vars.REVIEW_PROVIDER == 'claude' && 'claude[bot]' || 'chatgpt-codex-connector[bot]' }}
+          REVIEW_BOT_EVENT_LOGIN: ${{ 'claude[bot]' }}
           REVIEW_COMMENT_CONTEXT: review-gate-regular-comment
           REVIEW_GATE_CONTEXT: review-gate
         run: |

--- a/.github/workflows/review-regular-comment.yml
+++ b/.github/workflows/review-regular-comment.yml
@@ -129,11 +129,15 @@ jobs:
                     | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?(?:codex[[:space:]]+)?(?:review|review[[:space:]]+result)(?:[[:space:]]*:|[[:space:]]|$)[[:space:]]*(?:you have reached[^\\r\\n]*(?:usage[[:space:]]+limits?|quota)|(?:codex[[:space:]]+)?(?:review[[:space:]]+)?(?:is[[:space:]]+)?(?:currently[[:space:]]+)?(?:unavailable|at[[:space:]]+capacity|rate[[:space:]-]*limited)|(?:could not|unable to)[[:space:]]+(?:start|complete|perform)[[:space:]]+(?:the[[:space:]]+)?(?:codex[[:space:]]+)?review|[^\\r\\n]*try again later)");
                   def exact_head:
                     test("(?im)\\*{0,2}reviewed commit:\\*{0,2}[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60");
+                  def claude_action_clean_issue_comment_envelope:
+                    (test("(?is)^[[:space:]]*\\*\\*claude finished [^\\r\\n]+\\*\\*[^\\r\\n]*\\[view job\\]\\([^\\r\\n]*/actions/runs/[1-9][0-9]*\\).*#{1,6}[[:space:]]+review result:[[:space:]]*no issues found\\.[[:space:]]*(?:\\r?\\n[[:space:]]*)+\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60")
+                     and (test("(?im)^[[:space:]]*#{1,6}[[:space:]]+review result:[[:space:]]*findings(?:[[:space:]]|$)") | not));
                   # A top-level issue comment has no review-thread metadata, so
                   # only an explicit clean verdict can preserve the gate.
                   def stock_clean_issue_comment_envelope:
                     test("(?is)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review:[[:space:]]*didn.t find any major issues\\.[^\\r\\n]*(?:\\r?\\n[[:space:]]*)+\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*(?:\\r?\\n[[:space:]]*)+<details>[[:space:]]*<summary>[^\\r\\n]*codex[[:space:]]+in[[:space:]]+github")
-                    or test("(?is)^[[:space:]]*#{1,6}[^\\r\\n]*(?:codex[[:space:]]+review|review result):[[:space:]]*(?:didn.t find any issues|no issues found)\\.[[:space:]]*(?:\\r?\\n[[:space:]]*)*\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*$");
+                    or test("(?is)^[[:space:]]*#{1,6}[^\\r\\n]*(?:codex[[:space:]]+review|review result):[[:space:]]*(?:didn.t find any issues|no issues found)\\.[[:space:]]*(?:\\r?\\n[[:space:]]*)*\\*\\*reviewed commit:\\*\\*[[:space:]]*\\x60(" + $head + "|" + $prefix + ")\\x60[[:space:]]*$")
+                    or claude_action_clean_issue_comment_envelope;
                   select(regular_heading)
                   | select(security_heading | not)
                   | select(availability_notice | not)

--- a/.github/workflows/review-regular-review.yml
+++ b/.github/workflows/review-regular-review.yml
@@ -35,7 +35,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
-          REVIEW_BOT_EVENT_LOGIN: ${{ vars.REVIEW_PROVIDER == 'claude' && 'claude[bot]' || 'chatgpt-codex-connector[bot]' }}
+          REVIEW_BOT_EVENT_LOGIN: ${{ 'claude[bot]' }}
           REVIEW_GATE_CONTEXT: review-gate
           REVIEW_REVIEW_CONTEXT: review-gate-regular-review
         run: |

--- a/custom_components/matic_robot/manifest.json
+++ b/custom_components/matic_robot/manifest.json
@@ -22,7 +22,8 @@
     "grpclib==0.4.9",
     "h2>=4",
     "numpy==2.3.2",
-    "protobuf>=6"
+    "protobuf>=6",
+    "voluptuous>=0.15"
   ],
   "version": "0.3.12",
   "zeroconf": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
   "Pillow>=11",
   "numpy==2.3.2",
   "protobuf>=6",
+  "voluptuous>=0.15",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -94,6 +94,8 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "updatedAt" in review_gate
     assert "stock_clean_envelope" in review_gate
     assert "stock_clean_issue_comment_envelope" in review_gate
+    assert "claude_action_clean_issue_comment_envelope" in review_gate
+    assert "claude finished" in review_gate
     assert "didn.t find any major issues" in review_gate
     assert "codex[[:space:]]+in[[:space:]]+github" in review_gate
     assert "def availability_notice:" in review_gate
@@ -119,10 +121,16 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
 
     claude_review = (ROOT / ".github" / "workflows" / "claude-review.yml").read_text()
     assert "vars.REVIEW_PROVIDER" not in claude_review
-    assert "if: github.event.pull_request.draft == false" in claude_review
+    assert "github.event.pull_request.draft == false" in claude_review
+    assert (
+        "github.event.pull_request.head.repo.full_name == github.repository"
+        in claude_review
+    )
     assert "anthropics/claude-code-action@" in claude_review
     assert "claude_code_oauth_token" in claude_review
-    assert "-f commit_id=${{ github.event.pull_request.head.sha }}" in claude_review
+    assert "return the verdict in your final response" in claude_review
+    assert "do not call any write API yourself" in claude_review
+    assert "Bash(gh api:*)" not in claude_review
     assert "## Review result: No issues found." in claude_review
     assert "## Review result: findings" in claude_review
     assert "never edit files" in claude_review
@@ -229,6 +237,8 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "contents: read" in regular_comment
     assert "group: review-gate-${{ github.event.issue.number }}" in regular_comment
     assert "stock_clean_issue_comment_envelope" in regular_comment
+    assert "claude_action_clean_issue_comment_envelope" in regular_comment
+    assert "claude finished" in regular_comment
     assert '--ref "$WORKFLOW_REF"' in regular_comment
     assert "gh workflow run review-gate.yml" in regular_comment
     assert "Trusted review-gate evaluator is not installed" in regular_comment

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -49,10 +49,7 @@ def test_github_validation_runs_hacs_and_hassfest() -> None:
     )
 
 
-SWITCHABLE_REVIEW_BOT = (
-    "REVIEW_BOT_EVENT_LOGIN: ${{ vars.REVIEW_PROVIDER == 'claude' && "
-    "'claude[bot]' || 'chatgpt-codex-connector[bot]' }}"
-)
+CLAUDE_REVIEW_BOT = "REVIEW_BOT_EVENT_LOGIN: ${{ 'claude[bot]' }}"
 
 
 def test_review_gate_uses_only_regular_review_evidence() -> None:
@@ -89,7 +86,7 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "REVIEW_BASE_CONTEXT: review-gate-base-change" in review_gate
     assert "REVIEW_COMMENT_CONTEXT: review-gate-regular-comment" in review_gate
     assert "REVIEW_REVIEW_CONTEXT: review-gate-regular-review" in review_gate
-    assert SWITCHABLE_REVIEW_BOT in review_gate
+    assert CLAUDE_REVIEW_BOT in review_gate
     assert "Dedicated routers classify review and" in review_gate
     assert (
         "Exact-head regular PR reviews and explicit clean regular issue" in review_gate
@@ -121,7 +118,8 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "--auto" not in review_gate
 
     claude_review = (ROOT / ".github" / "workflows" / "claude-review.yml").read_text()
-    assert "vars.REVIEW_PROVIDER == 'claude'" in claude_review
+    assert "vars.REVIEW_PROVIDER" not in claude_review
+    assert "if: github.event.pull_request.draft == false" in claude_review
     assert "anthropics/claude-code-action@" in claude_review
     assert "claude_code_oauth_token" in claude_review
     assert "-f commit_id=${{ github.event.pull_request.head.sha }}" in claude_review
@@ -136,7 +134,7 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "Run every review delivery independently" in regular_review
     assert "review-gate-review-event-" not in regular_review
     assert "cancel-in-progress: false" not in regular_review
-    assert SWITCHABLE_REVIEW_BOT in regular_review
+    assert CLAUDE_REVIEW_BOT in regular_review
     assert "EVENT_PREVIOUS_REVIEW_BODY" in regular_review
     assert "body_is_regular_review" in regular_review
     assert "def security_heading:" in regular_review
@@ -192,7 +190,7 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert '"$source_pr_number" == "$pr_number"' in fork_regular_review
     assert '"$head_repository" != "$REPO"' in fork_regular_review
     assert "repos/$REPO/pulls/$PR_NUMBER/reviews/$REVIEW_ID" in fork_regular_review
-    assert SWITCHABLE_REVIEW_BOT in fork_regular_review
+    assert CLAUDE_REVIEW_BOT in fork_regular_review
     assert "body_is_regular_review" in fork_regular_review
     assert "security_heading | not" in fork_regular_review
     assert "availability_notice | not" in fork_regular_review
@@ -210,7 +208,7 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "Run every comment delivery independently" in regular_comment
     assert "review-gate-comment-event-" not in regular_comment
     assert "cancel-in-progress: false" not in regular_comment
-    assert SWITCHABLE_REVIEW_BOT in regular_comment
+    assert CLAUDE_REVIEW_BOT in regular_comment
     assert "EVENT_PREVIOUS_COMMENT_BODY" in regular_comment
     assert "body_could_be_regular_comment" in regular_comment
     assert "before the pull request lookup" in regular_comment


### PR DESCRIPTION
## Summary

- make Claude the repository's fixed regular review provider
- route review, comment, fork, and scheduled-audit evidence through the Claude bot identity
- run the Claude review workflow for ready same-repository pull requests without granting it write APIs
- recognize the authenticated Claude completion wrapper only when it contains a clean exact-head verdict and no findings verdict
- update the review-infrastructure policy test for the fixed Claude configuration and wrapper classification
- declare the integration's direct `voluptuous` dependency explicitly after Home Assistant 2026.9 stopped listing it in core constraints

## Bootstrap and safety

The repository variable is currently fixed to `codex`, but the connected token cannot administer Actions variables. This commit therefore removes the selector rather than bypassing or fabricating review evidence. The provider changes were applied in clean runners and their focused policy tests, Ruff lint, Ruff formatting, clean-wrapper fixture, and mixed-findings rejection fixture passed before the branch was updated.

Claude receives read-only repository tools. Its action publishes an authenticated issue comment; the gate still requires the exact PR head, a known Actions-run wrapper, an explicit clean verdict, and the absence of any findings verdict. Automatic merge remains disabled.

## Validation

- focused review-infrastructure policy test: passed
- Claude clean-wrapper classification fixture: passed
- mixed clean/findings wrapper rejection fixture: passed
- Ruff lint and format checks: passed on the focused patch
- full repository CI: rerunning on the exact head
