### PR TITLE
Fix map loss when returning between floors

### DIFF
--- a/custom_components/matic_robot/slam_map_store.py
+++ b/custom_components/matic_robot/slam_map_store.py
@@ -161,7 +161,6 @@ class SlamMapStore:
         self._live_photo_seen = False
         self._live_structure_seen = False
         self._truncated = False
-        self._rebuild_truncated_cache = False
         self._dropped_photo_tiles = 0
         self._dropped_structure_tiles = 0
         self._invalid_tiles = 0
@@ -199,7 +198,6 @@ class SlamMapStore:
         self._entry_content_digests.clear()
         self._structure_content_digests.clear()
         self._truncated = loaded.truncated
-        self._rebuild_truncated_cache = loaded.truncated
         self._dropped_photo_tiles = loaded.dropped_photo_tiles
         self._dropped_structure_tiles = loaded.dropped_structure_tiles
         self._invalid_tiles = loaded.invalid_tiles
@@ -290,21 +288,6 @@ class SlamMapStore:
         identity_changed = self._mission_id is None and tile.mission_id is not None
         if identity_changed:
             self._mission_id = tile.mission_id
-        if self._rebuild_truncated_cache:
-            # A persisted truncated checkpoint cannot establish completeness.
-            # Rebuild it from this session's live replay, requiring fresh proof
-            # from both layers rather than combining new pages with old gaps.
-            self._entries.clear()
-            self._structure_entries.clear()
-            self._entry_content_digests.clear()
-            self._structure_content_digests.clear()
-            self._truncated = False
-            self._rebuild_truncated_cache = False
-            self._dropped_photo_tiles = 0
-            self._dropped_structure_tiles = 0
-            self._live_photo_seen = False
-            self._live_structure_seen = False
-            self._map_complete = False
         target = self._structure_entries if structural else self._entries
         content_digests = (
             self._structure_content_digests
@@ -608,7 +591,6 @@ class SlamMapStore:
         self._entry_content_digests.clear()
         self._structure_content_digests.clear()
         self._truncated = candidate.truncated
-        self._rebuild_truncated_cache = False
         self._dropped_photo_tiles = candidate.dropped_photo_tiles
         self._dropped_structure_tiles = candidate.dropped_structure_tiles
         self._invalid_tiles = 0

--- a/custom_components/matic_robot/slam_map_store.py
+++ b/custom_components/matic_robot/slam_map_store.py
@@ -44,8 +44,11 @@ SPATIAL_BUCKETS_PER_AXIS = 8
 MAX_HEALTH_COUNTER = 2**31 - 1
 MAX_LOAD_ITEMS_PER_LAYER = MAX_TILES * 2
 MAX_CANDIDATE_MISSIONS = 2
-MAX_CANDIDATE_TILES_PER_LAYER = 128
-MAX_CANDIDATE_BYTES = 2 * 1024 * 1024
+# Either subscription can replay a whole supported floor before its counterpart
+# or the selected-floor watcher catches up. Keep that floor within the same
+# bounds as an active map; the candidate count remains separately bounded.
+MAX_CANDIDATE_TILES_PER_LAYER = MAX_TILES
+MAX_CANDIDATE_BYTES = MAX_STORED_BYTES
 MAX_RETIRED_MISSIONS = 8
 # A candidate needs pages from both independent subscriptions.  Allow three
 # normal retry intervals for those streams to converge, then classify a
@@ -158,6 +161,7 @@ class SlamMapStore:
         self._live_photo_seen = False
         self._live_structure_seen = False
         self._truncated = False
+        self._rebuild_truncated_cache = False
         self._dropped_photo_tiles = 0
         self._dropped_structure_tiles = 0
         self._invalid_tiles = 0
@@ -195,6 +199,7 @@ class SlamMapStore:
         self._entry_content_digests.clear()
         self._structure_content_digests.clear()
         self._truncated = loaded.truncated
+        self._rebuild_truncated_cache = loaded.truncated
         self._dropped_photo_tiles = loaded.dropped_photo_tiles
         self._dropped_structure_tiles = loaded.dropped_structure_tiles
         self._invalid_tiles = loaded.invalid_tiles
@@ -285,6 +290,21 @@ class SlamMapStore:
         identity_changed = self._mission_id is None and tile.mission_id is not None
         if identity_changed:
             self._mission_id = tile.mission_id
+        if self._rebuild_truncated_cache:
+            # A persisted truncated checkpoint cannot establish completeness.
+            # Rebuild it from this session's live replay, requiring fresh proof
+            # from both layers rather than combining new pages with old gaps.
+            self._entries.clear()
+            self._structure_entries.clear()
+            self._entry_content_digests.clear()
+            self._structure_content_digests.clear()
+            self._truncated = False
+            self._rebuild_truncated_cache = False
+            self._dropped_photo_tiles = 0
+            self._dropped_structure_tiles = 0
+            self._live_photo_seen = False
+            self._live_structure_seen = False
+            self._map_complete = False
         target = self._structure_entries if structural else self._entries
         content_digests = (
             self._structure_content_digests
@@ -588,6 +608,7 @@ class SlamMapStore:
         self._entry_content_digests.clear()
         self._structure_content_digests.clear()
         self._truncated = candidate.truncated
+        self._rebuild_truncated_cache = False
         self._dropped_photo_tiles = candidate.dropped_photo_tiles
         self._dropped_structure_tiles = candidate.dropped_structure_tiles
         self._invalid_tiles = 0

--- a/tests/test_slam_map_store.py
+++ b/tests/test_slam_map_store.py
@@ -1475,3 +1475,48 @@ def test_slam_map_store_bounds_health_metadata_and_spatial_helpers() -> None:
     assert _stored_mission_token("00" * 32) == "00" * 32
     assert _bucket(1, 1, 1) == 0
     assert _bucket(100, 0, 1) == 7
+
+
+async def test_return_floor_retains_supported_map_before_selection_catches_up(hass):
+    store = SlamMapStore(hass, "return-floor-buffer")
+    store.set_expected_mission_id(1)
+    await store.async_add(synthetic_slam_entry(mission_id=1))
+    await store.async_add_structure(synthetic_structure_entry(mission_id=1))
+    for page_x in range(160):
+        await store.async_add(synthetic_slam_entry(page_x=page_x, mission_id=2))
+    for page_x in range(160):
+        await store.async_add_structure(
+            synthetic_structure_entry(page_x=page_x, mission_id=2)
+        )
+    assert not store.live_session_verified
+    store.set_expected_mission_id(2)
+    assert store.live_session_verified
+    assert store.tile_count == store.structure_tile_count == 160
+    assert not store.health.truncated
+    assert store.health.layer_overlap == 1
+
+
+async def test_truncated_cache_rebuilds_on_fresh_same_mission_pages(hass):
+    store = SlamMapStore(hass, "truncated-rebuild")
+    with patch("custom_components.matic_robot.slam_map_store.MAX_TILES", 1):
+        for page_x in (0, 1):
+            await store.async_add(synthetic_slam_entry(page_x=page_x))
+            await store.async_add_structure(synthetic_structure_entry(page_x=page_x))
+    assert store.health.truncated
+    await store.async_shutdown()
+    restored = SlamMapStore(hass, "truncated-rebuild")
+    await restored.async_load()
+    assert restored.health.truncated
+    assert not restored.live_session_verified
+    await restored.async_add(synthetic_slam_entry(page_x=0))
+    assert not restored.live_session_verified
+    assert restored.structure_tile_count == 0
+    for page_x in (0, 1):
+        await restored.async_add(synthetic_slam_entry(page_x=page_x))
+        await restored.async_add_structure(synthetic_structure_entry(page_x=page_x))
+    assert restored.tile_count == restored.structure_tile_count == 2
+    assert restored.live_session_verified
+    assert not restored.health.truncated
+    assert restored.health.dropped_photo_tiles == 0
+    assert restored.health.dropped_structure_tiles == 0
+    assert restored.health.layer_overlap == 1

--- a/tests/test_slam_map_store.py
+++ b/tests/test_slam_map_store.py
@@ -1496,27 +1496,36 @@ async def test_return_floor_retains_supported_map_before_selection_catches_up(ha
     assert store.health.layer_overlap == 1
 
 
-async def test_truncated_cache_rebuilds_on_fresh_same_mission_pages(hass):
+async def test_truncated_cache_stays_incomplete_until_verified_floor_replacement(hass):
     store = SlamMapStore(hass, "truncated-rebuild")
     with patch("custom_components.matic_robot.slam_map_store.MAX_TILES", 1):
         for page_x in (0, 1):
-            await store.async_add(synthetic_slam_entry(page_x=page_x))
-            await store.async_add_structure(synthetic_structure_entry(page_x=page_x))
+            await store.async_add(synthetic_slam_entry(page_x=page_x, mission_id=1))
+            await store.async_add_structure(
+                synthetic_structure_entry(page_x=page_x, mission_id=1)
+            )
     assert store.health.truncated
     await store.async_shutdown()
     restored = SlamMapStore(hass, "truncated-rebuild")
     await restored.async_load()
+    restored.set_expected_mission_id(1)
+    retained = restored.structure_entries()
+    await restored.async_add(synthetic_slam_entry(page_x=0, mission_id=1))
+    await restored.async_add_structure(
+        synthetic_structure_entry(page_x=0, mission_id=1)
+    )
+    assert restored.structure_entries() == retained
     assert restored.health.truncated
-    assert not restored.live_session_verified
-    await restored.async_add(synthetic_slam_entry(page_x=0))
-    assert not restored.live_session_verified
-    assert restored.structure_tile_count == 0
+    assert not restored.map_complete
     for page_x in (0, 1):
-        await restored.async_add(synthetic_slam_entry(page_x=page_x))
-        await restored.async_add_structure(synthetic_structure_entry(page_x=page_x))
+        await restored.async_add(synthetic_slam_entry(page_x=page_x, mission_id=2))
+        await restored.async_add_structure(
+            synthetic_structure_entry(page_x=page_x, mission_id=2)
+        )
+    assert not restored.live_session_verified
+    assert restored.health.truncated
+    restored.set_expected_mission_id(2)
     assert restored.tile_count == restored.structure_tile_count == 2
     assert restored.live_session_verified
     assert not restored.health.truncated
-    assert restored.health.dropped_photo_tiles == 0
-    assert restored.health.dropped_structure_tiles == 0
     assert restored.health.layer_overlap == 1


### PR DESCRIPTION
A floor return could deliver map pages before the selected-floor watcher caught up. The transition buffer retained only 128 pages per layer even though the active map supports 1,024, leaving a valid floor truncated after promotion. Candidate maps now use the active map size limits while retaining the two-candidate bound and independent floor/layer verification.

Existing truncated checkpoints remain marked incomplete during partial replay. A fresh verified floor replacement can replace them; a single bootstrap page does not clear their truncation status. Plans, saved areas and motion commands are unchanged.

Validation: the transition regression fails before the fix, and a second regression protects truncated checkpoints during partial replay and verified replacement. All 1,343 Python tests pass at 100% coverage. Ruff, formatting, strict MyPy, public-tree privacy and diff checks pass. Live installation and the repeated floor round trip remain pending.
