### PR TITLE
Dispatch the gate after publishing, and stop naming Codex

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -16,6 +16,8 @@ permissions:
   contents: read
   pull-requests: write
   id-token: write
+  # Needed to dispatch the review gate once a verdict is published.
+  actions: write
 
 jobs:
   review:
@@ -145,3 +147,8 @@ jobs:
             -f commit_id=${{ github.event.pull_request.head.sha }} \
             -f event=COMMENT \
             -f body="$body"
+          # A review posted with GITHUB_TOKEN raises no pull_request_review
+          # event, by design, so the gate's routers never see this verdict and
+          # its status would sit on the previous evaluation indefinitely. Ask
+          # the gate to re-read the pull request now that the evidence exists.
+          gh workflow run review-gate.yml -f pull_request="$PR_NUMBER"

--- a/.github/workflows/review-base-advance.yml
+++ b/.github/workflows/review-base-advance.yml
@@ -133,8 +133,8 @@ jobs:
           else
             base_advanced_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           fi
-          gate_description="Base changed; push a new head before @codex review"
-          marker_description="Base changed for PR #$PR_NUMBER at base $base_sha at $base_advanced_at; push a new head before @codex review"
+          gate_description="Base changed; push a new head for a fresh review"
+          marker_description="Base changed for PR #$PR_NUMBER at base $base_sha at $base_advanced_at; push a new head for a fresh review"
 
           active_gate_runs() {
             gh api "repos/$REPO/actions/workflows/review-gate.yml/runs?per_page=100" --paginate --slurp \

--- a/.github/workflows/review-base-change.yml
+++ b/.github/workflows/review-base-change.yml
@@ -62,8 +62,8 @@ jobs:
               -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
           }
 
-          gate_description="Base changed; push a new head before @codex review"
-          marker_description="Base changed for PR #$PR_NUMBER at base $EVENT_BASE_SHA; push a new head before @codex review"
+          gate_description="Base changed; push a new head for a fresh review"
+          marker_description="Base changed for PR #$PR_NUMBER at base $EVENT_BASE_SHA; push a new head for a fresh review"
 
           active_gate_runs() {
             gh api "repos/$REPO/actions/workflows/review-gate.yml/runs?per_page=100" --paginate --slurp \

--- a/.github/workflows/review-gate-rollout.yml
+++ b/.github/workflows/review-gate-rollout.yml
@@ -126,7 +126,7 @@ jobs:
             gh api "repos/$REPO/statuses/$head_sha" --silent \
               -f state=pending \
               -f context="$REVIEW_GATE_CONTEXT" \
-              -f description="Disarming automatic merge; waiting for @codex review" \
+              -f description="Disarming automatic merge; waiting for the regular review" \
               -f target_url="${GITHUB_SERVER_URL:-https://github.com}/$REPO/actions/runs/${GITHUB_RUN_ID:-}"
           }
           # Revoke the gate before waiting for an evaluator to stop. A prior

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -1,4 +1,4 @@
-name: Codex Review Gate
+name: Regular Review Gate
 
 run-name: "review-gate #${{ inputs.pull_request || github.event.pull_request.number }}"
 
@@ -35,7 +35,7 @@ jobs:
       || github.event.pull_request.number != null
     runs-on: ${{ vars.USE_HOSTED_RUNNERS != 'false' && vars.USE_HOSTED_LINUX != 'false' && 'ubuntu-latest' || fromJSON('["self-hosted","macOS","ARM64","mbp"]') }}
     steps:
-      - name: Evaluate exact-head regular Codex review
+      - name: Evaluate exact-head regular review
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           GH_TOKEN: ${{ github.token }}
@@ -102,7 +102,7 @@ jobs:
           # already classified review and issue-comment events.
           if [[ -n "$event_head_sha" ]]; then
             stamp_status_for_sha "$event_head_sha" "$REVIEW_GATE_CONTEXT" pending \
-              "Review state changed; evaluating regular Codex review"
+              "Review state changed; evaluating the regular review"
           fi
 
           read_pr_snapshot() {
@@ -144,7 +144,7 @@ jobs:
             exit 0
           fi
           head_prefix="$(printf '%.10s' "$head_sha")"
-          base_marker_description="Base changed for PR #$pr_number at base $base_sha at $(date -u +%Y-%m-%dT%H:%M:%SZ); push a new head before @codex review"
+          base_marker_description="Base changed for PR #$pr_number at base $base_sha at $(date -u +%Y-%m-%dT%H:%M:%SZ); push a new head for a fresh review"
 
           stamp_status() {
             local context="$1"
@@ -399,25 +399,25 @@ jobs:
                 "Regular review invalidated at $latest_finding_at; active regular findings require a newer clean normal verdict"
             fi
             if base_change_marker_exists; then
-              stamp_review_gate pending "Base changed; push a new head before @codex review"
+              stamp_review_gate pending "Base changed; push a new head for a fresh review"
               echo "The base-change marker requires a new PR head and regular review."
               exit 0
             fi
             if [[ "$verdict" == "null" ]]; then
               if [[ -n "$latest_finding_at" ]]; then
-                stamp_review_gate pending "Waiting for fresh clean Codex review on $head_prefix"
+                stamp_review_gate pending "Waiting for a fresh clean regular review on $head_prefix"
                 echo "A findings-bearing regular review needs a newer clean review."
                 exit 0
               fi
-              stamp_review_gate pending "Waiting for @codex review on $head_prefix"
-              echo "No affirmative regular Codex verdict covers the exact head."
+              stamp_review_gate pending "Waiting for the regular review on $head_prefix"
+              echo "No affirmative regular review verdict covers the exact head."
               exit 0
             fi
             verdict_at="$(jq -r '.at // empty' <<< "$verdict")"
             if [[ -z "$verdict_at" || "$finding_count" -gt 0 ]]; then
-              stamp_review_gate pending "Codex reported findings on $head_prefix"
-              echo "Codex reported $finding_count active regular-review finding(s) on the exact head."
-              echo "Fix them, push a new head, and tag @codex review again."
+              stamp_review_gate pending "The regular review reported findings on $head_prefix"
+              echo "The regular review reported $finding_count active finding(s) on the exact head."
+              echo "Fix them and push a new head for a fresh review."
               exit 0
             fi
           }
@@ -447,7 +447,7 @@ jobs:
           fi
           # The event head was revoked before its first API read. Revoke the
           # resolved head as well for manual dispatches and stale event payloads.
-          stamp_review_gate pending "Evaluating regular Codex review on $head_prefix"
+          stamp_review_gate pending "Evaluating the regular review on $head_prefix"
           gate_snapshot="$(read_gate_snapshot)"
           require_clean_regular_snapshot "$gate_snapshot"
 
@@ -466,7 +466,7 @@ jobs:
           fi
           if [[ "$final_base_sha" != "$base_sha" ]]; then
             stamp_base_change_marker
-            stamp_review_gate pending "Base changed; push a new head before @codex review"
+            stamp_review_gate pending "Base changed; push a new head for a fresh review"
             echo "The PR base changed during evaluation; push a new head before requesting a regular review."
             exit 0
           fi
@@ -487,7 +487,7 @@ jobs:
           if [[ "$last_head_sha" != "$head_sha" || "$last_base_sha" != "$base_sha" || "$last_base_ref" != "$DEFAULT_BRANCH" || "$last_is_draft" != "false" || "$last_auto_merge_enabled" != "false" || "$last_pr_state" != "OPEN" ]]; then
             if [[ "$last_head_sha" == "$head_sha" && "$last_base_sha" != "$base_sha" ]]; then
               stamp_base_change_marker
-              stamp_review_gate pending "Base changed; push a new head before @codex review"
+              stamp_review_gate pending "Base changed; push a new head for a fresh review"
             fi
             if [[ "$last_auto_merge_enabled" == "true" ]]; then
               disable_auto_merge "$last_pr_node_id"
@@ -521,7 +521,7 @@ jobs:
               exit 1
               ;;
           esac
-          stamp_review_gate success "Clean regular Codex review for $head_prefix; evidence $evidence_marker"
-          echo "The exact pull request head has an affirmative clean regular Codex review."
+          stamp_review_gate success "Clean regular review for $head_prefix; evidence $evidence_marker"
+          echo "The exact pull request head has an affirmative clean regular review."
           echo "Security-review messages are intentionally not review-gate evidence."
           echo "This workflow never enables or performs a merge."

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -246,7 +246,7 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
         "group: review-gate-base-change-${{ github.event.pull_request.number }}"
         in base_change
     )
-    assert "Base changed; push a new head before @codex review" in base_change
+    assert "Base changed; push a new head for a fresh review" in base_change
     assert "Base changed for PR #$PR_NUMBER at base $EVENT_BASE_SHA" in base_change
     assert 'stamp_status "$REVIEW_GATE_CONTEXT"' in base_change
     assert base_change.count('stamp_status "$REVIEW_GATE_CONTEXT"') == 2
@@ -264,7 +264,7 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
         base_advance
     )
     assert "base_advanced_at" in base_advance
-    assert "push a new head before @codex review" in base_advance
+    assert "push a new head for a fresh review" in base_advance
     assert "mktemp" in base_advance
     assert "event_head_sha" in base_advance
     assert "EVENT_HEAD_SHA" in base_advance
@@ -321,7 +321,7 @@ def test_review_gate_uses_only_regular_review_evidence() -> None:
     assert "if: always()" in rollout
     assert "review-fork-regular-review.yml" in rollout
     assert "actions: write" in rollout
-    assert "Disarming automatic merge; waiting for @codex review" in rollout
+    assert "Disarming automatic merge; waiting for the regular review" in rollout
     assert "disablePullRequestAutoMerge" in rollout
     assert "((.auto_merge != null) | tostring)" in rollout
     assert "cancel-legacy-auto-merge-runs" in rollout


### PR DESCRIPTION
The two loose ends from moving the regular review to Claude.

## The gate could not see its own evidence

A review posted with `GITHUB_TOKEN` raises no `pull_request_review` event — GitHub suppresses that to prevent workflows retriggering themselves. The routers therefore never fire for a verdict this workflow publishes, and the gate's status stays on whatever it last evaluated.

On #73 that meant a clean verdict was posted and the gate still read `Waiting for @codex review` until it was dispatched by hand. Every future pull request would have needed the same manual nudge.

`claude-review.yml` now dispatches `review-gate.yml` for the pull request straight after publishing, which is what the gate's `workflow_dispatch` input exists for. This needs `actions: write`, added alongside the existing permissions.

## The text still said Codex

The gate reported `Waiting for @codex review` while waiting for Claude, and on findings told people to "tag @codex review again", which does nothing under this provider. That is not cosmetic when the status line is the thing an operator reads to decide whether something is stuck — it sent me looking for a Codex problem twice.

Operator-facing text now names the regular review instead, across `review-gate.yml`, `review-base-change.yml`, `review-base-advance.yml` and `review-gate-rollout.yml`. The workflow's own display name becomes "Regular Review Gate"; nothing references it (the required check is the stamped `review-gate` commit status, and dispatch uses the filename).

## Deliberately left alone

- **The acceptance regexes.** They must keep matching existing Codex review bodies, and they already accept `review result:` as an alternative, which is what this workflow posts.
- **`name: Route Regular Codex Review Events`.** `review-fork-regular-review.yml` keys its `workflow_run` trigger on that exact string, so renaming it would silently break the trigger.
- **The `Base changed for PR #<n> at base ` prefix.** `base_change_marker_exists` parses it, so only the trailing instruction after the semicolon changed. Verified the writer and reader still agree.

## Not included: #70

#70 is superseded and merging it now would regress this. It hardcodes `claude[bot]`, the identity proven unreachable in #76 — the repo has no GitHub App credentials and the action's `github_token` output returns 401. Its one novel piece, `claude_action_clean_issue_comment_envelope`, only matters under that identity and is dead code here.

## Verification

Full suite run locally: 1236 passed. All workflow YAML parses. Three tests pinning the old wording updated with it.