### PR TITLE
fix: recognize verified vacuum-only room completion

### DIFF
--- a/custom_components/matic_robot/client/api.py
+++ b/custom_components/matic_robot/client/api.py
@@ -1863,6 +1863,8 @@ def _decode_cleaning_session(payload: bytes) -> CleaningSession | None:
     room_durations: dict[str, int] = {}
     room_mode_statuses: dict[str, set[int]] = {}
     rooms_with_unknown_status: set[str] = set()
+    room_vacuum_statuses: dict[str, set[int]] = {}
+    rooms_without_vacuum_status: set[str] = set()
     try:
         fields = _bounded_fields(
             summary,
@@ -1903,6 +1905,15 @@ def _decode_cleaning_session(payload: bytes) -> CleaningSession | None:
                 seen_rooms.add(name)
                 rooms.append(name)
             status_fields = [field for field in detail_fields if field.number in (5, 6)]
+            vacuum_fields = [field for field in status_fields if field.number == 5]
+            if (
+                len(vacuum_fields) == 1
+                and vacuum_fields[0].wire_type == 0
+                and isinstance(vacuum_fields[0].value, int)
+            ):
+                room_vacuum_statuses.setdefault(name, set()).add(vacuum_fields[0].value)
+            else:
+                rooms_without_vacuum_status.add(name)
             statuses = room_mode_statuses.setdefault(name, set())
             for field in status_fields:
                 if field.wire_type == 0 and isinstance(field.value, int):
@@ -1953,6 +1964,20 @@ def _decode_cleaning_session(payload: bytes) -> CleaningSession | None:
         else:
             room_completion[name] = None
     completed_rooms = tuple(name for name in rooms if room_completion.get(name) is True)
+    # Confirmed vacuum-only runs finish with field 5 == 2 even when field 6
+    # is 1; confirmed interrupted vacuum runs have field 5 == 1 and field 6
+    # == 2. Preserve this command-specific proof instead of merging the fields.
+    # Other cleaning modes still require the conservative whole-room result.
+    vacuum_completed_rooms = tuple(
+        name
+        for name in rooms
+        if completion_status == _SESSION_COMPLETED_STATUS
+        and room_vacuum_statuses.get(name) == {_ROOM_MODE_COMPLETED_STATUS}
+        and name not in rooms_without_vacuum_status
+        and name not in rooms_with_unknown_status
+        and room_mode_statuses[name]
+        <= {_ROOM_MODE_COMPLETED_STATUS, _ROOM_MODE_NON_COMPLETION_STATUS}
+    )
     completed: bool | None
     if completion_status not in (None, _SESSION_COMPLETED_STATUS):
         completed = False
@@ -1972,6 +1997,7 @@ def _decode_cleaning_session(payload: bytes) -> CleaningSession | None:
         room_durations=tuple(room_durations.items()),
         completed=completed,
         completed_rooms=completed_rooms,
+        vacuum_completed_rooms=vacuum_completed_rooms,
     )
 
 

--- a/custom_components/matic_robot/client/models.py
+++ b/custom_components/matic_robot/client/models.py
@@ -224,6 +224,7 @@ class CleaningSession:
     room_durations: tuple[tuple[str, int], ...]
     completed: bool | None
     completed_rooms: tuple[str, ...] = ()
+    vacuum_completed_rooms: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)

--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -1524,12 +1524,19 @@ def _validated_native_reconciliation(
     parsed_expiry = dt_util.parse_datetime(expires_at)
     if parsed_expiry is None or parsed_expiry.tzinfo is None:
         return None
+    cleaning_mode = value.get("cleaning_mode")
     return {
         "plan_id": plan_id,
         "room_id": room_id,
         "room": room,
         "dispatched_at": dispatched_at,
         "expires_at": expires_at,
+        **(
+            {"cleaning_mode": cleaning_mode}
+            if isinstance(cleaning_mode, str)
+            and cleaning_mode in ("vacuum", "mop", "vacuum_and_mop")
+            else {}
+        ),
     }
 
 
@@ -1587,7 +1594,10 @@ def _reconcile_pending_native_history(
     matches: list[tuple[CleaningSessionRecord, str, int]] = []
     for record in records:
         session = record.session
-        if session.completed is not True:
+        vacuum_proven = pending.get("cleaning_mode") == "vacuum" and target in {
+            _native_room_key(name) for name in session.vacuum_completed_rooms
+        }
+        if session.completed is not True and not vacuum_proven:
             continue
         started = dt_util.parse_datetime(session.started_at or "")
         ended = dt_util.parse_datetime(session.ended_at or "")
@@ -1603,7 +1613,7 @@ def _reconcile_pending_native_history(
         if native_rooms != (target,):
             continue
         completed_rooms = {_native_room_key(name) for name in session.completed_rooms}
-        if target not in completed_rooms:
+        if target not in completed_rooms and not vacuum_proven:
             continue
         duration = next(
             (

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -145,6 +145,7 @@ class _NativeReconciliation:
     room_id: str
     room: str
     dispatched_at: datetime
+    cleaning_mode: str | None = None
 
 
 CLEAN_SERVICE_SCHEMA = cv.make_entity_service_schema(
@@ -2343,7 +2344,9 @@ def _build_native_reconciliation(
     """Build a late-native marker only after the robot visibly started the room."""
     if not room_started or dispatched_at is None:
         return None
-    return _NativeReconciliation(plan_id, room.room_id, room.name, dispatched_at)
+    return _NativeReconciliation(
+        plan_id, room.room_id, room.name, dispatched_at, room.cleaning_mode
+    )
 
 
 def _native_reconciliation_data(
@@ -2357,6 +2360,7 @@ def _native_reconciliation_data(
         "room_id": value.room_id,
         "room": value.room,
         "dispatched_at": value.dispatched_at.isoformat(),
+        **({"cleaning_mode": value.cleaning_mode} if value.cleaning_mode else {}),
     }
 
 

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -53,7 +53,7 @@ from .client.commands import CleaningMode, CoverageSetting, UserCommand
 from .client.endpoints import HERMES_ENDPOINT_MAP, HERMES_ENDPOINT_NAMES
 from .client.exceptions import MaticError
 from .client.floor_plan import pose_vector_paths
-from .client.models import CleaningSessionRecord, FloorPlan
+from .client.models import CleaningSession, CleaningSessionRecord, FloorPlan
 from .const import (
     DATA_FIRMWARE_TRACKER,
     DATA_PLAN_MANAGER,
@@ -1847,6 +1847,7 @@ async def _async_verify_leg_completion(
     if reader is None or baseline is None:
         return None
     targets = {room.name.strip().casefold(): room.room_id for room in rooms}
+    modes = {room.name.strip().casefold(): room.cleaning_mode for room in rooms}
     evidence: dict[str, tuple[str, int]] | None = None
     matched_key: bytes | None = None
     try:
@@ -1907,11 +1908,21 @@ async def _async_verify_leg_completion(
                     completed_names = {
                         name.strip().casefold() for name in session.completed_rooms
                     }
+                    vacuum_completed_names = {
+                        name.strip().casefold()
+                        for name in session.vacuum_completed_rooms
+                    }
                     evidence = {}
                     for name, room_id in targets.items():
                         duration = durations.get(name)
                         if (
-                            name in completed_names
+                            (
+                                name in completed_names
+                                or (
+                                    modes[name] == CleaningMode.VACUUM
+                                    and name in vacuum_completed_names
+                                )
+                            )
                             and isinstance(duration, int)
                             and not isinstance(duration, bool)
                             and duration > 0
@@ -2137,7 +2148,9 @@ async def _async_verify_room_completion(
                 matches: list[CleaningSessionRecord] = []
                 for record in records:
                     session = record.session
-                    if record.key in baseline or session.completed is not True:
+                    if record.key in baseline or not _session_confirms_room_mode(
+                        session, room
+                    ):
                         continue
                     started = dt_util.parse_datetime(session.started_at or "")
                     ended = dt_util.parse_datetime(session.ended_at or "")
@@ -2505,6 +2518,15 @@ async def _async_expire_native_reconciliation(
     _LOGGER.debug("Native Matic reconciliation expired without a history baseline")
 
 
+def _session_confirms_room_mode(session: CleaningSession, room: CleaningRoom) -> bool:
+    """Use explicit vacuum evidence only for a known vacuum-only dispatch."""
+    return session.completed is True or (
+        room.cleaning_mode == CleaningMode.VACUUM
+        and _area_key(room.name)
+        in {_area_key(name) for name in session.vacuum_completed_rooms}
+    )
+
+
 def _native_completion_match(
     records: tuple[CleaningSessionRecord, ...],
     baseline: frozenset[bytes],
@@ -2517,7 +2539,7 @@ def _native_completion_match(
     matches: list[tuple[CleaningSessionRecord, int]] = []
     for record in records:
         session = record.session
-        if record.key in baseline or session.completed is not True:
+        if record.key in baseline or not _session_confirms_room_mode(session, room):
             continue
         started = dt_util.parse_datetime(session.started_at or "")
         ended = dt_util.parse_datetime(session.ended_at or "")

--- a/custom_components/matic_robot/session_tracking.py
+++ b/custom_components/matic_robot/session_tracking.py
@@ -155,6 +155,7 @@ class CleaningSessionTracker:
                 room_durations=native_session.room_durations,
                 completed=native_session.completed,
                 completed_rooms=native_session.completed_rooms,
+                vacuum_completed_rooms=native_session.vacuum_completed_rooms,
             )
         native_started = _parse_timestamp(native_session.started_at)
         tracked_started = _parse_timestamp(tracked.started_at)

--- a/tests/test_native_completion_modes.py
+++ b/tests/test_native_completion_modes.py
@@ -84,3 +84,70 @@ def test_vacuum_proof_rejects_unknown_ambiguous_and_failed_results(
     session = _decode_cleaning_session(_session_payload(statuses, global_status))
     assert session is not None
     assert session.vacuum_completed_rooms == ()
+
+
+@pytest.mark.parametrize(
+    "mode", ["vacuum", "mop", "vacuum_and_mop", None, "unknown", 5]
+)
+async def test_restart_reconciliation_retains_only_known_vacuum_dispatch(hass, mode):
+    import json
+    from types import SimpleNamespace
+
+    from custom_components.matic_robot.client.models import FloorPlan, Room
+    from custom_components.matic_robot.plans import CleaningPlanManager
+    from custom_components.matic_robot.services import (
+        _build_native_reconciliation,
+        _native_reconciliation_data,
+    )
+
+    room = CleaningRoom("study", "Study", "vacuum", "standard")
+    dispatched = dt_util.utcnow() - timedelta(seconds=90)
+    marker = _native_reconciliation_data(
+        _build_native_reconciliation("synthetic-plan", room, dispatched, True)
+    )
+    assert marker["cleaning_mode"] == "vacuum"
+    if mode is None:
+        marker.pop("cleaning_mode")
+    else:
+        marker["cleaning_mode"] = mode
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    await manager.async_mark_started("synthetic-serial", "synthetic-plan", room)
+    await manager.async_mark_failed(
+        "synthetic-serial",
+        "synthetic-plan",
+        room,
+        "synthetic interruption",
+        native_reconciliation=marker,
+    )
+    stored = json.loads(json.dumps(manager._data))
+    restarted = CleaningPlanManager(hass)
+    restarted._store = SimpleNamespace(
+        async_load=AsyncMock(return_value=stored), async_save=AsyncMock()
+    )
+    await restarted.async_load()
+    session = _decode_cleaning_session(_session_payload(_vfield(5, 2) + _vfield(6, 1)))
+    record = CleaningSessionRecord(b"synthetic-new", session)
+    floor = FloorPlan(
+        1,
+        "synthetic",
+        b"synthetic",
+        (
+            Room(
+                "study",
+                "Study",
+                "synthetic-study",
+                b"synthetic-study",
+                ((0, 0), (1, 0), (1, 1)),
+            ),
+        ),
+    )
+    await restarted.async_import_native_history("synthetic-serial", floor, [record])
+    state = restarted.snapshot("synthetic-serial")
+    result = state["plan_history"]["synthetic-plan"]["rooms"]["study"]
+    assert result["last_result"] == ("completed" if mode == "vacuum" else "failed")
+    assert state["native_reconciliation_pending"] is (mode != "vacuum")
+    await restarted.async_import_native_history("synthetic-serial", floor, [record])
+    assert restarted.snapshot("synthetic-serial")["plan_history"]["synthetic-plan"][
+        "rooms"
+    ]["study"].get("completed_runs", 0) == (1 if mode == "vacuum" else 0)

--- a/tests/test_native_completion_modes.py
+++ b/tests/test_native_completion_modes.py
@@ -1,0 +1,86 @@
+"""Synthetic command-specific native completion evidence."""
+
+from datetime import timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+from homeassistant.util import dt as dt_util
+
+from custom_components.matic_robot.client.api import _decode_cleaning_session
+from custom_components.matic_robot.client.models import CleaningSessionRecord
+from custom_components.matic_robot.plans import CleaningRoom
+from custom_components.matic_robot.services import (
+    _async_verify_leg_completion,
+    _async_verify_room_completion,
+    _native_completion_match,
+)
+from tests.wire_builders import _bfield, _vfield
+
+
+def _session_payload(statuses: bytes, global_status: bytes = b"") -> bytes:
+    now = int(dt_util.utcnow().timestamp())
+    room = _bfield(3, b"Study") + _bfield(4, _vfield(1, 30)) + statuses
+    summary = (
+        _bfield(3, _bfield(1, _vfield(1, now - 60)))
+        + _bfield(4, _bfield(1, _vfield(1, now - 5)))
+        + _bfield(6, _bfield(1, _bfield(2, room)))
+        + global_status
+    )
+    return _bfield(5, summary)
+
+
+@pytest.mark.parametrize("vacuum_status,other_status", [(2, 1), (1, 2)])
+@pytest.mark.parametrize("mode", ["vacuum", "mop", "vacuum_and_mop"])
+async def test_native_mode_proof_matches_only_the_dispatched_mode(
+    vacuum_status, other_status, mode
+):
+    session = _decode_cleaning_session(
+        _session_payload(_vfield(5, vacuum_status) + _vfield(6, other_status))
+    )
+    assert session is not None
+    assert session.completed is None
+    assert session.completed_rooms == ()
+    assert session.vacuum_completed_rooms == (("Study",) if vacuum_status == 2 else ())
+    record = CleaningSessionRecord(b"synthetic-new", session)
+    reader = AsyncMock(return_value=(record,))
+    room = CleaningRoom("study", "Study", mode, "standard")
+    dispatched = dt_util.utcnow() - timedelta(seconds=90)
+    expected = vacuum_status == 2 and mode == "vacuum"
+    assert (
+        await _async_verify_room_completion(
+            reader, frozenset(), room, dispatched, attempts=1
+        )
+        is expected
+    )
+    leg = await _async_verify_leg_completion(
+        reader, frozenset(), [room], dispatched, attempts=1
+    )
+    assert leg == ({"study": (session.ended_at, 30)} if expected else {})
+    native = _native_completion_match((record,), frozenset(), room, dispatched)
+    assert native == ((record, 30) if expected else None)
+    # The same completed history key must never credit a later dispatch.
+    assert (
+        _native_completion_match((record,), frozenset({record.key}), room, dispatched)
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    "statuses,global_status",
+    [
+        (_vfield(6, 2), b""),
+        (_vfield(5, 3) + _vfield(6, 2), b""),
+        (_vfield(5, 2) + _vfield(6, 3), b""),
+        (_vfield(5, 2) + _bfield(6, b"malformed"), b""),
+        (_bfield(5, b"malformed") + _vfield(6, 2), b""),
+        (_vfield(5, 2) + _vfield(5, 2) + _vfield(6, 1), b""),
+        (_vfield(5, 2) + _vfield(6, 1), _vfield(5, 2)),
+        (_vfield(5, 2) + _vfield(6, 1), _bfield(5, b"malformed")),
+    ],
+)
+def test_vacuum_proof_rejects_unknown_ambiguous_and_failed_results(
+    statuses, global_status
+):
+    session = _decode_cleaning_session(_session_payload(statuses, global_status))
+    assert session is not None
+    assert session.vacuum_completed_rooms == ()


### PR DESCRIPTION
Successful vacuum-only native history can contain completion status 2 for the vacuum field and status 1 for the other mode field. Combining those fields leaves the completed room unverified and prevents a mixed-settings plan from advancing.

Preserve explicit vacuum completion separately and use it only when the dispatched room was vacuum-only. Persist the dispatched cleaning mode in the durable reconciliation marker so restart recovery applies the same proof. Legacy or invalid modes remain conservative. Keep existing record identity, time interval, unique room, duration, cancellation, malformed-status and global failure guards. Mop and combined cleaning retain conservative completion requirements. The mode distinction is supported by operator-confirmed completed and interrupted vacuum runs; public fixtures are synthetic.

Validation: 1,341 Python tests passed with 100% coverage; Ruff check/format, strict MyPy and public-tree privacy checks passed. Live acceptance of the updated candidate remains pending.
