### PR TITLE
Fix intelligent-plan stop return and threshold boundary

### DIFF
--- a/.github/scripts/apply_intelligent_stop_fix.py
+++ b/.github/scripts/apply_intelligent_stop_fix.py
@@ -1,0 +1,249 @@
+from pathlib import Path
+import re
+
+
+def replace_exact(path: str, old: str, new: str, expected: int = 1) -> None:
+    file = Path(path)
+    text = file.read_text()
+    actual = text.count(old)
+    if actual != expected:
+        raise SystemExit(f"{path}: expected {expected} occurrences, found {actual}")
+    file.write_text(text.replace(old, new))
+
+
+stop_path = Path("custom_components/matic_robot/stop_return.py")
+stop_text = stop_path.read_text()
+replace_target = '''DOCK_SETTLE_POLL_SECONDS = 3
+DOCK_SETTLE_TIMEOUT_SECONDS = OEM_STOP_FENCE_SECONDS
+
+SETTLED_STATE = "idle"
+'''
+replace_value = '''DOCK_SETTLE_POLL_SECONDS = 3
+DOCK_SETTLE_TIMEOUT_SECONDS = OEM_STOP_FENCE_SECONDS
+# Coordinator state can still show the pre-STOP cleaning task for one refresh.
+# Keep that stale edge from abandoning the settlement watcher, but stop waiting
+# if real replacement work persists.
+DOCK_SETTLE_TRANSITION_GRACE_SECONDS = 60
+
+SETTLED_STATE = "idle"
+'''
+if stop_text.count(replace_target) != 1:
+    raise SystemExit("stop_return.py: constants anchor did not match exactly")
+stop_text = stop_text.replace(replace_target, replace_value)
+
+function_pattern = re.compile(
+    r'''async def async_dock_when_stop_settles\(
+.*?
+
+
+def schedule_dock_after_stop\(''',
+    re.DOTALL,
+)
+function_replacement = '''async def async_dock_when_stop_settles(
+    hass: HomeAssistant,
+    *,
+    client: StopReturnClient,
+    refresh: Callable[[], Awaitable[None]],
+    manager: CleaningPlanManager,
+    serial_number: str,
+    entity_id: str,
+) -> bool:
+    """Dock once the stopped task ends and report whether DOCK was sent."""
+    started = monotonic()
+    deadline = started + DOCK_SETTLE_TIMEOUT_SECONDS
+    transition_grace_deadline = min(
+        deadline, started + DOCK_SETTLE_TRANSITION_GRACE_SECONDS
+    )
+    settled_state_observed = False
+    while True:
+        if not manager.stop_pending(serial_number):
+            return False
+        now = monotonic()
+        state = hass.states.get(entity_id)
+        if state is not None:
+            if state.state in HOMEWARD_STATES:
+                return False
+            if state.state in REPLACEMENT_STATES:
+                # The first state read commonly still reflects the task that
+                # accepted STOP. Refresh through that bounded transition edge;
+                # a later or persistent cleaning state is replacement motion.
+                if settled_state_observed or now >= transition_grace_deadline:
+                    return False
+            elif state.state == SETTLED_STATE:
+                settled_state_observed = True
+                try:
+                    active = await client.async_has_active_cleaning_session()
+                except MaticError as err:
+                    _LOGGER.debug(
+                        "Native Matic stop settlement unreadable (%s)",
+                        type(err).__name__,
+                    )
+                    active = None
+                if active is False:
+                    try:
+                        await client.async_send_user_command(UserCommand.DOCK)
+                    except MaticError as err:
+                        _LOGGER.warning(
+                            "Unable to dock Matic after its stop settled (%s)",
+                            type(err).__name__,
+                        )
+                        return False
+                    await refresh()
+                    return True
+        if now >= deadline:
+            return False
+        await asyncio.sleep(DOCK_SETTLE_POLL_SECONDS)
+        await refresh()
+
+
+def schedule_dock_after_stop('''
+stop_text, count = function_pattern.subn(function_replacement, stop_text)
+if count != 1:
+    raise SystemExit(f"stop_return.py: expected one watcher function, found {count}")
+stop_path.write_text(stop_text)
+
+replace_exact(
+    "custom_components/matic_robot/plans.py",
+    "    return max(0, round(elapsed))\n",
+    "    return max(0, math.floor(elapsed))\n",
+)
+replace_exact(
+    "custom_components/matic_robot/plans.py",
+    "    return max(0, min(100, round((elapsed / expected) * 100)))\n",
+    "    return max(0, min(100, math.floor((elapsed / expected) * 100)))\n",
+)
+
+replace_exact(
+    "tests/test_stop_return.py",
+    '''@pytest.mark.parametrize("state", ["cleaning", "paused"])
+async def test_skips_when_new_work_replaced_the_stop(hass, state: str) -> None:
+    hass.states.async_set(ENTITY, state, {})
+    client = _client(session=False)
+
+    assert await _run(hass, client, _manager()) is False
+    client.async_send_user_command.assert_not_awaited()
+
+
+''',
+    '''@pytest.mark.parametrize("state", ["cleaning", "paused"])
+async def test_skips_when_new_work_replaced_the_stop(
+    hass, state: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(stop_return, "DOCK_SETTLE_TRANSITION_GRACE_SECONDS", 0)
+    hass.states.async_set(ENTITY, state, {})
+    client = _client(session=False)
+
+    assert await _run(hass, client, _manager()) is False
+    client.async_send_user_command.assert_not_awaited()
+
+
+@pytest.mark.parametrize("state", ["cleaning", "paused"])
+async def test_refreshes_past_the_stale_pre_stop_state_before_docking(
+    hass, state: str
+) -> None:
+    """The accepted STOP can settle before the coordinator leaves cleaning."""
+    hass.states.async_set(ENTITY, state, {})
+    client = _client(session=False)
+
+    def settle_state() -> None:
+        hass.states.async_set(ENTITY, "idle", {})
+
+    refresh = AsyncMock(side_effect=settle_state)
+
+    assert await _run(hass, client, _manager(), refresh) is True
+    client.async_send_user_command.assert_awaited_once_with(UserCommand.DOCK)
+    assert refresh.await_count == 2
+
+
+async def test_abandons_when_new_work_starts_after_stop_settlement(hass) -> None:
+    """A post-settlement cleaning edge belongs to replacement motion."""
+    hass.states.async_set(ENTITY, "idle", {})
+    client = _client(session=True)
+
+    def start_replacement() -> None:
+        hass.states.async_set(ENTITY, "cleaning", {})
+
+    refresh = AsyncMock(side_effect=start_replacement)
+
+    assert await _run(hass, client, _manager(), refresh) is False
+    client.async_has_active_cleaning_session.assert_awaited_once()
+    client.async_send_user_command.assert_not_awaited()
+    refresh.assert_awaited_once()
+
+
+''',
+)
+
+plans_test = Path("tests/test_plans.py")
+plans_text = plans_test.read_text()
+new_test = '''
+
+async def test_finish_room_threshold_never_rounds_progress_up(hass) -> None:
+    """Just-below progress stops now; the exact threshold finishes the room."""
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    room = _room("Kitchen", "room-kitchen")
+    await manager.async_save_plan(
+        "serial",
+        "away",
+        {
+            "name": "Away",
+            "finish_current_room": True,
+            "finish_current_room_threshold": 50,
+            "rooms": [],
+        },
+    )
+    for _ in range(3):
+        manager.prepare_run("serial")
+        await manager.async_mark_started("serial", "away", room)
+        await manager.async_mark_completed(
+            "serial", "away", room, duration_seconds=100
+        )
+
+    lock = manager.lock("serial")
+    await lock.acquire()
+    try:
+        manager.prepare_run("serial")
+        await manager.async_mark_started("serial", "away", room)
+        active = manager._data["robots"]["serial"]["active_plan"]
+        active["active_elapsed_seconds"] = 49.9
+        active["active_segment_started"] = None
+
+        assert manager.request_stop("serial") == PlanStopDecision(
+            "immediate", 49, 50
+        )
+        assert manager.cancellation_event("serial").is_set()
+
+        manager.prepare_run("serial")
+        await manager.async_mark_started("serial", "away", room)
+        active = manager._data["robots"]["serial"]["active_plan"]
+        active["active_elapsed_seconds"] = 50.0
+        active["active_segment_started"] = None
+
+        assert manager.request_stop("serial") == PlanStopDecision(
+            "after_room", 50, 50
+        )
+        assert manager.finish_room_event("serial").is_set()
+        assert not manager.cancellation_event("serial").is_set()
+    finally:
+        lock.release()
+'''
+if "test_finish_room_threshold_never_rounds_progress_up" in plans_text:
+    raise SystemExit("tests/test_plans.py: boundary test already exists")
+plans_test.write_text(plans_text.rstrip() + new_test + "\n")
+
+replace_exact(
+    "docs/automation.md",
+    '''Until a confident compatible duration exists,
+enabling the policy means the current room finishes. Set the threshold to `0%`
+to always finish it. This is a time-based estimate, not a measured area
+percentage; pauses, recharge, and other delays can reduce its accuracy.
+''',
+    '''Until a confident compatible duration exists,
+enabling the policy means the current room finishes. At a configured boundary
+the estimate rounds down, so progress just below the threshold still stops
+immediately while the exact threshold finishes the room. Set the threshold to
+`0%` to always finish it. This is a time-based estimate, not a measured area
+percentage; pauses, recharge, and other delays can reduce its accuracy.
+''',
+)

--- a/.github/workflows/apply-intelligent-stop-fix.yml
+++ b/.github/workflows/apply-intelligent-stop-fix.yml
@@ -1,0 +1,48 @@
+name: Apply intelligent stop and threshold fix
+
+on:
+  push:
+    branches: [fix/intelligent-stop-return-threshold]
+
+permissions:
+  contents: write
+
+jobs:
+  apply:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - name: Apply exact patch
+        run: python .github/scripts/apply_intelligent_stop_fix.py
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.14"
+          cache: pip
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install -e '.[test]'
+      - name: Format patched Python
+        run: ruff format custom_components/matic_robot/stop_return.py custom_components/matic_robot/plans.py tests/test_stop_return.py tests/test_plans.py
+      - name: Run focused regressions
+        run: pytest tests/test_stop_return.py tests/test_plans.py
+      - name: Run full Python suite
+        run: pytest --cov=custom_components/matic_robot --cov-report=term-missing
+      - run: ruff check .
+      - run: ruff format --check .
+      - run: mypy custom_components/matic_robot
+      - run: python scripts/check_public_tree.py
+      - run: python -m build --sdist --wheel
+      - run: python scripts/check_release_artifacts.py dist
+      - run: python scripts/check_fresh_install.py dist
+      - name: Commit validated patch and remove temporary drivers
+        run: |
+          rm .github/scripts/apply_intelligent_stop_fix.py
+          rm .github/workflows/apply-intelligent-stop-fix.yml
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add -A
+          git commit -m 'Fix intelligent stop return and threshold boundary'
+          git push origin HEAD:fix/intelligent-stop-return-threshold

--- a/.github/workflows/certify-intelligent-stop-fix.yml
+++ b/.github/workflows/certify-intelligent-stop-fix.yml
@@ -1,0 +1,97 @@
+name: Certify intelligent stop and threshold fix
+
+on:
+  push:
+    branches: [fix/intelligent-stop-return-threshold]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: certify-intelligent-stop-return-threshold
+  cancel-in-progress: true
+
+jobs:
+  certify:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REVIEW_PROVIDER: ${{ vars.REVIEW_PROVIDER }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - name: Ensure the exact patch is present
+        run: |
+          if ! grep -q 'DOCK_SETTLE_TRANSITION_GRACE_SECONDS' custom_components/matic_robot/stop_return.py; then
+            test -f .github/scripts/apply_intelligent_stop_fix.py
+            python .github/scripts/apply_intelligent_stop_fix.py
+          fi
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.14"
+          cache: pip
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install -e '.[test]'
+      - run: ruff format custom_components/matic_robot/stop_return.py custom_components/matic_robot/plans.py tests/test_stop_return.py tests/test_plans.py
+      - name: Focused stop and threshold regressions
+        run: pytest tests/test_stop_return.py tests/test_plans.py
+      - name: Full Python release gate
+        run: pytest --cov=custom_components/matic_robot --cov-report=term-missing
+      - run: ruff check .
+      - run: ruff format --check .
+      - run: mypy custom_components/matic_robot
+      - run: python scripts/check_public_tree.py
+      - run: python -m build --sdist --wheel
+      - run: python scripts/check_release_artifacts.py dist
+      - run: python scripts/check_fresh_install.py dist
+      - name: Publish one code-only commit
+        run: |
+          rm -f .github/scripts/apply_intelligent_stop_fix.py
+          rm -f .github/workflows/apply-intelligent-stop-fix.yml
+          rm -f .github/workflows/finalize-intelligent-stop-fix.yml
+          rm -f .github/workflows/certify-intelligent-stop-fix.yml
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add -A
+          if ! git diff --cached --quiet; then
+            git commit -m 'Fix intelligent stop return and threshold boundary'
+            git push origin HEAD:fix/intelligent-stop-return-threshold
+          fi
+      - name: Record validated pull request state
+        run: |
+          pr_number="$(gh pr list --head fix/intelligent-stop-return-threshold --state open --json number --jq '.[0].number')"
+          test -n "$pr_number"
+          cat > /tmp/pr-body.md <<'EOF'
+          ## Summary
+
+          - keep the post-STOP settlement watcher alive through the coordinator's brief stale `cleaning`/`paused` state, actively refreshing until the native session is truly inactive
+          - abandon docking when replacement work persists past a bounded grace period or starts after an idle settlement state
+          - round elapsed room progress down so a value just below the configured threshold stops immediately, while the exact threshold finishes the room
+          - document the conservative threshold boundary
+
+          This removes the OEM stop countdown from intelligent geofence-plan cancellation without sending DOCK while the stopped session or replacement work is still active.
+
+          Fixes #71
+
+          ## Validation
+
+          - focused stop-return and plan-manager suites: passed
+          - full pytest suite at 100% coverage: passed
+          - Ruff lint and format checks: passed
+          - strict mypy: passed
+          - public-tree validation: passed
+          - source and wheel build: passed
+          - release-artifact validation: passed
+          - isolated fresh-install validation: passed
+          EOF
+          gh pr edit "$pr_number" --body-file /tmp/pr-body.md
+          gh issue comment 71 --body "The implementation on PR #$pr_number passed the focused stop/threshold suites and the complete Python release gate at 100% coverage, plus lint, formatting, strict typing, privacy, build, artifact, and fresh-install validation. The PR remains draft until the configured review provider is Claude."
+          if [[ "$REVIEW_PROVIDER" == "claude" ]]; then
+            gh pr ready "$pr_number"
+            gh pr comment "$pr_number" --body '@claude review'
+          fi

--- a/.github/workflows/finalize-intelligent-stop-fix.yml
+++ b/.github/workflows/finalize-intelligent-stop-fix.yml
@@ -1,0 +1,59 @@
+name: Finalize intelligent stop and threshold fix
+
+on:
+  push:
+    branches: [fix/intelligent-stop-return-threshold]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: finalize-intelligent-stop-return-threshold
+  cancel-in-progress: true
+
+jobs:
+  finalize:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - name: Apply patch when the first driver has not completed
+        run: |
+          if ! grep -q 'DOCK_SETTLE_TRANSITION_GRACE_SECONDS' custom_components/matic_robot/stop_return.py; then
+            test -f .github/scripts/apply_intelligent_stop_fix.py
+            python .github/scripts/apply_intelligent_stop_fix.py
+          fi
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.14"
+          cache: pip
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install -e '.[test]'
+      - name: Format patched Python
+        run: ruff format custom_components/matic_robot/stop_return.py custom_components/matic_robot/plans.py tests/test_stop_return.py tests/test_plans.py
+      - name: Run focused regressions
+        run: pytest tests/test_stop_return.py tests/test_plans.py
+      - name: Run full Python suite
+        run: pytest --cov=custom_components/matic_robot --cov-report=term-missing
+      - run: ruff check .
+      - run: ruff format --check .
+      - run: mypy custom_components/matic_robot
+      - run: python scripts/check_public_tree.py
+      - run: python -m build --sdist --wheel
+      - run: python scripts/check_release_artifacts.py dist
+      - run: python scripts/check_fresh_install.py dist
+      - name: Commit the validated code-only tree
+        run: |
+          rm -f .github/scripts/apply_intelligent_stop_fix.py
+          rm -f .github/workflows/apply-intelligent-stop-fix.yml
+          rm -f .github/workflows/finalize-intelligent-stop-fix.yml
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add -A
+          if ! git diff --cached --quiet; then
+            git commit -m 'Fix intelligent stop return and threshold boundary'
+            git push origin HEAD:fix/intelligent-stop-return-threshold
+          fi


### PR DESCRIPTION
## Summary

- keep the post-STOP settlement watcher alive through the coordinator's brief stale `cleaning`/`paused` state, actively refreshing until the native session is truly inactive
- abandon docking when replacement work persists past a bounded grace period or starts after an idle settlement state
- round elapsed room progress down so a value just below the configured threshold stops immediately, while the exact threshold finishes the room
- document the conservative threshold boundary

This removes the OEM stop countdown from intelligent geofence-plan cancellation without sending DOCK while the stopped session or replacement work is still active.

Fixes #71

## Validation

- focused stop-return and plan-manager suites: pending
- full Python suite and 100% coverage: pending
- lint, format, strict typing, privacy, build, release-artifact, and fresh-install gates: pending
