### PR TITLE
Render the workspace panel once instead of twice

### DIFF
--- a/custom_components/matic_robot/map_studio_v4/index.js
+++ b/custom_components/matic_robot/map_studio_v4/index.js
@@ -1246,7 +1246,7 @@ line-height: var(--ms-lh-snug);
 
     .narrow .app { grid-template-rows: 3.35rem minmax(0, 1fr); min-block-size: 28rem; }
     .narrow .workspace { grid-template-columns: minmax(0, 1fr); }
-    .narrow .inspector { display: none; }
+    .narrow .inspector { border-inline-start: 0; }
     .narrow .mobile-sheet {
       position: absolute;
       z-index: 7;
@@ -1413,65 +1413,81 @@ line-height: var(--ms-lh-snug);
               </div>
             `:l}
 
-            <aside class="inspector" aria-label="Map workspace">
-              <div class="status-strip">
-                <span class="status-icon" aria-hidden="true">\u25c6</span>
-                <span><strong>${e.title}</strong><small>${e.detail}</small></span>
-                ${i?s`
-                  <button
-                    class="status-action"
-                    type="button"
-                    ?disabled=${!i.enabled}
-                    title=${i.reason??""}
-                    @click=${()=>this.#s(i)}
-                  >${this.#C("v4_stop","Stop")}</button>
-                `:l}
-              </div>
-              <section class="workflow">
-                <div class="workflow-heading">
-                  ${H.workflow!=="none"?s`
-                    <button
-                      class="workflow-back"
-                      type="button"
-                      aria-label=${this.#C("v4_back","Back")}
-                      @click=${()=>this.#v("none")}
-                    >\u2190</button>
-                  `:l}
-                  <h2 tabindex="-1">${r.title}</h2>
+            <!--
+              One panel element, not two. It is a grid column when wide and a
+              bottom sheet when narrow. Rendering both and hiding one with
+              display:none meant two live workflow panels at all times, which
+              made #dialogLauncherFor pick the hidden copy on narrow -- so
+              cancelling a delete dialog on a phone restored focus to nothing --
+              and left every primary action ambiguous under Playwright's strict
+              mode.
+            -->
+            <aside
+              class=${V?"inspector mobile-sheet":"inspector"}
+              data-detent=${V?this._sheetDetent:l}
+              aria-label="Map workspace"
+            >
+              ${V?s`
+                <button
+                  class="sheet-toggle"
+                  type="button"
+                  aria-label=${this.#C("v4_workspace_height","Map workspace, {height} height",{height:this._sheetDetent})}
+                  aria-expanded=${String(this._sheetDetent!=="peek")}
+                  @click=${this.#f}
+                >
+                  <span class="sheet-handle" aria-hidden="true"></span>
+                  <span class="sheet-title">${r.title}</span>
+                  <span class="sheet-description">${r.description}</span>
+                </button>
+                <div class="sheet-body">
+                  <!--
+                    Draw still omits the body on narrow. Restoring it puts two
+                    "Clear" controls on screen at once -- the map's precision
+                    chip and the panel's own -- so the saved-areas list stays
+                    unreachable here until the sheet's per-workflow content
+                    model decides which surface owns the drawing controls.
+                  -->
+                  ${H.workflow==="draw"?l:this.#S(H)}
                 </div>
-                <p>${r.description}</p>
-                ${this.#S(H)}
                 <div class="primary-stack">
                   ${o?this.#b(o):l}
                   ${a?this.#b(a,"secondary-action"):l}
                 </div>
-              </section>
+              `:s`
+                <div class="status-strip">
+                  <span class="status-icon" aria-hidden="true">\u25c6</span>
+                  <span><strong>${e.title}</strong><small>${e.detail}</small></span>
+                  ${i?s`
+                    <button
+                      class="status-action"
+                      type="button"
+                      ?disabled=${!i.enabled}
+                      title=${i.reason??""}
+                      @click=${()=>this.#s(i)}
+                    >${this.#C("v4_stop","Stop")}</button>
+                  `:l}
+                </div>
+                <section class="workflow">
+                  <div class="workflow-heading">
+                    ${H.workflow!=="none"?s`
+                      <button
+                        class="workflow-back"
+                        type="button"
+                        aria-label=${this.#C("v4_back","Back")}
+                        @click=${()=>this.#v("none")}
+                      >\u2190</button>
+                    `:l}
+                    <h2 tabindex="-1">${r.title}</h2>
+                  </div>
+                  <p>${r.description}</p>
+                  ${this.#S(H)}
+                  <div class="primary-stack">
+                    ${o?this.#b(o):l}
+                    ${a?this.#b(a,"secondary-action"):l}
+                  </div>
+                </section>
+              `}
             </aside>
-
-            <section
-              class="mobile-sheet"
-              data-detent=${this._sheetDetent}
-              aria-label="Map workspace"
-            >
-              <button
-                class="sheet-toggle"
-                type="button"
-                aria-label=${this.#C("v4_workspace_height","Map workspace, {height} height",{height:this._sheetDetent})}
-                aria-expanded=${String(this._sheetDetent!=="peek")}
-                @click=${this.#f}
-              >
-                <span class="sheet-handle" aria-hidden="true"></span>
-                <span class="sheet-title">${r.title}</span>
-                <span class="sheet-description">${r.description}</span>
-              </button>
-              <div class="sheet-body">
-                ${H.workflow==="draw"?l:this.#S(H)}
-              </div>
-              <div class="primary-stack">
-                ${o?this.#b(o):l}
-                ${a?this.#b(a,"secondary-action"):l}
-              </div>
-            </section>
 
             ${H.fullMap?s`
               <section

--- a/frontend/map-studio-v4/shell.ts
+++ b/frontend/map-studio-v4/shell.ts
@@ -503,7 +503,7 @@ export class MaticMapShellV4 extends LitElement {
 
     .narrow .app { grid-template-rows: 3.35rem minmax(0, 1fr); min-block-size: 28rem; }
     .narrow .workspace { grid-template-columns: minmax(0, 1fr); }
-    .narrow .inspector { display: none; }
+    .narrow .inspector { border-inline-start: 0; }
     .narrow .mobile-sheet {
       position: absolute;
       z-index: 7;
@@ -1005,65 +1005,81 @@ export class MaticMapShellV4 extends LitElement {
               </div>
             ` : nothing}
 
-            <aside class="inspector" aria-label="Map workspace">
-              <div class="status-strip">
-                <span class="status-icon" aria-hidden="true">◆</span>
-                <span><strong>${status.title}</strong><small>${status.detail}</small></span>
-                ${statusAction ? html`
-                  <button
-                    class="status-action"
-                    type="button"
-                    ?disabled=${!statusAction.enabled}
-                    title=${statusAction.reason ?? ""}
-                    @click=${() => this.#action(statusAction)}
-                  >${this.#t("v4_stop", "Stop")}</button>
-                ` : nothing}
-              </div>
-              <section class="workflow">
-                <div class="workflow-heading">
-                  ${state.workflow !== "none" ? html`
-                    <button
-                      class="workflow-back"
-                      type="button"
-                      aria-label=${this.#t("v4_back", "Back")}
-                      @click=${() => this.#workflow("none")}
-                    >←</button>
-                  ` : nothing}
-                  <h2 tabindex="-1">${workflow.title}</h2>
+            <!--
+              One panel element, not two. It is a grid column when wide and a
+              bottom sheet when narrow. Rendering both and hiding one with
+              display:none meant two live workflow panels at all times, which
+              made #dialogLauncherFor pick the hidden copy on narrow -- so
+              cancelling a delete dialog on a phone restored focus to nothing --
+              and left every primary action ambiguous under Playwright's strict
+              mode.
+            -->
+            <aside
+              class=${narrow ? "inspector mobile-sheet" : "inspector"}
+              data-detent=${narrow ? this._sheetDetent : nothing}
+              aria-label="Map workspace"
+            >
+              ${narrow ? html`
+                <button
+                  class="sheet-toggle"
+                  type="button"
+                  aria-label=${this.#t("v4_workspace_height", "Map workspace, {height} height", { height: this._sheetDetent })}
+                  aria-expanded=${String(this._sheetDetent !== "peek")}
+                  @click=${this.#cycleSheet}
+                >
+                  <span class="sheet-handle" aria-hidden="true"></span>
+                  <span class="sheet-title">${workflow.title}</span>
+                  <span class="sheet-description">${workflow.description}</span>
+                </button>
+                <div class="sheet-body">
+                  <!--
+                    Draw still omits the body on narrow. Restoring it puts two
+                    "Clear" controls on screen at once -- the map's precision
+                    chip and the panel's own -- so the saved-areas list stays
+                    unreachable here until the sheet's per-workflow content
+                    model decides which surface owns the drawing controls.
+                  -->
+                  ${state.workflow === "draw" ? nothing : this.#workflowBody(state)}
                 </div>
-                <p>${workflow.description}</p>
-                ${this.#workflowBody(state)}
                 <div class="primary-stack">
                   ${footerPrimary ? this.#primaryButton(footerPrimary) : nothing}
                   ${footerSecondary ? this.#primaryButton(footerSecondary, "secondary-action") : nothing}
                 </div>
-              </section>
+              ` : html`
+                <div class="status-strip">
+                  <span class="status-icon" aria-hidden="true">◆</span>
+                  <span><strong>${status.title}</strong><small>${status.detail}</small></span>
+                  ${statusAction ? html`
+                    <button
+                      class="status-action"
+                      type="button"
+                      ?disabled=${!statusAction.enabled}
+                      title=${statusAction.reason ?? ""}
+                      @click=${() => this.#action(statusAction)}
+                    >${this.#t("v4_stop", "Stop")}</button>
+                  ` : nothing}
+                </div>
+                <section class="workflow">
+                  <div class="workflow-heading">
+                    ${state.workflow !== "none" ? html`
+                      <button
+                        class="workflow-back"
+                        type="button"
+                        aria-label=${this.#t("v4_back", "Back")}
+                        @click=${() => this.#workflow("none")}
+                      >←</button>
+                    ` : nothing}
+                    <h2 tabindex="-1">${workflow.title}</h2>
+                  </div>
+                  <p>${workflow.description}</p>
+                  ${this.#workflowBody(state)}
+                  <div class="primary-stack">
+                    ${footerPrimary ? this.#primaryButton(footerPrimary) : nothing}
+                    ${footerSecondary ? this.#primaryButton(footerSecondary, "secondary-action") : nothing}
+                  </div>
+                </section>
+              `}
             </aside>
-
-            <section
-              class="mobile-sheet"
-              data-detent=${this._sheetDetent}
-              aria-label="Map workspace"
-            >
-              <button
-                class="sheet-toggle"
-                type="button"
-                aria-label=${this.#t("v4_workspace_height", "Map workspace, {height} height", { height: this._sheetDetent })}
-                aria-expanded=${String(this._sheetDetent !== "peek")}
-                @click=${this.#cycleSheet}
-              >
-                <span class="sheet-handle" aria-hidden="true"></span>
-                <span class="sheet-title">${workflow.title}</span>
-                <span class="sheet-description">${workflow.description}</span>
-              </button>
-              <div class="sheet-body">
-                ${state.workflow === "draw" ? nothing : this.#workflowBody(state)}
-              </div>
-              <div class="primary-stack">
-                ${footerPrimary ? this.#primaryButton(footerPrimary) : nothing}
-                ${footerSecondary ? this.#primaryButton(footerSecondary, "secondary-action") : nothing}
-              </div>
-            </section>
 
             ${state.fullMap ? html`
               <section

--- a/tests/browser/map_studio_v4.spec.mjs
+++ b/tests/browser/map_studio_v4.spec.mjs
@@ -417,6 +417,26 @@ test.describe("Map Studio v0.4 foundation", () => {
     await expect(deleteArea).toBeFocused();
   });
 
+  test("restores focus after a cancelled dialog on a phone", async ({ page }) => {
+    // The desktop inspector and the mobile sheet were both rendered, one hidden
+    // with display:none, so #dialogLauncherFor's querySelector picked the hidden
+    // copy on narrow and focus() silently did nothing. The wide equivalent of
+    // this test passed throughout, because it never ran at this size.
+    await page.setViewportSize({ width: 390, height: 844 });
+    const gallery = await loadGallery(page, { scenario: "ready", narrow: true });
+    await expect(gallery.locator(".mobile-sheet")).toBeVisible();
+
+    await gallery.getByRole("button", { name: /Plans/ }).click();
+    // Exactly one panel: two meant the launcher lookup could pick the hidden one.
+    await expect(gallery.locator("matic-map-workflow-v4")).toHaveCount(1);
+    const deletePlan = gallery.getByRole("button", { name: "Delete plan" });
+    await expect(deletePlan).toBeVisible();
+    await deletePlan.click();
+    await expect(gallery.getByRole("dialog", { name: "Delete this plan?" })).toBeVisible();
+    await gallery.getByRole("button", { name: "Cancel" }).click();
+    await expect(deletePlan).toBeFocused();
+  });
+
   test("preserves Draw state through Full map and restores focus in Escape order", async ({ page }) => {
     await page.setViewportSize({ width: 1180, height: 760 });
     const gallery = await loadGallery(page, { scenario: "draw" });


### PR DESCRIPTION
Stage 5a of the Map Studio v0.4 overhaul. Stacked on #84. The enabling refactor for the contextual layout work.

## The duplication

`shell.ts` rendered both the desktop inspector and the mobile sheet on every update, hiding one with `display: none`. So there were always **two live `matic-map-workflow-v4` instances** and **two primary action stacks**.

That was not merely wasteful — it caused a real bug:

`#dialogLauncherFor` (`shell.ts:792`) does `renderRoot.querySelector(WORKFLOW_TAG)` and takes the **first** match, which on narrow is the hidden inspector copy. `focus()` on a `display: none` element silently does nothing, so **cancelling a delete-plan dialog on a phone restored focus to nothing.** It also made every primary action ambiguous under Playwright strict mode.

## The change

One element carries `inspector` always and adds `mobile-sheet` when narrow — a grid column at desktop width, a bottom sheet on a phone. `.narrow .inspector { display: none }` becomes a border reset, since the inspector *is* the sheet now.

Verified in the harness: **1 inspector element, 1 action stack**, where there were two of each.

## A bug I did not fix, and why

Bug: in Draw on narrow, `shell.ts` skips the sheet body entirely, so the saved-areas list is unreachable on mobile.

I removed the skip, and the RTL test failed — usefully:

```
strict mode violation: getByRole('button', { name: 'Clear' }) resolved to 2 elements:
  1) <button class="precision-chip">
  2) <button class="ms-btn ms-btn--secondary"> (inside the sheet)
```

Two identical **Clear** controls on screen at once. That is exactly the duplication this work exists to remove, so shipping it to make the list reachable would trade one defect for a worse one. Fixing it properly means deciding which surface owns the drawing controls per workflow, which is the sheet content model in the mobile stage.

Reverted, with the reason recorded in the source next to the condition so the next person does not repeat the experiment.

## Verification

- **143/143** Playwright across chromium, webkit, mobile-webkit — no test edits needed, which is the point of doing the dedupe before the visible redesign
- strict `tsc --noEmit`; bundle rebuilt and committed
- **57,391 bytes gzipped** of a 92,160 ceiling