### PR TITLE
Allow delayed native plan completion and deduplicate room starts

### DIFF
--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -1156,10 +1156,10 @@ async def _async_run_room(
                             active_session
                         )
                         if session_active is False or active_session is None:
+                            mission_timeout.reschedule(None)
                             await manager.async_mark_verifying(
                                 serial_number, call.data["plan_id"], room
                             )
-                            mission_timeout.reschedule(None)
                             completion_verified = await _async_verify_room_completion(
                                 session_history,
                                 history_baseline,
@@ -1174,9 +1174,6 @@ async def _async_run_room(
                             raise RoomInterruptedError(
                                 f"{room.name} completion could not be verified"
                             )
-                        await manager.async_mark_verifying(
-                            serial_number, call.data["plan_id"], room
-                        )
                         session_resolution = (
                             await _async_wait_for_active_session_resolution(
                                 hass,
@@ -1187,6 +1184,9 @@ async def _async_run_room(
                         )
                         if session_resolution is False:
                             mission_timeout.reschedule(None)
+                            await manager.async_mark_verifying(
+                                serial_number, call.data["plan_id"], room
+                            )
                             completion_verified = await _async_verify_room_completion(
                                 session_history,
                                 history_baseline,
@@ -1613,9 +1613,6 @@ async def _async_run_leg(
                         )
                         continue
                     if outcome is RoomRunOutcome.HANDOFF_CANDIDATE:
-                        await manager.async_mark_verifying(
-                            serial_number, call.data["plan_id"], active_room
-                        )
                         if active_session is not None:
                             session_resolution = (
                                 await _async_wait_for_active_session_resolution(
@@ -1632,6 +1629,9 @@ async def _async_run_leg(
                                     "Native session completion could not be confirmed"
                                 )
                         mission_timeout.reschedule(None)
+                        await manager.async_mark_verifying(
+                            serial_number, call.data["plan_id"], active_room
+                        )
                         evidence = await _async_verify_leg_completion(
                             session_history,
                             history_baseline,

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -111,6 +111,7 @@ ACTIVE_SESSION_UNKNOWN_RETRY_SECONDS = 1
 # verification window bounded and cancellable instead of finalizing after 10 s.
 SESSION_HISTORY_ATTEMPTS = 151
 SESSION_HISTORY_RETRY_SECONDS = 2
+SESSION_HISTORY_TIMEOUT_SECONDS = 300
 OEM_STOP_RECONCILIATION_POLL_SECONDS = 5
 
 _LOGGER = logging.getLogger(__name__)
@@ -1848,83 +1849,87 @@ async def _async_verify_leg_completion(
     targets = {room.name.strip().casefold(): room.room_id for room in rooms}
     evidence: dict[str, tuple[str, int]] | None = None
     matched_key: bytes | None = None
-    for attempt in range(attempts):
-        _raise_if_completion_verification_was_replaced(
-            hass,
-            entity_id,
-            cancel_event,
-            allow_active_cleaning=allow_active_cleaning,
-        )
-        try:
-            records = await reader()
-        except MaticError as err:
-            _LOGGER.debug(
-                "Native Matic leg evidence unavailable (%s)", type(err).__name__
-            )
-            records = ()
-        _raise_if_completion_verification_was_replaced(
-            hass,
-            entity_id,
-            cancel_event,
-            allow_active_cleaning=allow_active_cleaning,
-        )
-        now = dt_util.utcnow()
-        matches: list[CleaningSessionRecord] = []
-        for record in records:
-            session = record.session
-            if record.key in baseline:
-                continue
-            started = dt_util.parse_datetime(session.started_at or "")
-            ended = dt_util.parse_datetime(session.ended_at or "")
-            if started is None or ended is None or started > ended:
-                continue
-            if ended < dispatched_at or started > now or ended > now:
-                continue
-            names = [name.strip().casefold() for name in session.rooms]
-            if not names or any(name not in targets for name in names):
-                continue
-            matches.append(record)
-        if len(matches) == 1:
-            if matched_key is not None and matched_key != matches[0].key:
-                return None
-            matched_key = matches[0].key
-            session = matches[0].session
-            ended_at = session.ended_at
-            assert isinstance(ended_at, str)
-            durations = {
-                name.strip().casefold(): duration
-                for name, duration in session.room_durations
-            }
-            completed_names = {
-                name.strip().casefold() for name in session.completed_rooms
-            }
-            evidence = {}
-            for name, room_id in targets.items():
-                duration = durations.get(name)
-                if (
-                    name in completed_names
-                    and isinstance(duration, int)
-                    and not isinstance(duration, bool)
-                    and duration > 0
-                ):
-                    evidence[room_id] = (ended_at, duration)
-            # Native history can publish timestamps before per-room results.
-            # Keep polling the same record until complete or the bounded window
-            # expires; never combine evidence from different physical sessions.
-            if len(evidence) == len(targets):
-                return evidence
-        if len(matches) > 1:
-            return None
-        if attempt + 1 < attempts:
-            if cancel_event is None:
-                await asyncio.sleep(SESSION_HISTORY_RETRY_SECONDS)
-            else:
+    try:
+        async with asyncio.timeout(SESSION_HISTORY_TIMEOUT_SECONDS):
+            for attempt in range(attempts):
+                _raise_if_completion_verification_was_replaced(
+                    hass,
+                    entity_id,
+                    cancel_event,
+                    allow_active_cleaning=allow_active_cleaning,
+                )
                 try:
-                    async with asyncio.timeout(SESSION_HISTORY_RETRY_SECONDS):
-                        await cancel_event.wait()
-                except TimeoutError:
-                    continue
-                raise PlanCancelledError
+                    records = await reader()
+                except MaticError as err:
+                    _LOGGER.debug(
+                        "Native Matic leg evidence unavailable (%s)", type(err).__name__
+                    )
+                    records = ()
+                _raise_if_completion_verification_was_replaced(
+                    hass,
+                    entity_id,
+                    cancel_event,
+                    allow_active_cleaning=allow_active_cleaning,
+                )
+                now = dt_util.utcnow()
+                matches: list[CleaningSessionRecord] = []
+                for record in records:
+                    session = record.session
+                    if record.key in baseline:
+                        continue
+                    started = dt_util.parse_datetime(session.started_at or "")
+                    ended = dt_util.parse_datetime(session.ended_at or "")
+                    if started is None or ended is None or started > ended:
+                        continue
+                    if ended < dispatched_at or started > now or ended > now:
+                        continue
+                    names = [name.strip().casefold() for name in session.rooms]
+                    if not names or any(name not in targets for name in names):
+                        continue
+                    matches.append(record)
+                if len(matches) == 1:
+                    if matched_key is not None and matched_key != matches[0].key:
+                        return None
+                    matched_key = matches[0].key
+                    session = matches[0].session
+                    ended_at = session.ended_at
+                    assert isinstance(ended_at, str)
+                    durations = {
+                        name.strip().casefold(): duration
+                        for name, duration in session.room_durations
+                    }
+                    completed_names = {
+                        name.strip().casefold() for name in session.completed_rooms
+                    }
+                    evidence = {}
+                    for name, room_id in targets.items():
+                        duration = durations.get(name)
+                        if (
+                            name in completed_names
+                            and isinstance(duration, int)
+                            and not isinstance(duration, bool)
+                            and duration > 0
+                        ):
+                            evidence[room_id] = (ended_at, duration)
+                    # Native history can publish timestamps before per-room results.
+                    # Keep polling the same record until complete or the bounded window
+                    # expires; never combine evidence from different physical sessions.
+                    if len(evidence) == len(targets):
+                        return evidence
+                if len(matches) > 1:
+                    return None
+                if attempt + 1 < attempts:
+                    if cancel_event is None:
+                        await asyncio.sleep(SESSION_HISTORY_RETRY_SECONDS)
+                    else:
+                        try:
+                            async with asyncio.timeout(SESSION_HISTORY_RETRY_SECONDS):
+                                await cancel_event.wait()
+                        except TimeoutError:
+                            continue
+                        raise PlanCancelledError
+    except TimeoutError:
+        return evidence
     return evidence
 
 
@@ -2099,60 +2104,65 @@ async def _async_verify_room_completion(
     if reader is None or baseline is None:
         return False
     target = room.name.strip().casefold()
-    for attempt in range(attempts):
-        _raise_if_completion_verification_was_replaced(
-            hass,
-            entity_id,
-            cancel_event,
-            allow_active_cleaning=allow_active_cleaning,
-        )
-        try:
-            records = await reader()
-        except MaticError as err:
-            _LOGGER.debug(
-                "Native Matic completion evidence unavailable (%s)", type(err).__name__
-            )
-            records = ()
-        _raise_if_completion_verification_was_replaced(
-            hass,
-            entity_id,
-            cancel_event,
-            allow_active_cleaning=allow_active_cleaning,
-        )
-        now = dt_util.utcnow()
-        matches: list[CleaningSessionRecord] = []
-        for record in records:
-            session = record.session
-            if record.key in baseline or session.completed is not True:
-                continue
-            started = dt_util.parse_datetime(session.started_at or "")
-            ended = dt_util.parse_datetime(session.ended_at or "")
-            if started is None or ended is None or started > ended:
-                continue
-            if ended < dispatched_at or started > now or ended > now:
-                continue
-            rooms = [name.strip().casefold() for name in session.rooms]
-            durations = [
-                duration
-                for name, duration in session.room_durations
-                if name.strip().casefold() == target and duration > 0
-            ]
-            if rooms == [target] and len(durations) == 1:
-                matches.append(record)
-        if len(matches) == 1:
-            return True
-        if len(matches) > 1:
-            return False
-        if attempt + 1 < attempts:
-            if cancel_event is None:
-                await asyncio.sleep(SESSION_HISTORY_RETRY_SECONDS)
-            else:
+    try:
+        async with asyncio.timeout(SESSION_HISTORY_TIMEOUT_SECONDS):
+            for attempt in range(attempts):
+                _raise_if_completion_verification_was_replaced(
+                    hass,
+                    entity_id,
+                    cancel_event,
+                    allow_active_cleaning=allow_active_cleaning,
+                )
                 try:
-                    async with asyncio.timeout(SESSION_HISTORY_RETRY_SECONDS):
-                        await cancel_event.wait()
-                except TimeoutError:
-                    continue
-                raise PlanCancelledError
+                    records = await reader()
+                except MaticError as err:
+                    _LOGGER.debug(
+                        "Native Matic completion evidence unavailable (%s)",
+                        type(err).__name__,
+                    )
+                    records = ()
+                _raise_if_completion_verification_was_replaced(
+                    hass,
+                    entity_id,
+                    cancel_event,
+                    allow_active_cleaning=allow_active_cleaning,
+                )
+                now = dt_util.utcnow()
+                matches: list[CleaningSessionRecord] = []
+                for record in records:
+                    session = record.session
+                    if record.key in baseline or session.completed is not True:
+                        continue
+                    started = dt_util.parse_datetime(session.started_at or "")
+                    ended = dt_util.parse_datetime(session.ended_at or "")
+                    if started is None or ended is None or started > ended:
+                        continue
+                    if ended < dispatched_at or started > now or ended > now:
+                        continue
+                    rooms = [name.strip().casefold() for name in session.rooms]
+                    durations = [
+                        duration
+                        for name, duration in session.room_durations
+                        if name.strip().casefold() == target and duration > 0
+                    ]
+                    if rooms == [target] and len(durations) == 1:
+                        matches.append(record)
+                if len(matches) == 1:
+                    return True
+                if len(matches) > 1:
+                    return False
+                if attempt + 1 < attempts:
+                    if cancel_event is None:
+                        await asyncio.sleep(SESSION_HISTORY_RETRY_SECONDS)
+                    else:
+                        try:
+                            async with asyncio.timeout(SESSION_HISTORY_RETRY_SECONDS):
+                                await cancel_event.wait()
+                        except TimeoutError:
+                            continue
+                        raise PlanCancelledError
+    except TimeoutError:
+        return False
     return False
 
 

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -1144,7 +1144,9 @@ async def _async_run_room(
             else None
         )
         try:
-            async with asyncio.timeout(call.data["completion_timeout"]):
+            async with asyncio.timeout(
+                call.data["completion_timeout"]
+            ) as mission_timeout:
                 while True:
                     outcome = await _async_wait_for_room_outcome(
                         hass, entity_id, room, cancel_event
@@ -1157,6 +1159,7 @@ async def _async_run_room(
                             await manager.async_mark_verifying(
                                 serial_number, call.data["plan_id"], room
                             )
+                            mission_timeout.reschedule(None)
                             completion_verified = await _async_verify_room_completion(
                                 session_history,
                                 history_baseline,
@@ -1183,6 +1186,7 @@ async def _async_run_room(
                             )
                         )
                         if session_resolution is False:
+                            mission_timeout.reschedule(None)
                             completion_verified = await _async_verify_room_completion(
                                 session_history,
                                 history_baseline,
@@ -1566,7 +1570,9 @@ async def _async_run_leg(
             else None
         )
         try:
-            async with asyncio.timeout(call.data["completion_timeout"]):
+            async with asyncio.timeout(
+                call.data["completion_timeout"]
+            ) as mission_timeout:
                 while True:
                     outcome, changed_room = await _async_wait_for_leg_outcome(
                         hass,
@@ -1625,6 +1631,7 @@ async def _async_run_leg(
                                 raise RoomInterruptedError(
                                     "Native session completion could not be confirmed"
                                 )
+                        mission_timeout.reschedule(None)
                         evidence = await _async_verify_leg_completion(
                             session_history,
                             history_baseline,

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -107,7 +107,9 @@ TARGET_KEYS = (
 ROOM_STATUS_REFRESH_SECONDS = 5
 ACTIVE_SESSION_UNKNOWN_ATTEMPTS = 3
 ACTIVE_SESSION_UNKNOWN_RETRY_SECONDS = 1
-SESSION_HISTORY_ATTEMPTS = 6
+# Native completion records can arrive several minutes after docking. Keep the
+# verification window bounded and cancellable instead of finalizing after 10 s.
+SESSION_HISTORY_ATTEMPTS = 151
 SESSION_HISTORY_RETRY_SECONDS = 2
 OEM_STOP_RECONCILIATION_POLL_SECONDS = 5
 
@@ -1589,15 +1591,17 @@ async def _async_run_leg(
                             stop_sent = True
                             continue
                         active_room = changed_room
+                        first_observation = active_room.room_id not in observed_ids
                         observed_ids.add(active_room.room_id)
                         await manager.async_mark_started(
                             serial_number, call.data["plan_id"], active_room
                         )
-                        hass.bus.async_fire(
-                            f"{DOMAIN}_room_started",
-                            event_data(active_room),
-                            context=call.context,
-                        )
+                        if first_observation:
+                            hass.bus.async_fire(
+                                f"{DOMAIN}_room_started",
+                                event_data(active_room),
+                                context=call.context,
+                            )
                         await manager.async_mark_resumed(
                             serial_number, call.data["plan_id"], active_room
                         )

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -502,7 +502,8 @@ even when live room observations revisit that room, followed by
 `matic_robot_room_cancelled`, plus `matic_robot_room_interrupted` when the task
 is replaced/stopped and `matic_robot_room_ended_unverified` when operational
 handoff is safe but the native completion ledger does not prove success. Native
-history verification allows up to five minutes of retry delays; cancellation and
+history verification has a five-minute elapsed-time deadline including reads and
+retry delays; cancellation and
 replacement checks remain active throughout. No completion is inferred if the
 bounded window expires without native evidence. Only
 `room_completed` advances last-cleaned, successful duration samples, completed

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -496,11 +496,15 @@ Template-visible attributes and recorded history follow one deliberate model:
 
 ## Events and observability
 
-Room execution emits `matic_robot_room_started`,
+Room execution emits `matic_robot_room_started` once per room in a native mission,
+even when live room observations revisit that room, followed by
 `matic_robot_room_completed`, `matic_robot_room_failed`, and
 `matic_robot_room_cancelled`, plus `matic_robot_room_interrupted` when the task
 is replaced/stopped and `matic_robot_room_ended_unverified` when operational
-handoff is safe but the native completion ledger does not prove success. Only
+handoff is safe but the native completion ledger does not prove success. Native
+history verification allows up to five minutes of retry delays; cancellation and
+replacement checks remain active throughout. No completion is inferred if the
+bounded window expires without native evidence. Only
 `room_completed` advances last-cleaned, successful duration samples, completed
 run totals, or intelligent rotation. Exact plan and room details remain
 available through the response-only plan preview and management actions instead

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -5535,3 +5535,62 @@ async def test_leg_room_revisits_emit_one_start_each(hass, monkeypatch):
     await hass.async_block_till_done()
     assert starts == ["Kitchen", "Office"]
     assert manager.async_mark_completed.await_count == 2
+
+
+@pytest.mark.parametrize(
+    "multi_room,resolves", [(True, False), (False, False), (False, True)]
+)
+async def test_terminal_history_has_its_own_budget(
+    hass, monkeypatch, multi_room, resolves
+):
+    """Verification outlives the returned mission's cleaning deadline."""
+    rooms = _leg_rooms() if multi_room else [_leg_rooms()[0]]
+    manager = _leg_manager()
+
+    async def send_command(call):
+        hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Kitchen"})
+
+    hass.services.async_register("vacuum", "send_command", send_command)
+
+    async def terminal(*args, **kwargs):
+        hass.states.async_set("vacuum.matic", "returning")
+        if multi_room:
+            return RoomRunOutcome.HANDOFF_CANDIDATE, None
+        return RoomRunOutcome.HANDOFF_CANDIDATE
+
+    monkeypatch.setattr(
+        "custom_components.matic_robot.services._async_wait_for_leg_outcome"
+        if multi_room
+        else "custom_components.matic_robot.services._async_wait_for_room_outcome",
+        terminal,
+    )
+    reads = 0
+
+    async def history():
+        nonlocal reads
+        reads += 1
+        if reads == 1:
+            return ()
+        await asyncio.sleep(0.05)
+        names = tuple(room.name for room in rooms)
+        return (_leg_record(names, names),)
+
+    sender = AsyncMock()
+    completed = await _async_run_leg(
+        hass,
+        _leg_call(hass, completion_timeout=0.02),
+        manager,
+        "vacuum.matic",
+        "serial",
+        rooms,
+        session_history=history,
+        active_session=AsyncMock(side_effect=[True, False])
+        if resolves
+        else AsyncMock(return_value=False),
+        managed_user_command=sender,
+        motion_token=7,
+    )
+    assert completed
+    manager.async_mark_failed.assert_not_awaited()
+    assert manager.async_mark_completed.await_count == len(rooms)
+    sender.assert_not_awaited()

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -2823,7 +2823,7 @@ async def test_active_session_can_resume_then_end_unverified() -> None:
         )
 
     manager.async_mark_suspended.assert_not_awaited()
-    assert manager.async_mark_verifying.await_count == 2
+    assert manager.async_mark_verifying.await_count == 1
     assert manager.async_mark_resumed.await_count == 2
     manager.async_mark_ended_unverified.assert_awaited_once()
     manager.async_mark_completed.assert_not_awaited()
@@ -5546,6 +5546,11 @@ async def test_terminal_history_has_its_own_budget(
     """Verification outlives the returned mission's cleaning deadline."""
     rooms = _leg_rooms() if multi_room else [_leg_rooms()[0]]
     manager = _leg_manager()
+
+    async def slow_persist(*args):
+        await asyncio.sleep(0.05)
+
+    manager.async_mark_verifying = AsyncMock(side_effect=slow_persist)
 
     async def send_command(call):
         hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Kitchen"})

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -75,6 +75,14 @@ from custom_components.matic_robot.services import (
 )
 
 
+@pytest.fixture(autouse=True)
+def fast_native_history_retries(monkeypatch):
+    """Exercise bounded retry counts without spending minutes on wall time."""
+    monkeypatch.setattr(
+        "custom_components.matic_robot.services.SESSION_HISTORY_RETRY_SECONDS", 0
+    )
+
+
 def _heavy_room(name: str, room_id: str) -> CleaningRoom:
     return CleaningRoom(
         room_id=room_id,
@@ -2717,7 +2725,12 @@ async def test_native_completion_evidence_fails_closed_on_errors_and_ambiguity()
         asyncio.get_running_loop().call_soon(cancel_event.set)
         return ()
 
-    with pytest.raises(PlanCancelledError):
+    with (
+        patch(
+            "custom_components.matic_robot.services.SESSION_HISTORY_RETRY_SECONDS", 1
+        ),
+        pytest.raises(PlanCancelledError),
+    ):
         await _async_verify_room_completion(
             cancel_during_retry,
             frozenset(),
@@ -3717,7 +3730,12 @@ async def test_leg_runs_two_rooms_in_one_mission_without_redispatch(
     sender.assert_not_awaited()
 
 
-async def test_leg_partial_record_credits_only_verified_subset(hass) -> None:
+async def test_leg_partial_record_credits_only_verified_subset(
+    hass, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "custom_components.matic_robot.services.SESSION_HISTORY_RETRY_SECONDS", 0
+    )
     rooms = [_room("Kitchen", "room-kitchen"), _room("Office", "room-office")]
     manager = _leg_manager()
 
@@ -5443,3 +5461,77 @@ async def test_multi_room_leg_persists_completion_before_next_dispatch(
         prefetch_next=prefetch,
     )
     assert prefetched
+
+
+async def test_leg_accepts_native_history_after_three_minutes(monkeypatch):
+    """The default budget covers delayed native publication, without motion."""
+    monkeypatch.setattr(
+        "custom_components.matic_robot.services.SESSION_HISTORY_RETRY_SECONDS", 0
+    )
+    final = _leg_record(("Kitchen", "Office"), ("Kitchen", "Office"))
+    reader = AsyncMock(side_effect=[()] * 90 + [(final,)])
+    evidence = await _async_verify_leg_completion(
+        reader,
+        frozenset(),
+        _leg_rooms(),
+        dt_util.utcnow() - timedelta(seconds=300),
+    )
+    assert evidence == {
+        "room-kitchen": (final.session.ended_at, 57),
+        "room-office": (final.session.ended_at, 57),
+    }
+    assert reader.await_count == 91
+
+
+async def test_leg_room_revisits_emit_one_start_each(hass, monkeypatch):
+    rooms = _leg_rooms()
+    manager = _leg_manager()
+    starts = []
+    hass.bus.async_listen(
+        f"{DOMAIN}_room_started", lambda event: starts.append(event.data["room"])
+    )
+
+    async def send_command(call):
+        hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Kitchen"})
+
+    hass.services.async_register("vacuum", "send_command", send_command)
+    outcomes = iter(
+        [
+            (RoomRunOutcome.ROOM_CHANGED, rooms[1]),
+            (RoomRunOutcome.ROOM_CHANGED, rooms[0]),
+            (RoomRunOutcome.ROOM_CHANGED, rooms[1]),
+            (RoomRunOutcome.HANDOFF_CANDIDATE, None),
+        ]
+    )
+
+    async def next_outcome(*args, **kwargs):
+        outcome = next(outcomes)
+        if outcome[0] is RoomRunOutcome.HANDOFF_CANDIDATE:
+            hass.states.async_set("vacuum.matic", "returning")
+        return outcome
+
+    monkeypatch.setattr(
+        "custom_components.matic_robot.services._async_wait_for_leg_outcome",
+        next_outcome,
+    )
+    reads = 0
+
+    async def history():
+        nonlocal reads
+        reads += 1
+        if reads == 1:
+            return ()
+        return (_leg_record(("Kitchen", "Office"), ("Kitchen", "Office")),)
+
+    assert await _async_run_leg(
+        hass,
+        _call(hass),
+        manager,
+        "vacuum.matic",
+        "serial",
+        rooms,
+        session_history=history,
+    )
+    await hass.async_block_till_done()
+    assert starts == ["Kitchen", "Office"]
+    assert manager.async_mark_completed.await_count == 2

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -5599,3 +5599,31 @@ async def test_terminal_history_has_its_own_budget(
     manager.async_mark_failed.assert_not_awaited()
     assert manager.async_mark_completed.await_count == len(rooms)
     sender.assert_not_awaited()
+
+
+@pytest.mark.parametrize("multi_room", [False, True])
+async def test_native_history_budget_includes_slow_reads(monkeypatch, multi_room):
+    monkeypatch.setattr(
+        "custom_components.matic_robot.services.SESSION_HISTORY_TIMEOUT_SECONDS", 0.01
+    )
+    cancelled = False
+
+    async def slow_reader():
+        nonlocal cancelled
+        try:
+            await asyncio.sleep(1)
+        finally:
+            cancelled = True
+        return ()
+
+    verify = (
+        _async_verify_leg_completion if multi_room else _async_verify_room_completion
+    )
+    result = await verify(
+        slow_reader,
+        frozenset(),
+        _leg_rooms() if multi_room else _leg_rooms()[0],
+        dt_util.utcnow() - timedelta(seconds=300),
+    )
+    assert not result
+    assert cancelled


### PR DESCRIPTION
Native room history can arrive several minutes after a cleaning mission ends. Managed plans previously exhausted six reads over ten seconds and finalized successful rooms as unverified before that evidence arrived. Allow up to 151 reads with two-second retry delays within a five-minute elapsed-time deadline, retaining cancellation, replacement, baseline, timestamp, room identity, and ambiguity checks. If evidence never arrives, the run still receives no unverified completion credit.

Room-start events now fire once per room in a native multi-room mission, even when live room observations revisit earlier rooms. Active-room tracking continues on each transition.

The mission deadline is disarmed after terminal/native-session resolution and before saving verification state, so delayed history and slow persistence do not consume the cleaning budget.

Validation: 1,300 Python tests at 100% coverage, including delayed publication, revisits, and all terminal paths with slow persistence; Ruff, strict types, and public-tree privacy checks. Physical acceptance of this patch remains pending; no release or tag is being published.
