### PR TITLE
claude-review: drop LS from allowed tools

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: >-
-            --allowedTools "Read,Grep,Glob,LS,Bash(gh pr diff:*),Bash(gh pr
+            --allowedTools "Read,Grep,Glob,Bash(gh pr diff:*),Bash(gh pr
             view:*)" --disallowedTools "Task"
           prompt: |
             You are this repository's regular review gate. Review pull request


### PR DESCRIPTION
`LS` is not a current Claude Code tool name; Read/Grep/Glob remain. actionlint clean. No other workflow bytes changed.