### PR TITLE
Fix premature cleaning finished events

### DIFF
--- a/custom_components/matic_robot/coordinator.py
+++ b/custom_components/matic_robot/coordinator.py
@@ -113,7 +113,6 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
         self._snapshot_retry_after = 0.0
         self._device_software_version: str | None = None
         self._last_finished_session: CleaningSession | None = None
-        self._finished_history_initialized = False
         self._finished_observation_started_at = dt_util.utcnow()
         self._session_tracker = CleaningSessionTracker()
         self._session_history_recovered = False
@@ -624,15 +623,14 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
     ) -> None:
         """Announce a newly completed robot cleaning session exactly once."""
         session = state.telemetry.latest_session
-        if not self._finished_history_initialized:
-            if (
-                session is not None
-                or state.telemetry.local_cleaning_sessions is not None
-            ):
-                self._finished_history_initialized = True
-                self._last_finished_session = session
+        if session is None:
             return
-        if session is None or session.ended_at is None:
+        if session.ended_at is None:
+            previous = self._last_finished_session
+            if previous is None or _parse_timestamp(
+                session.started_at
+            ) > _parse_timestamp(previous.started_at):
+                self._last_finished_session = session
             return
         # A partial first snapshot may omit pre-existing runs. Never replay
         # sessions that had already ended before this coordinator started.

--- a/custom_components/matic_robot/coordinator.py
+++ b/custom_components/matic_robot/coordinator.py
@@ -109,6 +109,7 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
         self._snapshot_retry_after = 0.0
         self._device_software_version: str | None = None
         self._last_finished_session: CleaningSession | None = None
+        self._finished_history_initialized = False
         self._session_tracker = CleaningSessionTracker()
         self._session_history_recovered = False
         self._pending_error_codes: tuple[int, ...] = ()
@@ -251,12 +252,13 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
                 pose=pose,
                 telemetry=telemetry,
             )
-            state = await self._async_track_cleaning_session(state)
             version = telemetry.software_version or operational.software_version
             if version is not None:
                 self._async_update_device_software(version, info.serial_number)
             self._async_clear_identity_issue()
+            # Events require native evidence; local estimates are display-only.
             self._async_fire_session_finished(state, version)
+            state = await self._async_track_cleaning_session(state)
             if self.firmware_tracker is not None:
                 await self.firmware_tracker.async_observe_version(
                     self.config_entry.entry_id,
@@ -617,16 +619,23 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
     ) -> None:
         """Announce a newly completed robot cleaning session exactly once."""
         session = state.telemetry.latest_session
+        if not self._finished_history_initialized:
+            if (
+                session is not None
+                or state.telemetry.local_cleaning_sessions is not None
+            ):
+                self._finished_history_initialized = True
+                self._last_finished_session = session
+            return
         if session is None or session.ended_at is None:
             return
         key = (session.started_at, session.ended_at)
         previous = self._last_finished_session
         self._last_finished_session = session
-        # Native history can refine the locally observed interval after the
-        # run has ended. That enrichment must not trigger automations twice.
-        if (
-            previous is None
-            or (previous.started_at, previous.ended_at) == key
+        # Native history can refine timestamps after publication.
+        # That enrichment must not trigger automations twice.
+        if previous is not None and (
+            (previous.started_at, previous.ended_at) == key
             or _sessions_overlap(previous, session)
         ):
             return

--- a/custom_components/matic_robot/coordinator.py
+++ b/custom_components/matic_robot/coordinator.py
@@ -50,7 +50,11 @@ from .const import (
     UPDATE_INTERVAL_SECONDS,
 )
 from .firmware import FirmwareTracker, async_build_firmware_snapshot
-from .session_tracking import CleaningSessionTracker, _sessions_overlap
+from .session_tracking import (
+    CleaningSessionTracker,
+    _parse_timestamp,
+    _sessions_overlap,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -631,6 +635,15 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
             return
         key = (session.started_at, session.ended_at)
         previous = self._last_finished_session
+        # Partial collection snapshots can regress to an older run. Never
+        # move the publication cursor backwards or replay historical events.
+        if (
+            previous is not None
+            and previous.ended_at is not None
+            and _parse_timestamp(session.started_at)
+            <= _parse_timestamp(previous.started_at)
+        ):
+            return
         self._last_finished_session = session
         # Native history can refine timestamps after publication.
         # That enrichment must not trigger automations twice.

--- a/custom_components/matic_robot/coordinator.py
+++ b/custom_components/matic_robot/coordinator.py
@@ -114,6 +114,7 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
         self._device_software_version: str | None = None
         self._last_finished_session: CleaningSession | None = None
         self._finished_history_initialized = False
+        self._finished_observation_started_at = dt_util.utcnow()
         self._session_tracker = CleaningSessionTracker()
         self._session_history_recovered = False
         self._pending_error_codes: tuple[int, ...] = ()
@@ -633,15 +634,21 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
             return
         if session is None or session.ended_at is None:
             return
+        # A partial first snapshot may omit pre-existing runs. Never replay
+        # sessions that had already ended before this coordinator started.
+        if _parse_timestamp(session.ended_at) <= self._finished_observation_started_at:
+            return
         key = (session.started_at, session.ended_at)
         previous = self._last_finished_session
         # Partial collection snapshots can regress to an older run. Never
         # move the publication cursor backwards or replay historical events.
-        if (
-            previous is not None
-            and previous.ended_at is not None
-            and _parse_timestamp(session.started_at)
-            <= _parse_timestamp(previous.started_at)
+        if previous is not None and (
+            _parse_timestamp(session.started_at) < _parse_timestamp(previous.started_at)
+            or (
+                previous.ended_at is not None
+                and _parse_timestamp(session.started_at)
+                == _parse_timestamp(previous.started_at)
+            )
         ):
             return
         self._last_finished_session = session

--- a/custom_components/matic_robot/coordinator.py
+++ b/custom_components/matic_robot/coordinator.py
@@ -634,7 +634,18 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
             return
         # A partial first snapshot may omit pre-existing runs. Never replay
         # sessions that had already ended before this coordinator started.
-        if _parse_timestamp(session.ended_at) <= self._finished_observation_started_at:
+        previous = self._last_finished_session
+        observed_active = (
+            previous is not None
+            and previous.ended_at is None
+            and _parse_timestamp(previous.started_at)
+            == _parse_timestamp(session.started_at)
+        )
+        if (
+            not observed_active
+            and _parse_timestamp(session.ended_at)
+            <= self._finished_observation_started_at
+        ):
             return
         key = (session.started_at, session.ended_at)
         previous = self._last_finished_session

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -515,7 +515,10 @@ or custom logging. Local activity estimates never emit this event. Delivery wait
 for native history refresh; unavailable or stale history can delay or prevent it.
 Existing history at startup is not replayed, and timestamp refinement does not
 emit a duplicate. The completion flag is the native outcome, not an inference
-from docking or elapsed time.
+from docking or elapsed time. A natively observed active session can finish
+regardless of host/robot clock skew. For history-only discoveries, timestamps
+must place the end after integration startup; ambiguous older records are
+omitted rather than replayed as new automation triggers.
 `matic_robot_firmware_changed` likewise carries `device_id`/`entry_id` so
 multi-robot homes can tell which robot updated.
 `matic_robot_firmware_analyzed` is the silent post-snapshot result with safe

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -506,12 +506,16 @@ run totals, or intelligent rotation. Exact plan and room details remain
 available through the response-only plan preview and management actions instead
 of being written into recorder-backed attributes.
 
-When the robot finishes a cleaning session the integration fires
+When native history reports a newly ended cleaning session the integration fires
 `matic_robot_cleaning_finished` with the session's start/end timestamps,
 duration, completion flag, visited rooms, verified completed rooms, per-room
 durations, the firmware version that produced the run, and the
 `device_id`/`entry_id` of the robot — one payload for post-clean notifications
-or custom logging.
+or custom logging. Local activity estimates never emit this event. Delivery waits
+for native history refresh; unavailable or stale history can delay or prevent it.
+Existing history at startup is not replayed, and timestamp refinement does not
+emit a duplicate. The completion flag is the native outcome, not an inference
+from docking or elapsed time.
 `matic_robot_firmware_changed` likewise carries `device_id`/`entry_id` so
 multi-robot homes can tell which robot updated.
 `matic_robot_firmware_analyzed` is the silent post-snapshot result with safe

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1148,3 +1148,26 @@ async def test_finished_event_rejects_partial_startup_history(hass, active_at_st
     await hass.async_block_till_done()
     assert len(events) == 1
     assert events[0].data["completed"] is False
+
+
+async def test_finished_event_observed_native_run_ignores_host_clock_skew(hass):
+    from pytest_homeassistant_custom_component.common import async_capture_events
+
+    from custom_components.matic_robot.const import EVENT_CLEANING_FINISHED
+
+    client = _client()
+    coordinator = _coordinator(hass, client)
+    events = async_capture_events(hass, EVENT_CLEANING_FINISHED)
+    active = CleaningSession("2001-01-01T01:00:00+00:00", None, None, (), (), False)
+    client.async_get_telemetry.return_value = RobotTelemetry(latest_session=active)
+    await coordinator._async_update_data()
+    client.async_get_telemetry.return_value = RobotTelemetry(
+        latest_session=replace(
+            active, ended_at="2001-01-01T01:00:01+00:00", completed=True
+        )
+    )
+    coordinator._force_full_refresh = True
+    await coordinator._async_update_data()
+    await hass.async_block_till_done()
+    assert len(events) == 1
+    assert events[0].data["completed"] is True

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1029,7 +1029,7 @@ async def test_coordinator_updates_device_registry_firmware_once(hass) -> None:
     registry.async_update_device.assert_called_once_with("device", sw_version="v168.11")
 
 
-@pytest.mark.parametrize("empty_history", [False, True])
+@pytest.mark.parametrize("empty_history", [False, True, None])
 async def test_finished_event_waits_for_native_history_after_local_end(
     hass, empty_history
 ) -> None:
@@ -1063,8 +1063,10 @@ async def test_finished_event_waits_for_native_history_after_local_end(
         ("Study", "Den"),
     )
     client.async_get_telemetry.return_value = RobotTelemetry(
-        latest_session=None if empty_history else previous,
-        local_cleaning_sessions=0 if empty_history else 1,
+        latest_session=previous if empty_history is False else None,
+        local_cleaning_sessions=(
+            None if empty_history is None else 0 if empty_history else 1
+        ),
     )
     await coordinator._async_update_data()
     coordinator._session_tracker.latest_session = replace(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1023,3 +1023,62 @@ async def test_coordinator_updates_device_registry_firmware_once(hass) -> None:
         (DOMAIN, "synthetic"), "entry"
     )
     registry.async_update_device.assert_called_once_with("device", sw_version="v168.11")
+
+
+@pytest.mark.parametrize("empty_history", [False, True])
+async def test_finished_event_waits_for_native_history_after_local_end(
+    hass, empty_history
+) -> None:
+    """A local end must not consume the eventual native completion event."""
+    from pytest_homeassistant_custom_component.common import async_capture_events
+
+    from custom_components.matic_robot.const import EVENT_CLEANING_FINISHED
+
+    client = _client()
+    coordinator = _coordinator(hass, client)
+    events = async_capture_events(hass, EVENT_CLEANING_FINISHED)
+    previous = CleaningSession(
+        "2026-07-19T01:00:00+00:00",
+        "2026-07-19T01:10:00+00:00",
+        600,
+        (),
+        (),
+        False,
+    )
+    native = CleaningSession(
+        "2026-07-20T01:00:00+00:00",
+        "2026-07-20T01:30:00+00:00",
+        1800,
+        ("Study", "Den"),
+        (("Study", 800), ("Den", 700)),
+        True,
+        ("Study", "Den"),
+    )
+    client.async_get_telemetry.return_value = RobotTelemetry(
+        latest_session=None if empty_history else previous,
+        local_cleaning_sessions=0 if empty_history else 1,
+    )
+    await coordinator._async_update_data()
+    coordinator._session_tracker.latest_session = replace(
+        native,
+        started_at="2026-07-20T01:00:30+00:00",
+        ended_at="2026-07-20T01:30:02+00:00",
+        completed=False,
+        rooms=(),
+        completed_rooms=(),
+        room_durations=(),
+    )
+    await coordinator._async_update_data()
+    await hass.async_block_till_done()
+    assert not events
+
+    client.async_get_telemetry.return_value = RobotTelemetry(latest_session=native)
+    coordinator._force_full_refresh = True
+    await coordinator._async_update_data()
+    await coordinator._async_update_data()
+    await hass.async_block_till_done()
+    assert len(events) == 1
+    assert events[0].data["completed"] is True
+    assert events[0].data["completed_rooms"] == ["Study", "Den"]
+    assert events[0].data["room_durations"] == {"Study": 800, "Den": 700}
+    assert events[0].data["duration_seconds"] == 1800

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1082,3 +1082,12 @@ async def test_finished_event_waits_for_native_history_after_local_end(
     assert events[0].data["completed_rooms"] == ["Study", "Den"]
     assert events[0].data["room_durations"] == {"Study": 800, "Den": 700}
     assert events[0].data["duration_seconds"] == 1800
+
+    # A partial history snapshot must neither replay an older session nor
+    # roll the deduplication cursor back and replay the completed run.
+    for session in (previous, native):
+        client.async_get_telemetry.return_value = RobotTelemetry(latest_session=session)
+        coordinator._force_full_refresh = True
+        await coordinator._async_update_data()
+    await hass.async_block_till_done()
+    assert len(events) == 1

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -802,7 +802,11 @@ async def test_cleaning_finished_event_fires_once_per_new_session(hass) -> None:
 
     client = _client()
     events = async_capture_events(hass, EVENT_CLEANING_FINISHED)
-    coordinator = _coordinator(hass, client)
+    with patch(
+        "custom_components.matic_robot.coordinator.dt_util.utcnow",
+        return_value=datetime(2026, 7, 20, 1, 45, tzinfo=UTC),
+    ):
+        coordinator = _coordinator(hass, client)
 
     client.async_get_telemetry.return_value = RobotTelemetry(
         software_version="v168.11", latest_session=_session("1")
@@ -1035,7 +1039,11 @@ async def test_finished_event_waits_for_native_history_after_local_end(
     from custom_components.matic_robot.const import EVENT_CLEANING_FINISHED
 
     client = _client()
-    coordinator = _coordinator(hass, client)
+    with patch(
+        "custom_components.matic_robot.coordinator.dt_util.utcnow",
+        return_value=datetime(2026, 7, 19, 12, tzinfo=UTC),
+    ):
+        coordinator = _coordinator(hass, client)
     events = async_capture_events(hass, EVENT_CLEANING_FINISHED)
     previous = CleaningSession(
         "2026-07-19T01:00:00+00:00",
@@ -1091,3 +1099,50 @@ async def test_finished_event_waits_for_native_history_after_local_end(
         await coordinator._async_update_data()
     await hass.async_block_till_done()
     assert len(events) == 1
+
+
+@pytest.mark.parametrize("active_at_startup", [False, True])
+async def test_finished_event_rejects_partial_startup_history(hass, active_at_startup):
+    from pytest_homeassistant_custom_component.common import async_capture_events
+
+    from custom_components.matic_robot.const import EVENT_CLEANING_FINISHED
+
+    client = _client()
+    with patch(
+        "custom_components.matic_robot.coordinator.dt_util.utcnow",
+        return_value=datetime(2026, 7, 20, 1, 45, tzinfo=UTC),
+    ):
+        coordinator = _coordinator(hass, client)
+    events = async_capture_events(hass, EVENT_CLEANING_FINISHED)
+    active = CleaningSession("2026-07-20T01:40:00+00:00", None, None, (), (), False)
+    client.async_get_telemetry.return_value = RobotTelemetry(
+        latest_session=active if active_at_startup else None,
+        local_cleaning_sessions=1 if active_at_startup else 0,
+    )
+    await coordinator._async_update_data()
+    # An empty startup snapshot can omit a completed historical run. An
+    # active startup cursor must also reject older starts even if their
+    # reported end timestamp is newer than coordinator initialization.
+    old = CleaningSession(
+        "2026-07-20T01:00:00+00:00",
+        "2026-07-20T01:50:00+00:00"
+        if active_at_startup
+        else "2026-07-20T01:30:00+00:00",
+        1800,
+        (),
+        (),
+        False,
+    )
+    client.async_get_telemetry.return_value = RobotTelemetry(latest_session=old)
+    coordinator._force_full_refresh = True
+    await coordinator._async_update_data()
+    await hass.async_block_till_done()
+    assert not events
+    client.async_get_telemetry.return_value = RobotTelemetry(
+        latest_session=replace(active, ended_at="2026-07-20T02:00:00+00:00")
+    )
+    coordinator._force_full_refresh = True
+    await coordinator._async_update_data()
+    await hass.async_block_till_done()
+    assert len(events) == 1
+    assert events[0].data["completed"] is False


### PR DESCRIPTION
A finished event could publish a local, unverified `completed: false` estimate before native history arrived, then suppress the verified native result as a duplicate. Publish finished events from native telemetry before local display enrichment, preserving the native outcome, room evidence and duration.

Use coordinator startup time to exclude pre-existing completed sessions without requiring an authoritative initial history snapshot. Keep the native event cursor monotonic, including active sessions, so partial or regressed snapshots cannot replay old runs. First post-start completions still publish after an initial history outage. Local activity estimates remain available for display; native-history availability determines event delivery.

Validation: 1,293 Python tests at 100% coverage; 399 browser tests; Ruff lint/format, strict mypy, frontend types, privacy and wiki checks passed. Regressions cover local/native timing, empty or unavailable startup history, historical replay, active startup sessions, and duplicate suppression. The installed RC15 two-room credit test passed independently; real-robot verification of this event change remains pending.

Known active native sessions finish independently of host clock skew. History-only discoveries with ambiguous pre-startup timestamps remain suppressed; no arbitrary skew allowance replays old automation triggers.
