### PR TITLE
Prepare 0.4.0 release candidate metadata and acceptance record

### DIFF
--- a/custom_components/matic_robot/manifest.json
+++ b/custom_components/matic_robot/manifest.json
@@ -25,7 +25,7 @@
     "protobuf>=6",
     "voluptuous>=0.15"
   ],
-  "version": "0.4.0b1",
+  "version": "0.4.0rc1",
   "zeroconf": [
     "_matic_hermes._tcp.local."
   ]

--- a/docs/acceptance-0.4.md
+++ b/docs/acceptance-0.4.md
@@ -1,9 +1,11 @@
 # 0.4 end-to-end acceptance
 
-Status: in progress, not release sign-off. Installed baseline: unpublished
-`16e0ae7`. The 2026-09-05 non-motion audit and corner-control follow-up are
-installed and verified live. This is not physical acceptance of every workflow.
-Run affected journeys and final gates against the exact candidate being promoted.
+Status: in progress, not release sign-off. Installed UI baseline: unpublished
+`2753701`, with exact three-file readback and guarded restart verified.
+September 6 actual iPhone navigation and saved-outline checks passed; the owner
+reported the guided iPhone VoiceOver flow worked and waived separate iPad
+acceptance. This is not physical acceptance of every robot workflow.
+Release preparation targets `0.4.0rc1`; rerun affected gates before promotion.
 
 ## Evidence rules
 
@@ -35,7 +37,7 @@ Run affected journeys and final gates against the exact candidate being promoted
 | Completion credit/events | Only positive native room evidence earns credit; events occur once | Installed baseline two-room pass: one credit/start/completion per room and one correct native finished event |
 | Floor round trip | Floor A → B → A scene/pose/rooms/history/actions agree; no duplicate Repairs | Earlier stable #54 proof; fresh 0.4 physical regression open |
 | Recovery | Honest reconnect/auth/reopen; no stale actions or command replay | Synthetic and prior live non-motion checks; interruption during motion open |
-| Accessibility | Keyboard/focus/labels/zoom/touch usable throughout | 521 browser checks passed on installed UI baseline; native VoiceOver and physical phone/tablet open |
+| Accessibility | Keyboard/focus/labels/zoom/touch usable throughout | 567 browser checks; actual iPhone flows and guided owner VoiceOver pass; iPad waived; broader assistive-technology cases remain separate |
 | Support | Useful redacted diagnostics and discoverable recovery | Privacy tests; fresh live diagnostics connected with verified floor/session; reporter confirmation open |
 
 ## Latest bounded physical evidence

--- a/docs/acceptance-0.4.md
+++ b/docs/acceptance-0.4.md
@@ -121,11 +121,12 @@ candidate is reviewed, installed and current operator readiness is confirmed.
 
 ## Perimeter live follow-up
 
-The unpublished perimeter candidate after `16e0ae7` is installed; final frontend
-SHA-256 prefix `9eb8a5eac8ec`. Guarded file readback and idle restart passed.
-Live Safari found/fixed hidden vertex controls and the missing desktop naming
-step. Final responsive desktop/tablet/phone checks, point editing and save/reopen
-passed; a saved outline survived restart. Temporary test data was removed with
-recovery retained and original areas unchanged. No robot motion occurred.
-The final browser suite passes519 checks; native devices and VoiceOver remain
-open. See [release readiness](release-readiness-0.4.md) for separate gates.
+The installed `2753701` UI baseline passed guarded file readback and restart.
+Live Safari verified point editing, automatic closure, further-point extension,
+save/exit without a false discard prompt and saved-outline reopen. Earlier
+perimeter checks also verified persistence across restart. Temporary test areas
+were removed with recovery retained and original areas unchanged.
+The current browser suite passes 567 checks. Actual iPhone navigation and saved
+outline checks passed; guided iPhone VoiceOver has an owner-reported pass, and
+separate iPad acceptance is waived. Broader assistive-technology and physical
+cleaning gates remain separate. See [release readiness](release-readiness-0.4.md).

--- a/docs/acceptance-0.4.md
+++ b/docs/acceptance-0.4.md
@@ -30,7 +30,7 @@ Release preparation targets `0.4.0rc1`; rerun affected gates before promotion.
 | Everyday navigation | 2D/3D, room/photo views, drafts, preferences and reopen preserve intent | Automated and live checks; installed narrow drawing exit and arrow/End navigation passed |
 | Saved floor | Read-only history, no live pose or cleaning actions; return restores live controls | Fresh 2026-09-05 live read-only pass |
 | One-time clean | Explicit settings, one dispatch, visible scene and native completion | Earlier bounded room run passed; current settings inspected without dispatch |
-| Saved plan | Persist settings/order; preview matches legs; no duplicate start | Same-settings two-room baseline passed; different-settings multi-leg execution open |
+| Saved plan | Persist settings/order; preview matches legs; no duplicate start | Same-settings two-room baseline passed; different-settings attempt stopped after scene loss; handoff open |
 | Custom area | Draw/save/reopen/run selected geometry; stale geometry has safe recovery | Live create/save/reopen and one bounded saved-zone completion passed; separately interrupted run remains open |
 | Immediate stop | Settlement, replacement-work protection and prompt safe dock | Regression coverage; fresh physical #71 retest open |
 | Finish-current-room | Below threshold stops; exact/above finishes only current room; next room never starts | Synthetic boundaries; physical threshold/pause/recharge cases open |
@@ -63,6 +63,16 @@ but native history still marked that run completed, so interruption is not
 proved. A subsequent attempt was rejected before dispatch by the changed-map
 binding guard. The automation and original saved-area state were restored.
 The UI-only `e29d7fd` follow-up passed guarded restart and idle readback.
+
+On unpublished `2753701`, a different-settings two-leg plan was stopped after
+its first leg lost the visible live scene. The second leg never started. Return
+to dock succeeded, managed completion totals stayed unchanged, and the temporary
+plan was removed with original plan definitions, selection and automation state
+restored. Native history nevertheless marked the interrupted first leg completed
+and emitted a finished event. The stop-settlement fence remained set. Mixed-leg
+handoff, scene recovery and interrupted native completion remain unresolved;
+this attempt is not a release acceptance pass. Retain the fence and investigate
+before another physical run.
 
 ## Remaining physical sequence
 

--- a/docs/product-review-0.4.md
+++ b/docs/product-review-0.4.md
@@ -1,12 +1,15 @@
 # 0.4 product review
 
 Status: in progress; not a claim of complete end-to-end or physical acceptance.
-Installed baseline: unpublished `16e0ae7`; audit and corner-control fixes are
-installed and verified live. Physical and native-device acceptance remain open.
+Installed baseline: unpublished `2753701`; perimeter and phone follow-ups are
+verified live. Actual iPhone checks passed; the owner reported guided iPhone
+VoiceOver navigation passed and waived separate iPad acceptance. Broader physical
+acceptance remains open. Current baseline: 567 browser checks.
 Authority: redesign structure and workflows where evidence supports it.
 Live walkthrough uses the actual signed-in HA; synthetic states are regression
 fixtures, never evidence of deployed behavior. Historical RC11 checks are
-scoped below; the current audit is dated 2026-09-05.
+scoped below; the earlier audit is dated 2026-09-05. Current acceptance is in
+[release readiness](release-readiness-0.4.md).
 
 ## Principles
 
@@ -20,7 +23,7 @@ scoped below; the current audit is dated 2026-09-05.
 - Evaluate empty/error/loading states as product screens, not exceptions.
 - Each acceptance claim names its evidence and remaining limitations.
 
-## Coverage ledger
+## Historical September 5 coverage ledger
 
 | Surface | Review focus | Current evidence |
 | --- | --- | --- |
@@ -39,7 +42,7 @@ scoped below; the current audit is dated 2026-09-05.
 | Packaging/upgrades | Artifact parity, HACS, cache changes | Installed baseline parity/restart, packaging, CI and review verified |
 | Hardware | Multi-leg, area, interruption, floor round trip | Open; see acceptance-0.4.md |
 
-## Current non-motion audit
+## Historical non-motion audit — installed `16e0ae7`
 
 Fresh live read-only inspection covers one-time settings, the blank drawing
 workspace, saved-floor action/pose withholding and return to current, plus
@@ -123,7 +126,7 @@ walkthroughs verify the side-profile task/sidebar icons, visible room choices,
 All tasks, saved-floor selection, read-only guards and custom-area review copy.
 Real-device, assistive-technology and remaining physical journeys stay open.
 
-## Perimeter and responsive follow-up
+## Perimeter and responsive follow-up — superseded initial evidence
 
 The new Zone tool preserves editable perimeter points, validates the generated
 coverage, and retains Paint/Erase. Point actions have keyboard equivalents and
@@ -132,7 +135,11 @@ Portrait tablets now use the sheet, while landscape tablets and desktop keep
 the sidebar. The phone mode/history rows, theme-aware map background and
 separated scale/context controls have dedicated browser checks.
 Live HA testing found and fixed hidden Safari accessibility controls and the
-missing desktop naming step. The final installed bundle passed responsive
+missing desktop naming step. The initial installed bundle passed responsive
 checks, vertex editing and save/reopen, with 519 browser tests passing.
-Exact review, native accessibility and physical acceptance remain open in
+The later `2753701` baseline passed 567 browser checks, actual iPhone automatic
+closure, further-point extension, save/exit without false discard and reopen.
+The owner reported guided iPhone VoiceOver passed and waived separate iPad
+acceptance. Review of PR #114 and its hosted gates passed before installation.
+Broader physical gates and PR #115 preparation review remain tracked in
 [release readiness](release-readiness-0.4.md).

--- a/docs/release-notes-0.4.md
+++ b/docs/release-notes-0.4.md
@@ -39,7 +39,7 @@ not published releases.
 Earlier unpublished `56b4d4b` passed a bounded same-settings two-room run with one
 credit/start/completion per room and one correct native finished event, followed
 by clean return-to-charge and ownership cleanup. This is not evidence for all
-physical workflows. The installed audit passed 1,301 Python tests at 100%
+physical workflows. The earlier `16e0ae7` audit passed 1,301 Python tests at 100%
 coverage, 471 browser checks, hosted gates, exact-head review and affected live
 non-motion checks. Subsequent changes require their own validation.
 

--- a/docs/release-notes-0.4.md
+++ b/docs/release-notes-0.4.md
@@ -1,8 +1,8 @@
 # 0.4 release notes — draft
 
 Unpublished draft, not a release announcement or acceptance certificate.
-The installed unpublished candidate includes the perimeter editor and live
-Safari accessibility/naming fixes after `16e0ae7`. The intended first public candidate is `v0.4.0-rc1`, subject to
+The installed unpublished UI baseline is `2753701`, including automatic
+perimeter closure, saved-area recovery and companion-app safe-area fixes. The intended first public candidate is `v0.4.0-rc1`, subject to
 completed acceptance and explicit release approval. Intermediate builds are
 not published releases.
 
@@ -43,9 +43,12 @@ physical workflows. The installed audit passed 1,301 Python tests at 100%
 coverage, 471 browser checks, hosted gates, exact-head review and affected live
 non-motion checks. Subsequent changes require their own validation.
 
-Different-settings mission legs, custom-area runs, Stop/interruption and
-threshold behavior, a fresh floor round trip, affected #65/#71 hardware, native
-VoiceOver and physical phone/tablet acceptance remain open. Fresh hardware
+Actual iPhone navigation, plan creation/discard and saved-outline checks passed.
+The owner reported the guided iPhone VoiceOver flow worked; separate iPad
+acceptance was waived. Different-settings mission legs, Stop/interruption and
+threshold behavior, a fresh floor round trip and affected #65/#71 hardware
+remain open. A saved-zone completion passed, while its separate interrupted
+run retained an unresolved native completed classification. Fresh hardware
 pairing and Container reauthentication also remain distinct checks. See the
 [acceptance checklist](acceptance-0.4.md) for outcomes and release gates.
 

--- a/docs/release-readiness-0.4.md
+++ b/docs/release-readiness-0.4.md
@@ -20,6 +20,10 @@ Release preparation targets `0.4.0rc1` / `v0.4.0-rc1`; it is not yet published.
 - An isolated HA 2026.7 Store rehearsal preserved synthetic plan/area selection
   across stable-to-candidate loading and restored the matching backup byte for
   byte. This does not prove live credential migration or HACS rollback.
+- A different-settings attempt on `2753701` stopped after first-leg scene loss.
+  Docking succeeded and managed completion totals stayed unchanged; native
+  history still reported completion and the stop-settlement fence remained.
+  Original plans, selection and automation were restored; test plan removed.
 - Different-settings handoff, interruption/native completion semantics, physical
   thresholds, fresh floor carries and affected reporter hardware remain open.
 

--- a/docs/release-readiness-0.4.md
+++ b/docs/release-readiness-0.4.md
@@ -1,9 +1,27 @@
 # 0.4 release readiness
 
 Status: acceptance in progress; no release authorization implied.
-Installed candidate: unpublished `e29d7fd`, verified live after guarded restart.
-PR109/110 regular exact-head review and CI passed; public release approval is open.
-Saved-area startup recovery is the current follow-up under validation.
+Installed UI baseline: unpublished `2753701` (PR #114), reviewed at `2443f8b`.
+Pre- and post-merge Python, browser, HACS and Hassfest checks passed. The three
+installed UI files matched their recorded hashes after guarded restart.
+Release preparation targets `0.4.0rc1` / `v0.4.0-rc1`; it is not yet published.
+
+## September 6 acceptance update
+
+- Actual iPhone Air testing passed companion safe areas, HA navigation, plan
+  selection/creation, draft discard, automatic outline closure, further points,
+  save/exit without a false discard prompt, and four-point saved-area reopen.
+- The owner reported the guided iPhone VoiceOver plan/create/discard navigation
+  check worked. This is an owner-reported pass, not an instrumented audit.
+- Separate physical iPad acceptance is waived by the owner following phone
+  acceptance; no physical iPad test is claimed.
+- Latest UI baseline: 567 local browser checks and 55 focused packaging/privacy
+  checks passed. Full Python baseline remains 1,321 tests at 100% coverage.
+- An isolated HA 2026.7 Store rehearsal preserved synthetic plan/area selection
+  across stable-to-candidate loading and restored the matching backup byte for
+  byte. This does not prove live credential migration or HACS rollback.
+- Different-settings handoff, interruption/native completion semantics, physical
+  thresholds, fresh floor carries and affected reporter hardware remain open.
 
 ## Completed baseline evidence
 
@@ -47,7 +65,8 @@ Saved-area startup recovery is the current follow-up under validation.
   available; mismatched scene responses become retryable errors.
 - Exact HA2026.7 Bluetooth/camera and integration imports pass with platform
   manifest dependencies installed; pip check passes. This is not hardware proof.
-- Native devices, VoiceOver and physical cleaning remain separate open gates.
+- Phone and guided owner VoiceOver checks passed as scoped above; broader
+  assistive technology and physical cleaning remain separate evidence.
 
 ## Work queue
 
@@ -58,7 +77,7 @@ Saved-area startup recovery is the current follow-up under validation.
 | Performance/resource observation | Record final-build load and interaction conditions; synthetic traces do not prove live-map or long-session performance |
 | Minimum supported HA | Legacy registry migration and Bluetooth/camera dependency imports pass on HA2026.7; hardware setup remains separate |
 | Stable upgrade and rollback | Rehearse stable-to-candidate upgrade and matching-backup recovery on a disposable instance; preserve plans/areas/configuration |
-| Native accessibility/devices | VoiceOver, actual phone/tablet, touch, orientation and enlarged text; emulation is separate |
+| Native accessibility/devices | Phone and guided owner VoiceOver pass; iPad waived. Broader touch, orientation and enlarged-text evidence stays separate |
 | Pairing/reauthentication | Supported hardware and Container credential replacement; imports and synthetic Bluetooth tests are separate |
 | Mixed-settings plan | Native multi-leg completion, handoff, exactly-once credit/events and ownership cleanup |
 | Stop/interruption | Map/action/automation Stop, pause/resume, reconnect/restart during work, no replay or false credit |

--- a/docs/release-readiness-0.4.md
+++ b/docs/release-readiness-0.4.md
@@ -27,7 +27,7 @@ Release preparation targets `0.4.0rc1` / `v0.4.0-rc1`; it is not yet published.
 - Different-settings handoff, interruption/native completion semantics, physical
   thresholds, fresh floor carries and affected reporter hardware remain open.
 
-## Completed baseline evidence
+## Historical audit evidence (`16e0ae7`)
 
 - 1,301 Python tests at 100% coverage and 471 browser tests; lint, format,
   types, privacy, packaging, hosted CI and clean exact-head review passed.
@@ -44,6 +44,9 @@ Release preparation targets `0.4.0rc1` / `v0.4.0-rc1`; it is not yet published.
 
 ## Perimeter editor and live verification
 
+The results below cover successive unpublished perimeter fixes; the current
+installed baseline and September 6 results are identified above.
+
 - Saved zones retain editable vertices as private optional metadata. Dispatch
   still uses the verified circle command, with coverage contained inside the
   perimeter and bound to the current map. Narrow edges can remain uncovered;
@@ -52,12 +55,13 @@ Release preparation targets `0.4.0rc1` / `v0.4.0-rc1`; it is not yet published.
   sheet. Phone tools use separate mode/history rows with 44px targets.
 - Light/dark layouts, mouse/touch/keyboard input, vertex edits, invalid geometry,
   cancellation, stale-floor privacy and saved metadata have automated coverage.
-- Local gates: 521 browser tests; 1,321 Python tests at100% coverage; lint,
-  types, privacy,76-file archive parity/fresh import and HA2026.7 migration pass.
+- Current UI baseline `2753701`: 567 browser checks. Candidate code passes
+  1,321 Python tests at 100% coverage, lint, types, privacy and 76-file archive
+  parity. Minimum-runtime fresh imports and synthetic migration also pass.
 - Guarded installation and restart passed with exact file readback and rollback.
 - Live Safari exposed two defects: image semantics hid vertex controls, and
   desktop bypassed the naming step. Both are fixed and verified live; unchanged
-  saved outlines also return to review. The installed tree passes 521 browser tests.
+  saved outlines also return to review.
 - Actual HA passed create/close/drag, insert/delete, undo/redo, keyboard point
   editing, save/reopen and persistence across restart. Final responsive checks
   covered desktop, both tablet orientations and 320/390px phones.
@@ -76,11 +80,11 @@ Release preparation targets `0.4.0rc1` / `v0.4.0-rc1`; it is not yet published.
 
 | Gate | Status and next evidence |
 | --- | --- |
-| Keyboard and perimeter editor | Installed and tested live, including naming and saved metadata; exact review passed; native-device acceptance remains open |
+| Keyboard and perimeter editor | Installed and tested live, including naming and saved metadata; exact review and scoped iPhone checks passed; broader device cases remain separate |
 | Screen/state coverage | Reconcile frontend closure report with normal, empty, loading, error and recovery cases; retain explicit native-device gaps |
 | Performance/resource observation | Record final-build load and interaction conditions; synthetic traces do not prove live-map or long-session performance |
 | Minimum supported HA | Legacy registry migration and Bluetooth/camera dependency imports pass on HA2026.7; hardware setup remains separate |
-| Stable upgrade and rollback | Rehearse stable-to-candidate upgrade and matching-backup recovery on a disposable instance; preserve plans/areas/configuration |
+| Stable upgrade and rollback | Synthetic Store rehearsal passed with plan/area selection and byte-for-byte backup restoration; live credential migration and HACS rollback remain open |
 | Native accessibility/devices | Phone and guided owner VoiceOver pass; iPad waived. Broader touch, orientation and enlarged-text evidence stays separate |
 | Pairing/reauthentication | Supported hardware and Container credential replacement; imports and synthetic Bluetooth tests are separate |
 | Mixed-settings plan | Native multi-leg completion, handoff, exactly-once credit/events and ownership cleanup |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "matic-home-assistant"
-version = "0.4.0b1"
+version = "0.4.0rc1"
 description = "Unofficial local-only Home Assistant integration for Matic robot vacuums"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -28,7 +28,7 @@ def test_release_versions_and_links_are_consistent() -> None:
     hacs = json.loads((ROOT / "hacs.json").read_text())
     project = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]
 
-    assert manifest["version"] == "0.4.0b1"
+    assert manifest["version"] == "0.4.0rc1"
     assert project["version"] == manifest["version"]
     assert hacs["homeassistant"] == "2026.7.0"
     assert manifest["documentation"].startswith("https://github.com/")


### PR DESCRIPTION
Prepare the first 0.4 release candidate by aligning package and HACS metadata at `0.4.0rc1` and updating packaging expectations. Acceptance records include actual iPhone navigation and outline checks, the guided owner-reported VoiceOver pass, the iPad waiver, and synthetic backup recovery.

A different-settings physical attempt on the installed baseline stopped after first-leg scene loss. The second leg never started; docking succeeded and managed completion totals stayed unchanged. Native history still marked the interrupted leg complete and emitted a finished event. Original plans, selection and automation were restored and the temporary plan removed. Mixed-leg handoff and interrupted native completion remain unresolved; no public release or physical acceptance is claimed.

Rebased onto the merged scene-recovery fix from #116. That fix passed 569 browser checks and a clean exact-head regular review; it repairs a reproduced retry gap without establishing the physical failure's original cause. The earlier release-preparation head passed 1,321 Python tests at 100% coverage, 567 browser checks, Ruff, format, MyPy, TypeScript, privacy and 76-file wheel/sdist parity. Fresh hosted checks and regular review are required on this combined head.
