### PR TITLE
Keep active session readback fresh after cleaning

### DIFF
--- a/custom_components/matic_robot/coordinator.py
+++ b/custom_components/matic_robot/coordinator.py
@@ -525,7 +525,7 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
             and self._cached_telemetry is not None
             and now < self._slow_refresh_due
         ):
-            return self._cached_telemetry
+            return await self._async_live_session_telemetry(self._cached_telemetry)
         try:
             telemetry = await self.client.async_get_telemetry()
             self._cached_telemetry = telemetry
@@ -534,7 +534,20 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
         except MaticError as err:
             _LOGGER.debug("Optional Hermes telemetry unavailable: %s", err)
             self._slow_refresh_due = now + UPDATE_INTERVAL_SECONDS
-            return self._cached_telemetry or RobotTelemetry()
+            return await self._async_live_session_telemetry(
+                self._cached_telemetry or RobotTelemetry()
+            )
+
+    async def _async_live_session_telemetry(
+        self, telemetry: RobotTelemetry
+    ) -> RobotTelemetry:
+        """Refresh lifecycle state independently of slow settings telemetry."""
+        try:
+            active = await self.client.async_has_active_cleaning_session()
+        except MaticError as err:
+            _LOGGER.debug("Active Hermes session unavailable: %s", err)
+            active = None
+        return replace(telemetry, active_cleaning_session=active)
 
     async def async_request_full_refresh(self) -> None:
         """Refresh slow settings immediately after a local write."""

--- a/docs/acceptance-0.4.md
+++ b/docs/acceptance-0.4.md
@@ -1,7 +1,7 @@
 # 0.4 end-to-end acceptance
 
-Status: candidate, not stable-release sign-off. Baseline: `v0.4.0-rc10`
-(`ebf2a79`). Run this checklist against the exact candidate being promoted.
+Status: candidate, not stable-release sign-off. Installed baseline: `v0.4.0-rc11`
+(`570a3bf`). Run this checklist against the exact candidate being promoted.
 Automated coverage, browser emulation, and read-only live checks do not prove
 physical cleaning, native assistive technology, or affected reporter hardware.
 
@@ -24,7 +24,7 @@ physical cleaning, native assistive technology, or affected reporter hardware.
 | First map | Live scene, coherent floor identity, verified pose, honest loading/error states | Live read-only check recorded; affected #65 hardware open |
 | Everyday navigation | 2D/3D, room/photo views, back navigation, floor selector, drafts and reopen preserve intent | Automated and live non-motion checks recorded |
 | Saved floor | History is read-only; no live pose or cleaning actions; return restores current-floor controls | Automated and live non-motion checks recorded |
-| One-time clean | Explicit room/settings selection dispatches once; scene stays visible; completion agrees with native history | RC10 completed one bounded room with Stop immediately available, verified map and reopen without replay |
+| One-time clean | Explicit room/settings selection dispatches once; scene stays visible; completion agrees with native history | RC11 completed one bounded room: 430s session, 340s positive native room evidence; one dispatch and panel reopen without replay |
 | Saved plan | Save/edit/reorder/reload preserves settings; preview matches actual mission legs; no unintended duplicate start | Preview recorded; real multi-leg execution open |
 | Custom area | Create/edit/save/reopen/run matches selected area; stale geometry blocks safely and offers recovery | Automated editing/fail-closed checks; real run open |
 | Immediate stop | Accepted stop settles, replacement work is protected, dock follows idle with native session clear | Regression tests; physical #71 retest open |
@@ -60,6 +60,14 @@ physical cleaning, native assistive technology, or affected reporter hardware.
    incorrect credit, or a runner that fails to settle; record the failed case.
 
 ## Stable promotion gate
+
+RC11 physical check (2026-09-04 Pacific): one room-started and one room-completed
+event; returned to dock, error-free, managed lock/plan and reconciliation clear.
+The presence automation was restored and verified enabled. Native-session
+telemetry remained stale until its five-minute settings cache expired, then
+cleared. A separate cleaning-finished event reported unconfirmed local evidence
+before positive native history arrived; lifecycle-event reconciliation needs
+review. Aggregate credit counters were not independently read in this run.
 
 - Python suite at 100% coverage; Chromium/WebKit desktop and touch suites;
   Ruff, formatting, Python/TypeScript types, privacy, artifact and fresh-install

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -56,6 +56,7 @@ def _client() -> AsyncMock:
     client.async_get_floor_plan.return_value = None
     client.async_get_pose.return_value = None
     client.async_get_telemetry.return_value = RobotTelemetry(protocol_version=25)
+    client.async_has_active_cleaning_session.return_value = None
     return client
 
 
@@ -603,6 +604,48 @@ async def test_coordinator_caches_slow_reads_and_can_force_them(hass) -> None:
     assert client.async_get_telemetry.await_count == 2
 
 
+@pytest.mark.parametrize("initial,current", [(True, False), (False, True)])
+async def test_session_state_refreshes_while_settings_remain_cached(
+    hass, initial, current
+) -> None:
+    client = _client()
+    client.async_get_telemetry.return_value = RobotTelemetry(
+        software_version="test", active_cleaning_session=initial
+    )
+    client.async_has_active_cleaning_session.return_value = current
+    coordinator = _coordinator(hass, client)
+
+    first = await coordinator._async_update_data()
+    second = await coordinator._async_update_data()
+
+    assert first.telemetry.active_cleaning_session is initial
+    assert second.telemetry.active_cleaning_session is current
+    assert second.telemetry.software_version == "test"
+    assert client.async_get_telemetry.await_count == 1
+    client.async_has_active_cleaning_session.assert_awaited_once()
+
+
+@pytest.mark.parametrize("slow_failure", [False, True])
+async def test_failed_live_session_read_does_not_reuse_cached_state(
+    hass, slow_failure
+) -> None:
+    client = _client()
+    client.async_get_telemetry.return_value = RobotTelemetry(
+        active_cleaning_session=True
+    )
+    coordinator = _coordinator(hass, client)
+    await coordinator._async_update_data()
+    client.async_has_active_cleaning_session.side_effect = MaticError("offline")
+    if slow_failure:
+        coordinator._force_full_refresh = True
+        client.async_get_telemetry.side_effect = MaticError("settings unavailable")
+
+    state = await coordinator._async_update_data()
+
+    assert state.telemetry.active_cleaning_session is None
+    assert state.info.name == "Test"
+
+
 async def test_coordinator_refreshes_floor_plan_without_invalidating_telemetry(
     hass,
 ) -> None:
@@ -636,7 +679,7 @@ async def test_slow_refresh_failure_retains_last_good_values(hass) -> None:
     second = await coordinator._async_update_data()
 
     assert second.floor_plan is first.floor_plan
-    assert second.telemetry is first.telemetry
+    assert second.telemetry == first.telemetry
 
 
 async def test_coordinator_records_observed_firmware(hass) -> None:


### PR DESCRIPTION
After a completed cleaning run, active-session telemetry could retain its previous value for five minutes because it shared the settings cache. Refresh the existing read-only active-session property on normal coordinator polls while preserving cached settings. A failed lifecycle read returns unknown instead of stale activity.

Record the RC11 bounded physical result and the separate lifecycle-event reconciliation gap. No motion commands change.

Validation: 1,267 Python tests, 100% coverage, Ruff/format, strict MyPy and public-tree privacy. Regressions cover both active-state transitions during cached settings and failed reads with cached or failed settings telemetry.
