### PR TITLE
Publish the review verdict from the workflow, not the model

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -83,7 +83,6 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.review.outputs.github_token }}
           EXECUTION_FILE: ${{ steps.review.outputs.execution_file }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
@@ -112,7 +111,9 @@ jobs:
               exit 1
               ;;
           esac
+          # Take the reviewed commit straight from the trusted event context,
+          # so the evidence can only ever name this pull request's exact head.
           gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
-            -f commit_id="$HEAD_SHA" \
+            -f commit_id=${{ github.event.pull_request.head.sha }} \
             -f event=COMMENT \
             -f body="$body"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -29,11 +29,12 @@ jobs:
         with:
           fetch-depth: 1
       - uses: anthropics/claude-code-action@5ee796a55f92566ecd7e39d70dd613abcbea0d7c # v1
+        id: review
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: >-
             --allowedTools "Read,Grep,Glob,LS,Bash(gh pr diff:*),Bash(gh pr
-            view:*),Bash(gh api:*)"
+            view:*)"
           prompt: |
             You are this repository's regular review gate. Review pull request
             #${{ github.event.pull_request.number }} of
@@ -49,25 +50,65 @@ jobs:
             adequacy for changed behavior. Review only — never edit files,
             push commits, approve, or request changes.
 
-            When done, post exactly one pull request review with a single
-            command that begins with `gh api`, passing the review body as a
-            literal single-quoted argument. Do not assign a shell variable and
-            do not chain commands: only a command starting with `gh api` is
-            permitted, so a body passed through `$BODY` can never be sent.
+            When done, return the verdict as your final message and nothing
+            else. Do not call any write API: this workflow publishes your
+            final message as the pull request review.
 
-            If the change has no blocking findings, run exactly:
+            If the change has no blocking findings, your final message must be
+            exactly these two lines:
 
-            gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews -f commit_id=${{ github.event.pull_request.head.sha }} -f event=COMMENT -f body='## Review result: No issues found.
+            ## Review result: No issues found.
 
-            **Reviewed commit:** `${{ github.event.pull_request.head.sha }}`'
+            **Reviewed commit:** `${{ github.event.pull_request.head.sha }}`
 
-            The body must be exactly those two lines, with nothing else before
-            or after them.
-
-            If there are blocking findings, run the same single `gh api`
-            command with a literal single-quoted body that starts with the
-            heading `## Review result: findings`, followed by the line
+            If there are blocking findings, your final message must start with
+            the heading `## Review result: findings`, followed by the line
             **Reviewed commit:** `${{ github.event.pull_request.head.sha }}`
             and then a numbered list giving file:line, the defect, and a
-            concrete failure scenario for every finding. If you cannot
-            complete the review, post nothing.
+            concrete failure scenario for every finding.
+
+            Your final message must always begin with `## Review result:`. If
+            you cannot complete the review, say so in a final message that
+            does not begin with that heading, and nothing will be published.
+
+      # The reviewer holds no write tools, so publish its verdict here instead.
+      # Post with the action's own token: it is the Claude App installation
+      # token where one is available, which keeps the review authored by the
+      # identity review-gate.yml checks for.
+      - name: Publish the review verdict
+        env:
+          GH_TOKEN: ${{ steps.review.outputs.github_token }}
+          EXECUTION_FILE: ${{ steps.review.outputs.execution_file }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ -z "${EXECUTION_FILE:-}" ] || [ ! -s "$EXECUTION_FILE" ]; then
+            echo "No execution output file was produced." >&2
+            exit 1
+          fi
+          # Record the shape of the transcript so a future extraction failure
+          # is diagnosable from the log alone.
+          echo "Transcript entry types:"
+          jq -r '[.[] | .type] | join(" ")' "$EXECUTION_FILE" || true
+          body="$(jq -r '[.[] | select(.type == "result") | .result // empty] | last // empty' "$EXECUTION_FILE")"
+          if [ -z "$body" ]; then
+            body="$(jq -r '[.[] | select(.type == "assistant") | .message.content[]? | select(.type == "text") | .text] | last // empty' "$EXECUTION_FILE")"
+          fi
+          if [ -z "$body" ]; then
+            echo "Could not extract a verdict from the transcript." >&2
+            exit 1
+          fi
+          case "$body" in
+            "## Review result:"*) ;;
+            *)
+              echo "The reviewer did not return a verdict; publishing nothing." >&2
+              printf '%s\n' "$body" >&2
+              exit 1
+              ;;
+          esac
+          gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \
+            -f commit_id="$HEAD_SHA" \
+            -f event=COMMENT \
+            -f body="$body"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -75,7 +75,11 @@ jobs:
       # Post with the action's own token: it is the Claude App installation
       # token where one is available, which keeps the review authored by the
       # identity review-gate.yml checks for.
+      # Skipped when the action itself did not run, which is what happens on
+      # any pull request that edits this workflow file. A run that did happen
+      # but produced no usable verdict still fails below.
       - name: Publish the review verdict
+        if: steps.review.outputs.execution_file != ''
         env:
           GH_TOKEN: ${{ steps.review.outputs.github_token }}
           EXECUTION_FILE: ${{ steps.review.outputs.execution_file }}
@@ -84,8 +88,8 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          if [ -z "${EXECUTION_FILE:-}" ] || [ ! -s "$EXECUTION_FILE" ]; then
-            echo "No execution output file was produced." >&2
+          if [ ! -s "$EXECUTION_FILE" ]; then
+            echo "The execution output file $EXECUTION_FILE is missing or empty." >&2
             exit 1
           fi
           # Record the shape of the transcript so a future extraction failure


### PR DESCRIPTION
Supersedes the approach in #74, which did not work. Evidence below.

## Why #74 was not enough

#74 assumed the reviewer was denied because it could not define `$BODY` under a `Bash(gh api:*)` allowlist, and changed the prompt to pass the body as a literal argument of one `gh api` command.

Run [33718280368](https://github.com/ProspectOre/matic-home-assistant/actions/runs/33718280368) on #73 shows the reviewer issuing exactly that command:

```
gh api repos/ProspectOre/matic-home-assistant/pulls/73/reviews -f commit_id=1748dc32e8... -f event=COMMENT -f body='## Review result: No issues found.
...
```

and the result:

```
"subtype": "success",
"is_error": false,
"num_turns": 21,
"permission_denials_count": 38
```

Zero reviews and zero comments were created. The command was verbatim correct and still denied 38 times, so the prefix-match theory was wrong.

## The change

Stop routing the write through the model's tool permissions at all.

- The reviewer keeps only read tools: `Read, Grep, Glob, LS, Bash(gh pr diff:*), Bash(gh pr view:*)`. `Bash(gh api:*)` is removed, since it demonstrably cannot be used.
- The reviewer returns its verdict as its final message.
- A new workflow step extracts that message from the action's `execution_file` output and posts it.

## Posting identity

The step publishes with `steps.review.outputs.github_token`, not `secrets.GITHUB_TOKEN`. The action documents that output as "the GitHub token used by the action (Claude App token if available)". The Claude App is installed on this repository — the `claude[bot]` comments on #70 came from it.

This matters: `review-gate.yml` resolves `REVIEW_BOT_EVENT_LOGIN` to `claude[bot]` when `REVIEW_PROVIDER` is `claude`. Posting with the default workflow token would author the review as `github-actions[bot]` and the gate would ignore it.

## Failure behaviour

The step publishes nothing and fails loudly if the execution file is missing, if no verdict can be extracted, or if the text does not begin with `## Review result:`. It also logs the transcript entry types, so if the extraction ever needs adjusting, the log alone is enough to see the actual shape — no more silent success.

## Verification

Like #70 and #74, this cannot be verified before merging: the action refuses to run on any pull request that modifies its own workflow file ("The workflow file must exist and have identical content to the version on the repository's default branch"). It can only be exercised once on the default branch, against a pull request that does not touch this file.