### PR TITLE
fix: withhold room credit for conflicting native statuses

### DIFF
--- a/custom_components/matic_robot/client/api.py
+++ b/custom_components/matic_robot/client/api.py
@@ -1937,7 +1937,13 @@ def _decode_cleaning_session(payload: bytes) -> CleaningSession | None:
     room_completion: dict[str, bool | None] = {}
     for name in rooms:
         statuses = room_mode_statuses.get(name, set())
-        if _ROOM_MODE_COMPLETED_STATUS in statuses:
+        # Mixed mode statuses occur in confirmed interrupted sessions. Until
+        # the requested mode can be verified, one completed mode is not proof
+        # that the whole commanded room finished.
+        if (
+            statuses == {_ROOM_MODE_COMPLETED_STATUS}
+            and name not in rooms_with_unknown_status
+        ):
             room_completion[name] = True
         elif (
             statuses == {_ROOM_MODE_NON_COMPLETION_STATUS}

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -238,7 +238,7 @@ def test_decode_wifi_schedule_and_history() -> None:
         _bfield(3, b"Kitchen")
         + _bfield(4, _vfield(1, 600))
         + _vfield(5, 2)
-        + _vfield(6, 1)
+        + _vfield(6, 2)
     )
     room = _bfield(2, details)
     summary = (
@@ -355,7 +355,7 @@ def test_decode_room_completion_statuses_fail_closed() -> None:
             + b"".join(_vfield(field, value) for field, value in statuses)
         )
 
-    completed = details(b"Kitchen", 600, (5, 2), (6, 1))
+    completed = details(b"Kitchen", 600, (5, 2), (6, 2))
     interrupted = details(b"Hallway", 120, (5, 1), (6, 1))
     summary = _bfield(6, _bfield(1, _bfield(2, completed))) + _bfield(
         6, _bfield(1, _bfield(2, interrupted))
@@ -368,6 +368,25 @@ def test_decode_room_completion_statuses_fail_closed() -> None:
     assert session.room_durations == (("Kitchen", 600), ("Hallway", 120))
     assert session.completed_rooms == ("Kitchen",)
     assert session.completed is False
+
+    # A confirmed cancelled native record mixed non-complete and complete
+    # mode statuses. Neither ordering proves completion of the whole room.
+    for status_pair in [(1, 2), (2, 1), (2, 3)]:
+        ambiguous = details(b"Office", 90, (5, status_pair[0]), (6, status_pair[1]))
+        ambiguous_session = _decode_cleaning_session(
+            _bfield(5, _bfield(6, _bfield(1, _bfield(2, ambiguous))))
+        )
+        assert ambiguous_session is not None
+        assert ambiguous_session.completed is None
+        assert ambiguous_session.completed_rooms == ()
+
+    malformed_complete = details(b"Office", 90, (5, 2)) + _bfield(6, b"unknown")
+    malformed_complete_session = _decode_cleaning_session(
+        _bfield(5, _bfield(6, _bfield(1, _bfield(2, malformed_complete))))
+    )
+    assert malformed_complete_session is not None
+    assert malformed_complete_session.completed is None
+    assert malformed_complete_session.completed_rooms == ()
 
     unknown = details(b"Office", 90, (5, 3))
     unknown_session = _decode_cleaning_session(


### PR DESCRIPTION
Native room history can contain both complete and non-complete mode statuses. Previously, any complete status granted room completion, allowing a confirmed interrupted session to qualify for credit.

Require every observed mode status to be complete and well formed before crediting a room. Mixed, unknown, or malformed statuses remain unverified; wholly non-complete statuses remain false. This conservatively withholds credit when the requested mode cannot be established, without guessing a stop-reason enum. Synthetic regressions cover both mixed-status orderings, unknown status alongside completion, and malformed status alongside completion.

Validation: 1,321 Python tests pass at 100% coverage; Ruff, formatting, strict MyPy, privacy, and diff checks pass. Private read-only comparison retains completion for a confirmed finished record and removes completion credit from a confirmed interrupted record. No private records or identifiers are included.
