### PR TITLE
Polish classic map fallback label

### DIFF
--- a/custom_components/matic_robot/map_studio_v4/index.js
+++ b/custom_components/matic_robot/map_studio_v4/index.js
@@ -1657,7 +1657,7 @@ line-height: var(--ms-lh-snug);
                     </select>
                   </label>
                   <button class="ms-row ms-row--menu" type="button" @click=${()=>this.#T("support")}>${this.#C("v4_map_diagnostics","Map diagnostics")}</button>
-                  <button class="ms-row ms-row--menu" type="button" @click=${()=>this.#T("classic")}>${this.#C("v4_switch_classic","Switch to Map Studio 0.3")}</button>
+                  <button class="ms-row ms-row--menu" type="button" @click=${()=>this.#T("classic")}>${this.#C("v4_switch_classic","Open classic map view")}</button>
                   <button class="ms-row ms-row--menu" type="button" @click=${()=>this.#T("fullscreen")}>${this._browserFullscreen?this.#C("v4_leave_full_screen","Leave full screen"):this.#C("v4_full_screen","Full screen")}</button>
                 </div>
               `:l}

--- a/custom_components/matic_robot/strings.json
+++ b/custom_components/matic_robot/strings.json
@@ -346,7 +346,7 @@
     "v4_stopping": "Stopping",
     "v4_stream_failures": "Stream failures",
     "v4_support_privacy": "This summary contains no map, coordinates, room or floor names, device identifiers, addresses, or credentials.",
-    "v4_switch_classic": "Switch to Map Studio 0.3",
+    "v4_switch_classic": "Open classic map view",
     "v4_trackpad": "Trackpad",
     "v4_trackpad_help": "Scroll to pan · pinch to zoom · twist to rotate",
     "v4_try_again": "Try again shortly.",

--- a/custom_components/matic_robot/translations/en.json
+++ b/custom_components/matic_robot/translations/en.json
@@ -346,7 +346,7 @@
     "v4_stopping": "Stopping",
     "v4_stream_failures": "Stream failures",
     "v4_support_privacy": "This summary contains no map, coordinates, room or floor names, device identifiers, addresses, or credentials.",
-    "v4_switch_classic": "Switch to Map Studio 0.3",
+    "v4_switch_classic": "Open classic map view",
     "v4_trackpad": "Trackpad",
     "v4_trackpad_help": "Scroll to pan · pinch to zoom · twist to rotate",
     "v4_try_again": "Try again shortly.",

--- a/frontend/map-studio-v4/shell.ts
+++ b/frontend/map-studio-v4/shell.ts
@@ -1525,7 +1525,7 @@ export class MaticMapShellV4 extends LitElement {
                     </select>
                   </label>
                   <button class="ms-row ms-row--menu" type="button" @click=${() => this.#overflowAction("support")}>${this.#t("v4_map_diagnostics", "Map diagnostics")}</button>
-                  <button class="ms-row ms-row--menu" type="button" @click=${() => this.#overflowAction("classic")}>${this.#t("v4_switch_classic", "Switch to Map Studio 0.3")}</button>
+                  <button class="ms-row ms-row--menu" type="button" @click=${() => this.#overflowAction("classic")}>${this.#t("v4_switch_classic", "Open classic map view")}</button>
                   <button class="ms-row ms-row--menu" type="button" @click=${() => this.#overflowAction("fullscreen")}>${this._browserFullscreen ? this.#t("v4_leave_full_screen", "Leave full screen") : this.#t("v4_full_screen", "Full screen")}</button>
                 </div>
               ` : nothing}

--- a/tests/browser/map_studio_v4.spec.mjs
+++ b/tests/browser/map_studio_v4.spec.mjs
@@ -1671,7 +1671,7 @@ test.describe("Map Studio v0.4 foundation", () => {
     const menu = gallery.locator("#map-options");
     await expect(menu).not.toHaveAttribute("role", /menu/);
     await expect(menu.getByRole("menuitem")).toHaveCount(0);
-    await expect(menu.getByRole("button")).toHaveText(["Map diagnostics", "Switch to Map Studio 0.3", "Full screen"]);
+    await expect(menu.getByRole("button")).toHaveText(["Map diagnostics", "Open classic map view", "Full screen"]);
     await menu.getByRole("button", { name: "Full screen", exact: true }).click();
     expect(await page.evaluate(() => window.__v4FullscreenRequested)).toBe(true);
   });


### PR DESCRIPTION
## Summary
- replace the version-specific classic fallback label with user-facing wording
- update English translations and browser coverage

## Verification
- npm run build:map-studio-v4
- npx playwright test tests/browser/map_studio_v4.spec.mjs -g "native browser fullscreen"