### PR TITLE
Require the reviewer to reach a verdict in one turn

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -117,6 +117,18 @@ jobs:
               exit 1
               ;;
           esac
+          # A clean verdict must be the heading and the reviewed-commit line
+          # and nothing else. review-gate.yml anchors its match to the end of
+          # the body, so trailing prose would post a review the gate then
+          # silently ignores, which is indistinguishable from never having
+          # reviewed at all. Fail here instead, where the reason is visible.
+          if printf '%s' "$body" | head -n 1 | grep -qiE '^##[[:space:]]*Review result:[[:space:]]*No issues found\.[[:space:]]*$'; then
+            if [ "$(printf '%s\n' "$body" | grep -cvE '^[[:space:]]*$')" -ne 2 ]; then
+              echo "A clean verdict carried extra text; the gate would ignore it." >&2
+              printf '%s\n' "$body" >&2
+              exit 1
+            fi
+          fi
           # Take the reviewed commit straight from the trusted event context,
           # so the evidence can only ever name this pull request's exact head.
           gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" \

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -34,7 +34,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: >-
             --allowedTools "Read,Grep,Glob,LS,Bash(gh pr diff:*),Bash(gh pr
-            view:*)"
+            view:*)" --disallowedTools "Task"
           prompt: |
             You are this repository's regular review gate. Review pull request
             #${{ github.event.pull_request.number }} of
@@ -49,6 +49,11 @@ jobs:
             payload); rotation and completion-evidence invariants; and test
             adequacy for changed behavior. Review only — never edit files,
             push commits, approve, or request changes.
+
+            Do the reading and judging yourself in this one turn. Do not
+            delegate to subagents and do not defer any part of the verdict to
+            later work: nothing runs after your final message, so a promise to
+            report back publishes nothing at all.
 
             When done, return the verdict as your final message and nothing
             else. Do not call any write API: this workflow publishes your


### PR DESCRIPTION
Last known gap in the regular-review chain. #76 fixed publishing; this fixes what the reviewer returns.

## What run 33723666080 showed

Everything after the model now works. On [that run](https://github.com/ProspectOre/matic-home-assistant/actions/runs/33723666080) the publish step read the transcript, extracted the final message, shape-checked it, and hit no credential error — the 401 from #75 is gone.

It published nothing because of what the reviewer said:

> I've dispatched four parallel review agents covering the Python backend, frontend TypeScript, test adequacy, and bundled JS/config for PR #73. I'll compile their findings into the final verdict once they report back.

The reviewer delegated the review to subagents and ended its turn. Nothing runs after the final message, so there was no later point at which those findings could be compiled — the promise could never be kept. The guard refused to post it, which is the correct outcome: that text is not a verdict and must not stand as this pull request's review.

## The change

Two levels, so neither alone has to hold:

- `--disallowedTools "Task"` removes the delegation tool.
- The prompt states that the reading and judging happen in this one turn, and says why: deferred work publishes nothing.

## Verification

Full suite run locally: 1192 passed.

As with #70, #74, #75 and #76, the action cannot run on a pull request that edits its own workflow file, so this is exercisable only once it is on the default branch.