### PR TITLE
Harden stop settlement ownership

### DIFF
--- a/custom_components/matic_robot/stop_return.py
+++ b/custom_components/matic_robot/stop_return.py
@@ -17,7 +17,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
 from time import monotonic
 from typing import Protocol
 
@@ -50,6 +51,25 @@ class StopReturnClient(Protocol):
 
     async def async_send_user_command(self, command: UserCommand) -> None:
         """Send one vetted user command to the robot."""
+
+
+@asynccontextmanager
+async def _command_guard(
+    manager: CleaningPlanManager, serial_number: str
+) -> AsyncIterator[None]:
+    """Serialize the final stop-settlement check with replacement commands.
+
+    Older test doubles and integrations may not expose a command lock; those
+    callers retain the previous fail-closed behavior.  The real plan manager
+    does expose one, so a replacement cannot dispatch between the native
+    session read and the final stop-fence check.
+    """
+    command_lock = getattr(manager, "command_lock", None)
+    if not callable(command_lock):
+        yield
+        return
+    async with command_lock(serial_number):
+        yield
 
 
 async def async_dock_when_stop_settles(
@@ -86,25 +106,40 @@ async def async_dock_when_stop_settles(
                 refresh_transition = True
             elif state.state == SETTLED_STATE:
                 settled_state_observed = True
-                try:
-                    active = await client.async_has_active_cleaning_session()
-                except MaticError as err:
-                    _LOGGER.debug(
-                        "Native Matic stop settlement unreadable (%s)",
-                        type(err).__name__,
-                    )
-                    active = None
-                if active is False:
+                async with _command_guard(manager, serial_number):
+                    # Replacements invalidate the fence before waiting for
+                    # this lock. Recheck it both before and after the native
+                    # session read so a late false result cannot trigger a
+                    # stale DOCK command.
+                    if not manager.stop_pending(serial_number):
+                        return False
+                    latest_state = hass.states.get(entity_id)
+                    if latest_state is None or latest_state.state != SETTLED_STATE:
+                        return False
                     try:
-                        await client.async_send_user_command(UserCommand.DOCK)
+                        active = await client.async_has_active_cleaning_session()
                     except MaticError as err:
-                        _LOGGER.warning(
-                            "Unable to dock Matic after its stop settled (%s)",
+                        _LOGGER.debug(
+                            "Native Matic stop settlement unreadable (%s)",
                             type(err).__name__,
                         )
-                        return False
-                    await refresh()
-                    return True
+                        active = None
+                    if active is False:
+                        if not manager.stop_pending(serial_number):
+                            return False
+                        latest_state = hass.states.get(entity_id)
+                        if latest_state is None or latest_state.state != SETTLED_STATE:
+                            return False
+                        try:
+                            await client.async_send_user_command(UserCommand.DOCK)
+                        except MaticError as err:
+                            _LOGGER.warning(
+                                "Unable to dock Matic after its stop settled (%s)",
+                                type(err).__name__,
+                            )
+                            return False
+                        await refresh()
+                        return True
         if now >= deadline:
             return False
         await asyncio.sleep(DOCK_SETTLE_POLL_SECONDS)

--- a/tests/browser/map_studio_v4.spec.mjs
+++ b/tests/browser/map_studio_v4.spec.mjs
@@ -143,6 +143,27 @@ test.describe("Map Studio v0.4 foundation", () => {
       .toBe(true);
   });
 
+  test("rebuilds the live workspace after a cold browser reload", async ({ page }) => {
+    const errors = [];
+    page.on("pageerror", (error) => errors.push(error.message));
+    page.on("console", (message) => {
+      if (message.type() === "error") errors.push(message.text());
+    });
+
+    await page.goto("/map-studio-v4-audit");
+    const gallery = page.locator(GALLERY_TAG);
+    await expect(gallery).toBeVisible();
+    await expect(gallery.getByRole("heading", { name: "What should the robot clean?" })).toBeVisible();
+    await expect(gallery.getByRole("button", { name: "One-time clean" })).toBeVisible();
+
+    await page.reload();
+    const reloaded = page.locator(GALLERY_TAG);
+    await expect(reloaded).toBeVisible();
+    await expect(reloaded.getByRole("heading", { name: "What should the robot clean?" })).toBeVisible();
+    await expect(reloaded.getByRole("button", { name: "One-time clean" })).toBeVisible();
+    expect(errors).toEqual([]);
+  });
+
   test("disposes polling on unload and reattaches with fresh controllers", async ({ page }) => {
     const scene = syntheticScene("Room", 10);
     let catalogRequests = 0;

--- a/tests/test_stop_return.py
+++ b/tests/test_stop_return.py
@@ -145,6 +145,35 @@ async def test_waits_for_an_active_session_to_end_before_docking(hass) -> None:
     client.async_send_user_command.assert_awaited_once_with(UserCommand.DOCK)
 
 
+async def test_replacement_during_session_read_cannot_trigger_stale_dock(hass) -> None:
+    """A replacement that starts during the native read wins the race."""
+    hass.states.async_set(ENTITY, "idle", {})
+    manager = _manager()
+    manager.command_lock = MagicMock(return_value=asyncio.Lock())
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def read_active_session() -> bool:
+        entered.set()
+        await release.wait()
+        return False
+
+    client = _client()
+    client.async_has_active_cleaning_session = AsyncMock(
+        side_effect=read_active_session
+    )
+    task = asyncio.create_task(_run(hass, client, manager))
+    await entered.wait()
+    # The replacement path invalidates the stop fence before it waits for the
+    # same command lock. The watcher must observe that invalidation after the
+    # blocked session read and decline to send DOCK.
+    manager.stop_pending.return_value = False
+    release.set()
+
+    assert await task is False
+    client.async_send_user_command.assert_not_awaited()
+
+
 async def test_missing_entity_and_unreadable_session_never_dock(
     hass, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_stop_return.py
+++ b/tests/test_stop_return.py
@@ -145,6 +145,59 @@ async def test_waits_for_an_active_session_to_end_before_docking(hass) -> None:
     client.async_send_user_command.assert_awaited_once_with(UserCommand.DOCK)
 
 
+async def test_rechecks_stop_fence_before_reading_native_session(hass) -> None:
+    """A replacement that wins before the read prevents any native query."""
+    hass.states.async_set(ENTITY, "idle", {})
+    manager = _manager()
+    manager.command_lock = MagicMock(return_value=asyncio.Lock())
+    manager.stop_pending.side_effect = [True, False]
+    client = _client(session=False)
+
+    assert await _run(hass, client, manager) is False
+    client.async_has_active_cleaning_session.assert_not_awaited()
+    client.async_send_user_command.assert_not_awaited()
+
+
+async def test_rechecks_entity_state_before_reading_native_session(hass) -> None:
+    """A state transition while taking the command lock fails closed."""
+    hass.states.async_set(ENTITY, "idle", {})
+    manager = _manager()
+
+    class StateChangingLock:
+        async def __aenter__(self):
+            hass.states.async_set(ENTITY, "cleaning", {})
+            return self
+
+        async def __aexit__(self, *_args):
+            return False
+
+    manager.command_lock = MagicMock(return_value=StateChangingLock())
+    client = _client(session=False)
+
+    assert await _run(hass, client, manager) is False
+    client.async_has_active_cleaning_session.assert_not_awaited()
+    client.async_send_user_command.assert_not_awaited()
+
+
+async def test_rechecks_entity_state_after_native_session_read(hass) -> None:
+    """A state transition during the read cannot be followed by DOCK."""
+    hass.states.async_set(ENTITY, "idle", {})
+    manager = _manager()
+    manager.command_lock = MagicMock(return_value=asyncio.Lock())
+    client = _client()
+
+    async def read_active_session() -> bool:
+        hass.states.async_set(ENTITY, "cleaning", {})
+        return False
+
+    client.async_has_active_cleaning_session = AsyncMock(
+        side_effect=read_active_session
+    )
+
+    assert await _run(hass, client, manager) is False
+    client.async_send_user_command.assert_not_awaited()
+
+
 async def test_replacement_during_session_read_cannot_trigger_stale_dock(hass) -> None:
     """A replacement that starts during the native read wins the race."""
     hass.states.async_set(ENTITY, "idle", {})


### PR DESCRIPTION
### Summary
- serialize native stop settlement checks with the real command lock
- re-check the stop fence and entity state before dispatching DOCK
- cover replacement races and cold browser reload recovery

### Verification
- 1,240 Python tests, 100% coverage
- 201 browser tests across Chromium, WebKit, mobile WebKit, and mobile Chromium
- Ruff and strict mypy pass

No robot motion or cleaning commands were sent.