### PR TITLE
Correct room selection wording and record RC11 live checks

### DIFF
--- a/custom_components/matic_robot/map_studio_v4/index.js
+++ b/custom_components/matic_robot/map_studio_v4/index.js
@@ -1003,7 +1003,7 @@ font-size: var(--ms-t-sm);
       `;let e=V.selection.roomIds.length;return V.workflow==="rooms"&&e>0&&!this.narrow?d`
         <div class="map-dock ms-surface ms-surface--floating" data-map-control>
           <div class="selection-chip ms-surface ms-surface--floating" data-map-control>
-            <span>${this.#e("v4_rooms_selected","{count} rooms selected").replace("{count}",String(e))}</span>
+            <span>${this.#e("v4_rooms_selected","Rooms selected: {count}").replace("{count}",String(e))}</span>
             <button class="ms-btn ms-btn--sm" type="button" @click=${()=>this.#r()}>${this.#e("v4_clear","Clear")}</button>
           </div>
         </div>
@@ -1585,7 +1585,7 @@ line-height: var(--ms-lh-snug);
       </div>
       <p class="panel-description">${e.description}</p>
       ${this.#e1(H,V)}
-    `}#K(H,V){let r=o0(H,this.localize).title;return H.workflow==="rooms"&&H.selection.roomIds.length&&(r=`${this.#C("v4_rooms_selected","{count} rooms selected",{count:H.selection.roomIds.length})} \xB7 ${this.#U(H).join(", ")}`),this._sheetDetent!=="peek"?V.detail?`${V.title} \xB7 ${V.detail}`:V.title:V.notable?`${V.title} \xB7 ${r}`:r}#W(){let H=(V,e)=>this.#C(V,e);return u`
+    `}#K(H,V){let r=o0(H,this.localize).title;return H.workflow==="rooms"&&H.selection.roomIds.length&&(r=`${this.#C("v4_rooms_selected","Rooms selected: {count}",{count:H.selection.roomIds.length})} \xB7 ${this.#U(H).join(", ")}`),this._sheetDetent!=="peek"?V.detail?`${V.title} \xB7 ${V.detail}`:V.title:V.notable?`${V.title} \xB7 ${r}`:r}#W(){let H=(V,e)=>this.#C(V,e);return u`
       <div class="dialog-backdrop" @click=${V=>{V.target===V.currentTarget&&(this._helpOpen=!1)}}>
         <section
           class="dialog help-dialog ms-surface ms-surface--overlay"

--- a/custom_components/matic_robot/strings.json
+++ b/custom_components/matic_robot/strings.json
@@ -321,7 +321,7 @@
     "v4_room_ready": "Ready",
     "v4_room_selection_hint": "Select rooms here or directly on the map. The map and list stay in sync.",
     "v4_rooms_quick_detail": "Pick rooms and clean them now.",
-    "v4_rooms_selected": "{count} rooms selected",
+    "v4_rooms_selected": "Rooms selected: {count}",
     "v4_rooms_to_clean": "Rooms to clean",
     "v4_run_a_plan": "Run a plan",
     "v4_saved_floor": "Saved floor {number}",

--- a/custom_components/matic_robot/translations/en.json
+++ b/custom_components/matic_robot/translations/en.json
@@ -321,7 +321,7 @@
     "v4_room_ready": "Ready",
     "v4_room_selection_hint": "Select rooms here or directly on the map. The map and list stay in sync.",
     "v4_rooms_quick_detail": "Pick rooms and clean them now.",
-    "v4_rooms_selected": "{count} rooms selected",
+    "v4_rooms_selected": "Rooms selected: {count}",
     "v4_rooms_to_clean": "Rooms to clean",
     "v4_run_a_plan": "Run a plan",
     "v4_saved_floor": "Saved floor {number}",

--- a/docs/product-review-0.4.md
+++ b/docs/product-review-0.4.md
@@ -1,10 +1,10 @@
 # 0.4 product review
 
 Status: in progress; not a claim of complete end-to-end or physical acceptance.
-Baseline: PR #97 merged as `82fb4b9`; work: `feature/complete-product-review`.
+Baseline: PRs #97–#99 merged; RC11 installed from `570a3bf`.
 Authority: redesign structure and workflows where evidence supports it.
 Live walkthrough uses the actual signed-in HA; synthetic states are regression
-fixtures, never evidence of deployed behavior. RC10 remains installed.
+fixtures, never evidence of deployed behavior. RC11 live checks are recorded below.
 
 ## Principles
 
@@ -28,13 +28,13 @@ fixtures, never evidence of deployed behavior. RC10 remains installed.
 | One-time room clean | Stable target, per-room settings, one dispatch | Stable IDs preserved; mobile choices open visibly |
 | Saved plans | Save/edit/delete/order/enable, recovery | Live editor inspected; stale mutation results fenced |
 | Drawing/custom areas | Tools, coordinates, review, persistence | Live review inspected; duplicate and stale mutations fenced |
-| History/floor switching | Read-only identity, return to live, drafts | Source review underway |
+| History/floor switching | Read-only identity, return to live, drafts | RC11 live saved-floor/return pass; draft isolation regressions pass |
 | Diagnostics/support | Useful redacted output, recovery routes | Source review underway |
 | Stop/completion | Ownership, uncertainty, cancellation, credit | Baseline tests; physical matrix still open |
 | Themes/accessibility | Contrast, keyboard, focus, zoom, forced colors | Header regressions added; broader pass underway |
 | Preferences/lifecycle | Detach, identity changes, persistence | Owner-scoped writes and draft clearing regressions pass |
 | Architecture | Contracts/state/effects/rendering boundaries | 32 TS modules, no local import cycles; client has no HA imports; lifecycle fixes tested |
-| Packaging/upgrades | Artifact parity, HACS, cache changes | Baseline checks; new candidate checks pending |
+| Packaging/upgrades | Artifact parity, HACS, cache changes | RC11 archive/bundle parity, HACS install and restart verified |
 | Hardware | Multi-leg, area, interruption, floor round trip | Open; see acceptance-0.4.md |
 
 ## Findings and fixes
@@ -96,10 +96,13 @@ fixtures, never evidence of deployed behavior. RC10 remains installed.
 
 Validation: 1,263 Python tests at 100% coverage; 397 browser checks; strict
 TypeScript, Ruff, format, MyPy and public-tree privacy checks passed during this
-pass. Archive parity and fresh installation imports pass. Hosted review and live
-candidate installation remain pending.
+pass. Archive parity and fresh installation imports pass. PRs #98/#99 have
+clean exact-head review and green hosted gates; RC11 installation is verified.
 
 Live baseline: actual HA reopened with verified map/pose, six saved plans and
 docked/clean native readback. Saved-plan editor inspected without changing its
 settings or issuing motion. Saved-floor viewing and return to the live map were inspected without motion.
-New fixes remain local until candidate installation.
+RC11 matches its served frontend bundle after restart. Desktop and 390px live
+walkthroughs verify the side-profile task/sidebar icons, visible room choices,
+All tasks, saved-floor selection, read-only guards and custom-area review copy.
+Real-device, assistive-technology and remaining physical journeys stay open.

--- a/frontend/map-studio-v4/map-canvas.ts
+++ b/frontend/map-studio-v4/map-canvas.ts
@@ -620,7 +620,7 @@ export class MaticMapCanvasV4 extends LitElement {
       return html`
         <div class="map-dock ms-surface ms-surface--floating" data-map-control>
           <div class="selection-chip ms-surface ms-surface--floating" data-map-control>
-            <span>${this.#t("v4_rooms_selected", "{count} rooms selected").replace("{count}", String(count))}</span>
+            <span>${this.#t("v4_rooms_selected", "Rooms selected: {count}").replace("{count}", String(count))}</span>
             <button class="ms-btn ms-btn--sm" type="button" @click=${() => this.#clearSelection()}>${this.#t("v4_clear", "Clear")}</button>
           </div>
         </div>

--- a/frontend/map-studio-v4/shell.ts
+++ b/frontend/map-studio-v4/shell.ts
@@ -1092,7 +1092,7 @@ export class MaticMapShellV4 extends LitElement {
     const workflow = workflowCopy(state, this.localize);
     let line = workflow.title;
     if (state.workflow === "rooms" && state.selection.roomIds.length) {
-      line = `${this.#t("v4_rooms_selected", "{count} rooms selected", { count: state.selection.roomIds.length })} · ${this.#roomNames(state).join(", ")}`;
+      line = `${this.#t("v4_rooms_selected", "Rooms selected: {count}", { count: state.selection.roomIds.length })} · ${this.#roomNames(state).join(", ")}`;
     }
     // With the body open the h2 already names the workflow, so the grip line
     // carries the robot instead of repeating the title directly above it.


### PR DESCRIPTION
Use “Rooms selected: 1” consistently in the map overlay and workspace summary, avoiding the incorrect singular “1 rooms selected.” Update the product-review ledger with RC11 installation and live desktop/mobile-width navigation evidence.

Validation: TypeScript build, 397 browser checks, 38 targeted release checks and public-tree privacy. RC11 remains the installed physical-test candidate; this copy change is not installed. Native device/accessibility and remaining physical acceptance stay open.
