### PR TITLE
Fix managed verification cleanup and completion event identity

### DIFF
--- a/custom_components/matic_robot/coordinator.py
+++ b/custom_components/matic_robot/coordinator.py
@@ -31,6 +31,7 @@ from .client.exceptions import (
 )
 from .client.mission import decode_mission_client_state
 from .client.models import (
+    CleaningSession,
     CuesVoiceStatus,
     FloorPlan,
     RobotInfo,
@@ -49,7 +50,7 @@ from .const import (
     UPDATE_INTERVAL_SECONDS,
 )
 from .firmware import FirmwareTracker, async_build_firmware_snapshot
-from .session_tracking import CleaningSessionTracker
+from .session_tracking import CleaningSessionTracker, _sessions_overlap
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -107,7 +108,7 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
         self._snapshot_attempts: dict[str, int] = {}
         self._snapshot_retry_after = 0.0
         self._device_software_version: str | None = None
-        self._last_session_key: tuple[str | None, str] | None = None
+        self._last_finished_session: CleaningSession | None = None
         self._session_tracker = CleaningSessionTracker()
         self._session_history_recovered = False
         self._pending_error_codes: tuple[int, ...] = ()
@@ -619,9 +620,15 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
         if session is None or session.ended_at is None:
             return
         key = (session.started_at, session.ended_at)
-        previous = self._last_session_key
-        self._last_session_key = key
-        if previous is None or previous == key:
+        previous = self._last_finished_session
+        self._last_finished_session = session
+        # Native history can refine the locally observed interval after the
+        # run has ended. That enrichment must not trigger automations twice.
+        if (
+            previous is None
+            or (previous.started_at, previous.ended_at) == key
+            or _sessions_overlap(previous, session)
+        ):
             return
         self.hass.bus.async_fire(
             EVENT_CLEANING_FINISHED,

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -2853,13 +2853,24 @@ async def _async_execute_rooms(
                         },
                         context=call.context,
                     )
+                    session_ended = False
                     current = hass.states.get(entity_id)
-                    if current is None or current.state not in {
+                    if current is not None and current.state in {
                         "docked",
                         "charging",
                         "idle",
                         "returning",
                     }:
+                        try:
+                            session_ended = (
+                                await _async_active_session_state(active_session)
+                            ) is False
+                        except (Exception, asyncio.CancelledError) as cleanup_error:
+                            _LOGGER.warning(
+                                "Unable to confirm aborted native session ended (%s)",
+                                type(cleanup_error).__name__,
+                            )
+                    if not session_ended:
                         await _async_cleanup_managed_motion(
                             managed_user_command, motion_token, dispatch_attempted=True
                         )

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -2821,6 +2821,49 @@ async def _async_execute_rooms(
                     ) from err
         except PlanCancelledError:
             return
+        except (Exception, asyncio.CancelledError) as err:
+            # Leaf handlers retire expected failures. Unexpected failures must
+            # also leave a terminal record before ownership is released.
+            active = manager.snapshot(serial_number)["active_plan"]
+            if (
+                manager.managed_motion_is_current(serial_number, motion_token)
+                and isinstance(active, dict)
+                and active.get("plan_id") == call.data["plan_id"]
+            ):
+                room = next(
+                    (room for room in rooms if room.room_id == active.get("room_id")),
+                    None,
+                )
+                if room is not None:
+                    reason = f"Managed cleaning aborted ({type(err).__name__})"
+                    _LOGGER.error(reason)
+                    await manager.async_mark_interrupted(
+                        serial_number, call.data["plan_id"], room, reason
+                    )
+                    hass.bus.async_fire(
+                        f"{DOMAIN}_room_interrupted",
+                        {
+                            "entity_id": entity_id,
+                            "plan_id": call.data["plan_id"],
+                            "room": room.name,
+                            "room_id": room.room_id,
+                            "cleaning_mode": room.cleaning_mode,
+                            "coverage_setting": room.coverage_setting,
+                            "error": reason,
+                        },
+                        context=call.context,
+                    )
+                    current = hass.states.get(entity_id)
+                    if current is None or current.state not in {
+                        "docked",
+                        "charging",
+                        "idle",
+                        "returning",
+                    }:
+                        await _async_cleanup_managed_motion(
+                            managed_user_command, motion_token, dispatch_attempted=True
+                        )
+            raise
         finally:
             manager.end_managed_motion(serial_number, motion_token)
             manager.unregister_run_task(serial_number)

--- a/custom_components/matic_robot/session_tracking.py
+++ b/custom_components/matic_robot/session_tracking.py
@@ -354,4 +354,4 @@ def _sessions_overlap(left: CleaningSession, right: CleaningSession) -> bool:
     unknown = datetime.min.replace(tzinfo=UTC)
     if unknown in {left_start, left_end, right_start, right_end}:
         return False
-    return max(left_start, right_start) <= min(left_end, right_end)
+    return max(left_start, right_start) < min(left_end, right_end)

--- a/docs/acceptance-0.4.md
+++ b/docs/acceptance-0.4.md
@@ -1,7 +1,7 @@
 # 0.4 end-to-end acceptance
 
-Status: candidate, not stable-release sign-off. Installed baseline: `v0.4.0-rc11`
-(`570a3bf`). Run this checklist against the exact candidate being promoted.
+Status: candidate, not stable-release sign-off. Installed baseline: `v0.4.0-rc13`
+(`e279f64`). Run this checklist against the exact candidate being promoted.
 Automated coverage, browser emulation, and read-only live checks do not prove
 physical cleaning, native assistive technology, or affected reporter hardware.
 
@@ -60,6 +60,20 @@ physical cleaning, native assistive technology, or affected reporter hardware.
    incorrect credit, or a runner that fails to settle; record the failed case.
 
 ## Stable promotion gate
+
+RC12 two-room check (2026-09-04 Pacific): one native mission completed both
+rooms with positive native per-room durations and returned to dock. The managed
+runner released its lock but left its active room in `verifying`, with no room
+terminal events. Local and delayed native history emitted duplicate session
+finished events. Automation state and the original selected plan were restored;
+RC13 restart cleared the orphan, but does not establish a root-cause fix.
+
+Local follow-up reproduces duplicate events from revised timestamps and an
+orphaned active room when native-history verification raises an unexpected
+exception or task cancellation. Regression fixes suppress overlapping session
+notifications and terminalize owned interrupted work without completion credit.
+The exact trigger of the physical runner exit remains unknown; fresh installed
+candidate verification and a bounded physical retest remain required.
 
 RC11 physical check (2026-09-04 Pacific): one room-started and one room-completed
 event; returned to dock, error-free, managed lock/plan and reconciliation clear.

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -827,6 +827,20 @@ async def test_cleaning_finished_event_fires_once_per_new_session(hass) -> None:
     assert events[0].data["firmware_version"] == "v168.11"
     assert events[0].data["entry_id"] == "entry"
 
+    # Delayed native evidence describes the same physical run with more
+    # accurate timestamps, not a second completed cleaning session.
+    client.async_get_telemetry.return_value = RobotTelemetry(
+        latest_session=replace(
+            _session("2"),
+            started_at="2026-07-20T02:00:31+00:00",
+            ended_at="2026-07-20T02:29:45+00:00",
+        )
+    )
+    coordinator._force_full_refresh = True
+    await coordinator._async_update_data()
+    await hass.async_block_till_done()
+    assert len(events) == 1
+
     client.async_get_telemetry.return_value = RobotTelemetry(
         software_version="v168.11",
         latest_session=CleaningSession(
@@ -842,6 +856,15 @@ async def test_cleaning_finished_event_fires_once_per_new_session(hass) -> None:
     await coordinator._async_update_data()
     await hass.async_block_till_done()
     assert len(events) == 1
+
+    client.async_get_telemetry.return_value = RobotTelemetry(
+        latest_session=_session("3")
+    )
+    coordinator._force_full_refresh = True
+    await coordinator._async_update_data()
+    await hass.async_block_till_done()
+    assert len(events) == 2
+    assert events[-1].data["started_at"] == "2026-07-20T03:00:00+00:00"
 
 
 async def test_coordinator_recovers_newer_session_from_recorder(hass) -> None:

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -5131,9 +5131,19 @@ async def test_finish_room_threshold_never_rounds_progress_up(hass) -> None:
 
 
 @pytest.mark.parametrize("failure", [RuntimeError, asyncio.CancelledError])
-@pytest.mark.parametrize("still_cleaning", [False, True])
+@pytest.mark.parametrize(
+    ("activity", "session", "expect_stop"),
+    [
+        ("docked", False, False),
+        ("cleaning", False, True),
+        ("returning", True, True),
+        ("charging", True, True),
+        ("docked", None, True),
+        ("charging", RuntimeError, True),
+    ],
+)
 async def test_execute_history_failure_does_not_orphan_verifying_room(
-    hass, failure, still_cleaning
+    hass, failure, activity, session, expect_stop, monkeypatch
 ):
     """The real runner must retire ownership even when verification aborts."""
     manager = CleaningPlanManager(hass)
@@ -5156,15 +5166,25 @@ async def test_execute_history_failure_does_not_orphan_verifying_room(
         if reads == 1:
             return ()
         assert manager.snapshot("serial")["active_plan"]["status"] == "verifying"
-        if still_cleaning:
-            hass.states.async_set(
-                "vacuum.matic", "cleaning", {"current_area": "Kitchen"}
-            )
+        hass.states.async_set("vacuum.matic", activity, {"current_area": "Kitchen"})
         raise failure("synthetic verification abort")
 
     hass.services.async_register("vacuum", "send_command", send_command)
     sender = AsyncMock()
-    with pytest.raises(failure):
+    monkeypatch.setattr(
+        "custom_components.matic_robot.services.ACTIVE_SESSION_UNKNOWN_RETRY_SECONDS", 0
+    )
+
+    async def native_session():
+        # The runner's ordinary completion checks see a finished session;
+        # the failure cleanup sees the current recharge/unknown state.
+        if reads < 2:
+            return False
+        if session is RuntimeError:
+            raise RuntimeError("synthetic read failure")
+        return session
+
+    with pytest.raises(failure, match="synthetic verification abort"):
         await _async_execute_rooms(
             hass,
             _leg_call(hass),
@@ -5174,6 +5194,7 @@ async def test_execute_history_failure_does_not_orphan_verifying_room(
             rooms,
             intelligent=False,
             session_history=history,
+            active_session=native_session,
             managed_user_command=sender,
         )
     assert not manager.lock("serial").locked()
@@ -5184,7 +5205,7 @@ async def test_execute_history_failure_does_not_orphan_verifying_room(
     restored = CleaningPlanManager(hass)
     await restored.async_load()
     assert restored.snapshot("serial")["active_plan"] is None
-    if still_cleaning:
+    if expect_stop:
         assert sender.await_count == 1
         assert sender.await_args.args[1] is UserCommand.STOP
     else:

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -3636,10 +3636,16 @@ async def test_a_task_that_ends_in_place_is_not_a_completion_candidate(hass) -> 
     )
 
 
-async def test_leg_runs_two_rooms_in_one_mission_without_redispatch(hass) -> None:
+@pytest.mark.parametrize("real_store", [False, True])
+async def test_leg_runs_two_rooms_in_one_mission_without_redispatch(
+    hass, real_store
+) -> None:
     """One leg mission glides room to room; credit comes from one record."""
     rooms = [_room("Kitchen", "room-kitchen"), _room("Office", "room-office")]
-    manager = _leg_manager()
+    manager = CleaningPlanManager(hass) if real_store else _leg_manager()
+    if real_store:
+        await manager.async_load()
+        manager.async_mark_completed = AsyncMock(wraps=manager.async_mark_completed)
     commands = []
 
     async def send_command(call) -> None:
@@ -5122,3 +5128,64 @@ async def test_finish_room_threshold_never_rounds_progress_up(hass) -> None:
         assert not manager.cancellation_event("serial").is_set()
     finally:
         lock.release()
+
+
+@pytest.mark.parametrize("failure", [RuntimeError, asyncio.CancelledError])
+@pytest.mark.parametrize("still_cleaning", [False, True])
+async def test_execute_history_failure_does_not_orphan_verifying_room(
+    hass, failure, still_cleaning
+):
+    """The real runner must retire ownership even when verification aborts."""
+    manager = CleaningPlanManager(hass)
+    await manager.async_load()
+    rooms = _leg_rooms()
+    reads = 0
+
+    async def send_command(_call):
+        hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Kitchen"})
+
+        async def finish():
+            await asyncio.sleep(0)
+            hass.states.async_set("vacuum.matic", "docked", {"current_area": "Kitchen"})
+
+        hass.async_create_task(finish(), eager_start=True)
+
+    async def history():
+        nonlocal reads
+        reads += 1
+        if reads == 1:
+            return ()
+        assert manager.snapshot("serial")["active_plan"]["status"] == "verifying"
+        if still_cleaning:
+            hass.states.async_set(
+                "vacuum.matic", "cleaning", {"current_area": "Kitchen"}
+            )
+        raise failure("synthetic verification abort")
+
+    hass.services.async_register("vacuum", "send_command", send_command)
+    sender = AsyncMock()
+    with pytest.raises(failure):
+        await _async_execute_rooms(
+            hass,
+            _leg_call(hass),
+            manager,
+            "vacuum.matic",
+            "serial",
+            rooms,
+            intelligent=False,
+            session_history=history,
+            managed_user_command=sender,
+        )
+    assert not manager.lock("serial").locked()
+    snapshot = manager.snapshot("serial")
+    assert snapshot["active_plan"] is None
+    assert snapshot["completed_runs"] == 0
+    assert snapshot["interrupted_runs"] == 1
+    restored = CleaningPlanManager(hass)
+    await restored.async_load()
+    assert restored.snapshot("serial")["active_plan"] is None
+    if still_cleaning:
+        assert sender.await_count == 1
+        assert sender.await_args.args[1] is UserCommand.STOP
+    else:
+        sender.assert_not_awaited()

--- a/tests/test_session_tracking.py
+++ b/tests/test_session_tracking.py
@@ -459,3 +459,13 @@ def test_room_timeline_normalizes_names_once_per_room_and_event(
     assert rooms == list(room_names)
     assert current_room == "Room 99"
     assert calls <= len(room_names) + len(area_states)
+
+
+def test_adjacent_sessions_are_distinct():
+    first = CleaningSession(
+        "2026-07-20T01:00:00+00:00", "2026-07-20T02:00:00+00:00", 3600, (), (), True
+    )
+    second = CleaningSession(
+        first.ended_at, "2026-07-20T03:00:00+00:00", 3600, (), (), True
+    )
+    assert not _sessions_overlap(first, second)


### PR DESCRIPTION
A native-history verification exception or task cancellation could release the managed lock while leaving the active room in `verifying`. The runner now records an owned interruption without completion credit before releasing ownership, preserves the original exception, and uses the existing guarded Stop cleanup when motion may still be active. It skips Stop only when both the activity and fresh native-session readback support that cleanup is unnecessary; recharge and unknown/read-failure states still receive guarded Stop.

Delayed native history also reports corrected timestamps for a locally observed session. Overlapping intervals now count as the same finished session, preventing a second automation event; adjacent and later sessions remain distinct.

Validation: 1,281 Python tests at 100% coverage, 399 browser tests, Ruff/format, Python and TypeScript types, privacy check. Both orphan regressions (unexpected error and cancellation) and the duplicate-event regression failed before the changes. The real plan store is covered through completion and interruption/reload.

The physical two-room run completed natively but failed managed acceptance. These changes reproduce and fix failure classes consistent with the orphan; the exact exception behind that live exit is still unknown. RC13 remains installed, and a fresh corrected-candidate physical retest is required. The acceptance record reflects that limit.
