### PR TITLE
Publish from the verdict heading, not the whole final message

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -109,14 +109,24 @@ jobs:
             echo "Could not extract a verdict from the transcript." >&2
             exit 1
           fi
-          case "$body" in
-            "## Review result:"*) ;;
-            *)
-              echo "The reviewer did not return a verdict; publishing nothing." >&2
-              printf '%s\n' "$body" >&2
-              exit 1
-              ;;
-          esac
+          # The verdict is the contract, not what leads up to it. Reviewers
+          # tend to narrate before the heading ("Now I have everything I need
+          # for the verdict."), and review-gate.yml anchors its match to the
+          # start of the body, so publish from the heading onwards rather than
+          # discarding an otherwise complete review over its preamble.
+          verdict="$(printf '%s\n' "$body" | awk '
+            tolower($0) ~ /^[[:space:]]*#+[[:space:]]*review result:/ { found = 1 }
+            found { print }
+          ')"
+          if [ -z "${verdict//[[:space:]]/}" ]; then
+            echo "The reviewer did not return a verdict; publishing nothing." >&2
+            printf '%s\n' "$body" >&2
+            exit 1
+          fi
+          if [ "$verdict" != "$body" ]; then
+            echo "Dropped preamble before the verdict heading." >&2
+          fi
+          body="$verdict"
           # A clean verdict must be the heading and the reviewed-commit line
           # and nothing else. review-gate.yml anchors its match to the end of
           # the body, so trailing prose would post a review the gate then


### PR DESCRIPTION
Last gap in the regular-review chain, found by running it for real on #73.

## What happened

Run [33725928863](https://github.com/ProspectOre/matic-home-assistant/actions/runs/33725928863) produced a complete and, as it turned out, correct findings verdict — it caught a genuine bag-missing invariant bug in the statistics entities, since fixed. It published nothing, because the final message opened with:

> Now I have everything I need for the verdict.

before the `## Review result: findings` heading.

`review-gate.yml` anchors its match to the start of the comment body, so the preamble cannot simply be posted along with the verdict: the review would appear and then be silently ignored, which is the failure this step exists to prevent. But refusing the whole thing throws away a real review and leaves the gate waiting, which is no better.

## The change

Publish from the heading onwards, dropping anything before it and logging that it did so.

What is deliberately unchanged: a final message with **no** heading at all is still refused. The reviewer on run [33723666080](https://github.com/ProspectOre/matic-home-assistant/actions/runs/33723666080), which dispatched subagents and promised to "compile their findings into the final verdict once they report back", is still caught rather than posted as a verdict. Slicing tolerates narration before a real verdict; it does not invent one.

The clean-verdict check still runs on the sliced text, so a "No issues found" verdict that carries trailing prose is still refused rather than posted for the gate to ignore.

## Verification

The slicing was exercised against the four shapes seen so far:

| Final message | Result |
| --- | --- |
| `Now I have everything I need for the verdict.` + findings verdict | publishes from `## Review result: findings` |
| clean verdict, no preamble | unchanged |
| `I've dispatched four parallel review agents...` | refused, no verdict |
| notes + `### Review Result:` (different case and heading level) | publishes from the heading |

Full suite run locally: 1192 passed.

As with every previous workflow change here, the action will not run on a pull request that edits its own workflow file, so this is exercisable only once it is on the default branch.