### PR TITLE
Wait for native session completion before verifying multi-room credit

### DIFF
--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -109,7 +109,6 @@ ACTIVE_SESSION_UNKNOWN_ATTEMPTS = 3
 ACTIVE_SESSION_UNKNOWN_RETRY_SECONDS = 1
 SESSION_HISTORY_ATTEMPTS = 6
 SESSION_HISTORY_RETRY_SECONDS = 2
-HANDOFF_HISTORY_ATTEMPTS = 20
 OEM_STOP_RECONCILIATION_POLL_SECONDS = 5
 
 _LOGGER = logging.getLogger(__name__)
@@ -1149,38 +1148,6 @@ async def _async_run_room(
                         hass, entity_id, room, cancel_event
                     )
                     if outcome is RoomRunOutcome.HANDOFF_CANDIDATE:
-                        next_dispatch = (
-                            await prefetch_next() if prefetch_next is not None else None
-                        )
-                        if next_dispatch is not None:
-                            # Eager handoff: the next room is commanded during
-                            # the observed return so the robot can pivot
-                            # without docking.  Prefetch refuses ownership
-                            # while an OEM stop settles or the run is being
-                            # cancelled, and the current room still needs
-                            # native verification; an unverified room stops
-                            # the started next room without history credit.
-                            await manager.async_mark_verifying(
-                                serial_number, call.data["plan_id"], room
-                            )
-                            completion_verified = await _async_verify_room_completion(
-                                session_history,
-                                history_baseline,
-                                room,
-                                dispatched_at,
-                                hass=hass,
-                                entity_id=entity_id,
-                                cancel_event=cancel_event,
-                                attempts=HANDOFF_HISTORY_ATTEMPTS,
-                                allow_active_cleaning=True,
-                            )
-                            if not completion_verified:
-                                await _async_cleanup_managed_motion(
-                                    managed_user_command,
-                                    motion_token,
-                                    dispatch_attempted=True,
-                                )
-                            break
                         session_active = await _async_active_session_state(
                             active_session
                         )
@@ -1197,12 +1164,6 @@ async def _async_run_room(
                                 entity_id=entity_id,
                                 cancel_event=cancel_event,
                             )
-                            if completion_verified and prefetch_next is not None:
-                                # The eager dispatch above was unavailable;
-                                # retry once the session is verified so a
-                                # cleared stop fence or transient dispatch
-                                # error does not end the run early.
-                                await prefetch_next()
                             break
                         if session_active is None:
                             raise RoomInterruptedError(
@@ -1229,8 +1190,6 @@ async def _async_run_room(
                                 entity_id=entity_id,
                                 cancel_event=cancel_event,
                             )
-                            if completion_verified and prefetch_next is not None:
-                                await prefetch_next()
                             break
                         if session_resolution is None:
                             raise RoomInterruptedError(
@@ -1466,6 +1425,8 @@ async def _async_run_room(
         hass.bus.async_fire(
             f"{DOMAIN}_room_ended_unverified", event_data, context=call.context
         )
+    if completion_verified and prefetch_next is not None:
+        await prefetch_next()
     return completion_verified
 
 
@@ -1545,7 +1506,6 @@ async def _async_run_leg(
     )
     dispatch_attempted = False
     stop_sent = False
-    next_dispatch: _PreparedRoomDispatch | None = None
     evidence: dict[str, tuple[str, int]] | None = None
     dispatch: _PreparedRoomDispatch | None = prepared_dispatch
 
@@ -1643,12 +1603,10 @@ async def _async_run_leg(
                         )
                         continue
                     if outcome is RoomRunOutcome.HANDOFF_CANDIDATE:
-                        if prefetch_next is not None and not stop_sent:
-                            next_dispatch = await prefetch_next()
                         await manager.async_mark_verifying(
                             serial_number, call.data["plan_id"], active_room
                         )
-                        if next_dispatch is None and active_session is not None:
+                        if active_session is not None:
                             session_resolution = (
                                 await _async_wait_for_active_session_resolution(
                                     hass, entity_id, active_session, cancel_event
@@ -1671,12 +1629,6 @@ async def _async_run_leg(
                             hass=hass,
                             entity_id=entity_id,
                             cancel_event=cancel_event,
-                            attempts=(
-                                HANDOFF_HISTORY_ATTEMPTS
-                                if next_dispatch is not None
-                                else SESSION_HISTORY_ATTEMPTS
-                            ),
-                            allow_active_cleaning=next_dispatch is not None,
                         )
                         break
                     if outcome is RoomRunOutcome.STOPPED_IN_PLACE:
@@ -1855,12 +1807,10 @@ async def _async_run_leg(
                 context=call.context,
             )
     all_verified = all(room.room_id in credited for room in leg)
-    if not all_verified and next_dispatch is not None:
-        await _async_cleanup_managed_motion(
-            managed_user_command,
-            motion_token,
-            dispatch_attempted=True,
-        )
+    if all_verified and prefetch_next is not None and not stop_sent:
+        # Start the next settings leg only after evidence and persistence finish.
+        # Otherwise a short next mission can end before its observer attaches.
+        await prefetch_next()
     return all_verified
 
 
@@ -2769,7 +2719,7 @@ async def _async_execute_rooms(
                         )
                     except (HomeAssistantError, MaticError) as err:
                         _LOGGER.debug(
-                            "Early Matic room handoff was unavailable (%s)",
+                            "Next Matic leg dispatch was unavailable (%s)",
                             type(err).__name__,
                         )
                         return None

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -1648,6 +1648,21 @@ async def _async_run_leg(
                         await manager.async_mark_verifying(
                             serial_number, call.data["plan_id"], active_room
                         )
+                        if next_dispatch is None and active_session is not None:
+                            session_resolution = (
+                                await _async_wait_for_active_session_resolution(
+                                    hass, entity_id, active_session, cancel_event
+                                )
+                            )
+                            if session_resolution is True:
+                                await manager.async_mark_resumed(
+                                    serial_number, call.data["plan_id"], active_room
+                                )
+                                continue
+                            if session_resolution is None:
+                                raise RoomInterruptedError(
+                                    "Native session completion could not be confirmed"
+                                )
                         evidence = await _async_verify_leg_completion(
                             session_history,
                             history_baseline,
@@ -1870,6 +1885,8 @@ async def _async_verify_leg_completion(
     if reader is None or baseline is None:
         return None
     targets = {room.name.strip().casefold(): room.room_id for room in rooms}
+    evidence: dict[str, tuple[str, int]] | None = None
+    matched_key: bytes | None = None
     for attempt in range(attempts):
         _raise_if_completion_verification_was_replaced(
             hass,
@@ -1907,6 +1924,9 @@ async def _async_verify_leg_completion(
                 continue
             matches.append(record)
         if len(matches) == 1:
+            if matched_key is not None and matched_key != matches[0].key:
+                return None
+            matched_key = matches[0].key
             session = matches[0].session
             ended_at = session.ended_at
             assert isinstance(ended_at, str)
@@ -1917,7 +1937,7 @@ async def _async_verify_leg_completion(
             completed_names = {
                 name.strip().casefold() for name in session.completed_rooms
             }
-            evidence: dict[str, tuple[str, int]] = {}
+            evidence = {}
             for name, room_id in targets.items():
                 duration = durations.get(name)
                 if (
@@ -1927,7 +1947,11 @@ async def _async_verify_leg_completion(
                     and duration > 0
                 ):
                     evidence[room_id] = (ended_at, duration)
-            return evidence
+            # Native history can publish timestamps before per-room results.
+            # Keep polling the same record until complete or the bounded window
+            # expires; never combine evidence from different physical sessions.
+            if len(evidence) == len(targets):
+                return evidence
         if len(matches) > 1:
             return None
         if attempt + 1 < attempts:
@@ -1940,7 +1964,7 @@ async def _async_verify_leg_completion(
                 except TimeoutError:
                     continue
                 raise PlanCancelledError
-    return None
+    return evidence
 
 
 async def _async_wait_for_room_outcome(

--- a/docs/acceptance-0.4.md
+++ b/docs/acceptance-0.4.md
@@ -1,7 +1,7 @@
 # 0.4 end-to-end acceptance
 
-Status: candidate, not stable-release sign-off. Installed baseline: `v0.4.0-rc13`
-(`e279f64`). Run this checklist against the exact candidate being promoted.
+Status: candidate, not stable-release sign-off. Installed baseline: `v0.4.0-rc14`
+(`8e3a931`). Run this checklist against the exact candidate being promoted.
 Automated coverage, browser emulation, and read-only live checks do not prove
 physical cleaning, native assistive technology, or affected reporter hardware.
 
@@ -60,6 +60,16 @@ physical cleaning, native assistive technology, or affected reporter hardware.
    incorrect credit, or a runner that fails to settle; record the failed case.
 
 ## Stable promotion gate
+
+RC14 two-room retest (2026-09-04 Pacific): one Quick vacuum mission completed
+both requested rooms natively (378s and 984s; 1,657s overall). Ownership cleared
+and the finished-session event did not duplicate, but both managed rooms ended
+unverified. Total completion credit stayed 112; failure/cancellation/interruption
+counts were unchanged. Positive native evidence was available after verification had
+already ended. The multi-room path lacked the single-room native-session-end wait and
+could stop polling on a matching but incomplete history record. Regressions
+cover both cases; the corrected candidate still needs a fresh physical retest.
+The original plan, presence automation, and template draft were restored.
 
 RC12 two-room check (2026-09-04 Pacific): one native mission completed both
 rooms with positive native per-room durations and returned to dock. The managed

--- a/docs/acceptance-0.4.md
+++ b/docs/acceptance-0.4.md
@@ -68,7 +68,10 @@ unverified. Total completion credit stayed 112; failure/cancellation/interruptio
 counts were unchanged. Positive native evidence was available after verification had
 already ended. The multi-room path lacked the single-room native-session-end wait and
 could stop polling on a matching but incomplete history record. Regressions
-cover both cases; the corrected candidate still needs a fresh physical retest.
+cover both cases. Following settings legs now wait for verified completion
+and persistence before dispatch, so a short next run cannot finish unobserved.
+Same-settings rooms remain one mission. The corrected candidate still needs a
+fresh physical retest.
 The original plan, presence automation, and template draft were restored.
 
 RC12 two-room check (2026-09-04 Pacific): one native mission completed both

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -2817,10 +2817,10 @@ async def test_active_session_can_resume_then_end_unverified() -> None:
 
 
 @pytest.mark.parametrize("use_session_reader", [False, True])
-async def test_room_handoff_retries_prefetch_once_completion_is_verified(
+async def test_room_handoff_dispatches_after_completion_is_persisted(
     hass, use_session_reader: bool
 ) -> None:
-    """An unavailable eager dispatch is retried after verified completion."""
+    """The next dispatch waits for verified completion to be persisted."""
     room = _room("Kitchen", "room-kitchen")
     next_room = _room("Study", "room-study")
     manager = SimpleNamespace(
@@ -2873,11 +2873,9 @@ async def test_room_handoff_retries_prefetch_once_completion_is_verified(
     prefetch_calls = 0
 
     async def prefetch() -> _PreparedRoomDispatch | None:
-        # The eager dispatch at the observed return is unavailable once.
         nonlocal prefetch_calls
         prefetch_calls += 1
-        if prefetch_calls == 1:
-            return None
+        manager.async_mark_completed.assert_awaited_once()
         hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Study"})
         return _PreparedRoomDispatch((next_room,), frozenset(), dt_util.utcnow())
 
@@ -2898,7 +2896,7 @@ async def test_room_handoff_retries_prefetch_once_completion_is_verified(
     )
 
     assert completed is True
-    assert prefetch_calls == 2
+    assert prefetch_calls == 1
     manager.async_mark_verifying.assert_awaited_once()
     manager.async_mark_completed.assert_awaited_once()
     sender.assert_not_awaited()
@@ -3371,7 +3369,12 @@ async def test_leg_that_ends_in_place_is_interrupted_without_credit(hass) -> Non
     )
 
 
-async def test_leg_partial_verification_stops_started_next_leg(hass) -> None:
+async def test_leg_partial_verification_does_not_start_next_leg(
+    hass, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "custom_components.matic_robot.services.SESSION_HISTORY_RETRY_SECONDS", 0
+    )
     rooms = _leg_rooms()
     manager = _leg_manager()
 
@@ -3398,10 +3401,7 @@ async def test_leg_partial_verification_stops_started_next_leg(hass) -> None:
             return ()
         return (_leg_record(("Kitchen",), ("Kitchen",), completed=False),)
 
-    async def prefetch() -> _PreparedRoomDispatch:
-        return _PreparedRoomDispatch(
-            (_heavy_room("Den", "room-den"),), frozenset(), dt_util.utcnow()
-        )
+    prefetch = AsyncMock()
 
     sender = AsyncMock()
     completed = await _async_run_leg(
@@ -3418,7 +3418,8 @@ async def test_leg_partial_verification_stops_started_next_leg(hass) -> None:
     )
 
     assert completed is False
-    sender.assert_awaited_once_with(7, UserCommand.STOP)
+    sender.assert_not_awaited()
+    prefetch.assert_not_awaited()
 
 
 async def test_leg_verifier_filters_bad_records_and_ambiguity(hass) -> None:
@@ -3826,8 +3827,8 @@ async def test_leg_boundary_stop_finishes_current_room_only(hass) -> None:
     assert manager.async_mark_cancelled.await_args.args[2].name == "Office"
 
 
-async def test_room_handoff_dispatches_next_room_before_history_settles(hass) -> None:
-    """The next room is commanded at the observed return, before verification."""
+async def test_room_handoff_waits_for_history_before_dispatch(hass) -> None:
+    """History polling finishes before the next room can start."""
     room = _room("Kitchen", "room-kitchen")
     next_room = _room("Study", "room-study")
     manager = SimpleNamespace(
@@ -3856,10 +3857,13 @@ async def test_room_handoff_dispatches_next_room_before_history_settles(hass) ->
 
     hass.services.async_register("vacuum", "send_command", send_command)
     prefetched = False
+    reads = 0
 
     async def history() -> tuple[CleaningSessionRecord, ...]:
-        # The native record settles only after the next room is underway.
-        if not prefetched:
+        nonlocal reads
+        reads += 1
+        assert not prefetched
+        if reads == 1:
             return ()
         ended = dt_util.utcnow()
         return (
@@ -3878,6 +3882,7 @@ async def test_room_handoff_dispatches_next_room_before_history_settles(hass) ->
 
     async def prefetch() -> _PreparedRoomDispatch:
         nonlocal prefetched
+        manager.async_mark_completed.assert_awaited_once()
         prefetched = True
         hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Study"})
         return _PreparedRoomDispatch((next_room,), frozenset(), dt_util.utcnow())
@@ -3901,12 +3906,11 @@ async def test_room_handoff_dispatches_next_room_before_history_settles(hass) ->
     sender.assert_not_awaited()
 
 
-async def test_room_unverified_eager_handoff_stops_the_started_next_room(
+async def test_room_unverified_handoff_does_not_start_the_next_room(
     hass,
 ) -> None:
-    """An unverified current room stops its eagerly dispatched next room."""
+    """An unverified current room cannot dispatch the following room."""
     room = _room("Kitchen", "room-kitchen")
-    next_room = _room("Study", "room-study")
     manager = SimpleNamespace(
         async_mark_started=AsyncMock(),
         async_mark_completed=AsyncMock(),
@@ -3933,12 +3937,12 @@ async def test_room_unverified_eager_handoff_stops_the_started_next_room(
 
     hass.services.async_register("vacuum", "send_command", send_command)
 
-    async def prefetch() -> _PreparedRoomDispatch:
-        hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Study"})
-        return _PreparedRoomDispatch((next_room,), frozenset(), dt_util.utcnow())
+    prefetch = AsyncMock()
 
     sender = AsyncMock()
-    with patch("custom_components.matic_robot.services.HANDOFF_HISTORY_ATTEMPTS", 1):
+    with patch(
+        "custom_components.matic_robot.services.SESSION_HISTORY_RETRY_SECONDS", 0
+    ):
         completed = await _async_run_room(
             hass,
             _call(hass),
@@ -3953,7 +3957,8 @@ async def test_room_unverified_eager_handoff_stops_the_started_next_room(
         )
 
     assert completed is False
-    sender.assert_awaited_once_with(7, UserCommand.STOP)
+    sender.assert_not_awaited()
+    prefetch.assert_not_awaited()
     manager.async_mark_ended_unverified.assert_awaited_once()
     manager.async_mark_completed.assert_not_awaited()
 
@@ -5376,3 +5381,65 @@ async def test_leg_handles_unknown_and_resumed_native_session(
         assert manager.snapshot("serial")["interrupted_runs"] == 1
         sender.assert_awaited_once_with(7, UserCommand.STOP)
     assert manager.snapshot("serial")["active_plan"] is None
+
+
+async def test_multi_room_leg_persists_completion_before_next_dispatch(
+    hass, monkeypatch
+):
+    """A short next leg cannot run unobserved during prior evidence polling."""
+    manager = CleaningPlanManager(hass)
+    await manager.async_load()
+    monkeypatch.setattr(
+        "custom_components.matic_robot.services.SESSION_HISTORY_RETRY_SECONDS", 0
+    )
+    reads = 0
+    prefetched = False
+
+    async def send_command(_call):
+        hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Kitchen"})
+
+        async def finish():
+            await asyncio.sleep(0)
+            hass.states.async_set(
+                "vacuum.matic", "returning", {"current_area": "Kitchen"}
+            )
+
+        hass.async_create_task(finish(), eager_start=True)
+
+    async def history():
+        nonlocal reads
+        reads += 1
+        assert not prefetched, "next mission started during prior evidence polling"
+        if reads == 1:
+            return ()
+        record = _leg_record(("Kitchen", "Office"), ("Kitchen", "Office"))
+        if reads == 2:
+            record = replace(
+                record,
+                session=replace(record.session, completed_rooms=(), room_durations=()),
+            )
+        return (record,)
+
+    async def prefetch():
+        nonlocal prefetched
+        assert reads == 3
+        assert manager.snapshot("serial")["completed_runs"] == 2
+        assert manager.snapshot("serial")["active_plan"] is None
+        prefetched = True
+        return _PreparedRoomDispatch(
+            (_heavy_room("Den", "room-den"),), frozenset(), dt_util.utcnow()
+        )
+
+    hass.services.async_register("vacuum", "send_command", send_command)
+    assert await _async_run_leg(
+        hass,
+        _leg_call(hass),
+        manager,
+        "vacuum.matic",
+        "serial",
+        _leg_rooms(),
+        active_session=AsyncMock(return_value=False),
+        session_history=history,
+        prefetch_next=prefetch,
+    )
+    assert prefetched

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -5210,3 +5210,169 @@ async def test_execute_history_failure_does_not_orphan_verifying_room(
         assert sender.await_args.args[1] is UserCommand.STOP
     else:
         sender.assert_not_awaited()
+
+
+async def test_leg_waits_for_native_session_end_before_history(hass, monkeypatch):
+    """Returning to dock must not consume the evidence retry window."""
+    manager = CleaningPlanManager(hass)
+    await manager.async_load()
+    monkeypatch.setattr(
+        "custom_components.matic_robot.services.ACTIVE_SESSION_UNKNOWN_RETRY_SECONDS", 0
+    )
+    session_reads = 0
+    history_reads = 0
+
+    async def send_command(_call):
+        hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Kitchen"})
+
+        async def returning():
+            await asyncio.sleep(0)
+            hass.states.async_set(
+                "vacuum.matic", "returning", {"current_area": "Kitchen"}
+            )
+
+        hass.async_create_task(returning(), eager_start=True)
+
+    async def active_session():
+        nonlocal session_reads
+        session_reads += 1
+        return session_reads < 3
+
+    async def history():
+        nonlocal history_reads
+        history_reads += 1
+        if history_reads == 1:
+            return ()
+        assert session_reads >= 3, (
+            "history verification began before native session ended"
+        )
+        return (_leg_record(("Kitchen", "Office"), ("Kitchen", "Office")),)
+
+    hass.services.async_register("vacuum", "send_command", send_command)
+    result = await _async_run_leg(
+        hass,
+        _leg_call(hass),
+        manager,
+        "vacuum.matic",
+        "serial",
+        _leg_rooms(),
+        active_session=active_session,
+        session_history=history,
+    )
+    assert result is True
+    assert manager.snapshot("serial")["completed_runs"] == 2
+    assert manager.snapshot("serial")["active_plan"] is None
+
+
+async def test_leg_retries_matching_history_until_room_evidence_arrives(monkeypatch):
+    """A matching but incomplete record is not the end of verification."""
+    monkeypatch.setattr(
+        "custom_components.matic_robot.services.SESSION_HISTORY_RETRY_SECONDS", 0
+    )
+    final = _leg_record(("Kitchen", "Office"), ("Kitchen", "Office"))
+    early = replace(
+        final,
+        session=replace(
+            final.session, completed=False, completed_rooms=(), room_durations=()
+        ),
+    )
+    reader = AsyncMock(side_effect=[(early,), (final,)])
+    evidence = await _async_verify_leg_completion(
+        reader,
+        frozenset(),
+        _leg_rooms(),
+        dt_util.utcnow() - timedelta(seconds=180),
+        attempts=2,
+    )
+    assert evidence == {
+        "room-kitchen": (final.session.ended_at, 57),
+        "room-office": (final.session.ended_at, 57),
+    }
+    assert reader.await_count == 2
+
+
+async def test_leg_rejects_different_matching_sessions_across_retries(monkeypatch):
+    monkeypatch.setattr(
+        "custom_components.matic_robot.services.SESSION_HISTORY_RETRY_SECONDS", 0
+    )
+    first = _leg_record(("Kitchen",), ("Kitchen",))
+    second = replace(first, key=b"different-session")
+    assert (
+        await _async_verify_leg_completion(
+            AsyncMock(side_effect=[(first,), (second,)]),
+            frozenset(),
+            _leg_rooms(),
+            dt_util.utcnow() - timedelta(seconds=180),
+            attempts=2,
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("resumes", [False, True])
+async def test_leg_handles_unknown_and_resumed_native_session(
+    hass, monkeypatch, resumes
+):
+    manager = CleaningPlanManager(hass)
+    await manager.async_load()
+    reads = 0
+    resolutions = 0
+
+    async def return_later():
+        await asyncio.sleep(0)
+        hass.states.async_set("vacuum.matic", "returning", {"current_area": "Kitchen"})
+
+    async def send_command(_call):
+        hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Kitchen"})
+        hass.async_create_task(return_later(), eager_start=True)
+
+    async def resolution(*args):
+        nonlocal resolutions
+        resolutions += 1
+        if not resumes:
+            return None
+        if resolutions == 1:
+            hass.states.async_set(
+                "vacuum.matic", "cleaning", {"current_area": "Kitchen"}
+            )
+            hass.async_create_task(return_later(), eager_start=True)
+            return True
+        return False
+
+    async def history():
+        nonlocal reads
+        reads += 1
+        if reads == 1:
+            return ()
+        return (_leg_record(("Kitchen", "Office"), ("Kitchen", "Office")),)
+
+    monkeypatch.setattr(
+        "custom_components.matic_robot.services._async_wait_for_active_session_resolution",
+        resolution,
+    )
+    hass.services.async_register("vacuum", "send_command", send_command)
+    sender = AsyncMock()
+    run = _async_run_leg(
+        hass,
+        _leg_call(hass),
+        manager,
+        "vacuum.matic",
+        "serial",
+        _leg_rooms(),
+        active_session=AsyncMock(),
+        session_history=history,
+        managed_user_command=sender,
+        motion_token=7,
+    )
+    if resumes:
+        assert await run is True
+        assert resolutions == 2
+        assert manager.snapshot("serial")["completed_runs"] == 2
+        sender.assert_not_awaited()
+    else:
+        with pytest.raises(ServiceValidationError, match="Native session completion"):
+            await run
+        assert manager.snapshot("serial")["completed_runs"] == 0
+        assert manager.snapshot("serial")["interrupted_runs"] == 1
+        sender.assert_awaited_once_with(7, UserCommand.STOP)
+    assert manager.snapshot("serial")["active_plan"] is None


### PR DESCRIPTION
The RC14 two-room physical run completed both rooms natively, but both managed rooms were marked ended-unverified and received no completion credit. Cleanup and finished-event deduplication worked.

The multi-room runner began its short history window on the return transition, unlike the single-room path that waits for the native session to end. It also returned immediately for a matching history record even when per-room evidence was incomplete. The final multi-room leg now waits for native session resolution, handles resumed/unknown sessions, and polls the same matching record until every target has positive completion evidence or the existing bounded window expires. A different matching session remains ambiguous; evidence from separate sessions is never combined. For both single-room and multi-room legs, the following settings leg is dispatched only after verification and completion persistence finish. This prevents a short next mission from finishing before its observer attaches. Same-settings rooms remain grouped into one native mission.

Validation: both timing/enrichment regressions failed before the fix; 1,287 Python tests pass at 100% coverage, with real plan storage covered. Additional tests cover resume, unknown session state, partial credit and cross-poll ambiguity. Lint/format/types/privacy are green; 399 browser tests passed; hosted gates rerun on this head.

The acceptance record distinguishes native physical completion from the failed managed credit check. No real history was manually credited. A fresh corrected-candidate physical retest is still required.
