### PR TITLE
Fix map recovery past retained pages from other floors

### DIFF
--- a/custom_components/matic_robot/slam_map_store.py
+++ b/custom_components/matic_robot/slam_map_store.py
@@ -49,6 +49,11 @@ MAX_CANDIDATE_MISSIONS = 2
 # bounds as an active map; the candidate count remains separately bounded.
 MAX_CANDIDATE_TILES_PER_LAYER = MAX_TILES
 MAX_CANDIDATE_BYTES = MAX_STORED_BYTES
+MAP_SNAPSHOT_MAX_PAGES = MAX_TILES * (MAX_CANDIDATE_MISSIONS + 1)
+MAP_SNAPSHOT_MAX_BYTES = MAX_STORED_BYTES * (MAX_CANDIDATE_MISSIONS + 1)
+MAP_SNAPSHOT_TIMEOUT = 30.0
+MAP_SNAPSHOT_FIRST_TIMEOUT = 3.0
+MAP_SNAPSHOT_IDLE_TIMEOUT = 0.25
 MAX_RETIRED_MISSIONS = 8
 # A candidate needs pages from both independent subscriptions.  Allow three
 # normal retry intervals for those streams to converge, then classify a
@@ -146,6 +151,7 @@ class SlamMapStore:
         self._mission_token: str | None = None
         self._mission_id: int | None = None
         self._expected_mission_id: int | None = None
+        self._selection_generation = 0
         self._entries: dict[str, HermesCollectionEntry] = {}
         self._structure_entries: dict[str, HermesCollectionEntry] = {}
         self._entry_content_digests: dict[str, bytes] = {}
@@ -536,17 +542,22 @@ class SlamMapStore:
         self, client: MaticHermesClient
     ) -> None:
         """Read one page from each map collection without trusting cache state."""
+        generation = self._selection_generation
         try:
             photo_entries, structure_entries = await asyncio.gather(
-                client.async_get_collection_entries("map_compressed_rgb", limit=1),
-                client.async_get_collection_entries("map_integrated", limit=1),
+                self._async_read_map_layer(client, "map_compressed_rgb", False),
+                self._async_read_map_layer(client, "map_integrated", True),
             )
         except asyncio.CancelledError:
             raise
         except Exception:
             self._schedule_candidate_refresh_retry()
             return
-        if self._closed or not self._needs_candidate_refresh():
+        if (
+            self._closed
+            or generation != self._selection_generation
+            or not self._needs_candidate_refresh()
+        ):
             return
         try:
             for entry in photo_entries:
@@ -660,6 +671,56 @@ class SlamMapStore:
             if self._collection_client is client:
                 self._collection_client = None
 
+    async def _async_read_map_layer(
+        self,
+        client: MaticHermesClient,
+        name: str,
+        structural: bool,
+        *,
+        tracked: bool = False,
+    ) -> tuple[HermesCollectionEntry, ...]:
+        """Find fresh selected-floor proof past retained pages from other floors."""
+        mission_id = self._expected_mission_id
+        if mission_id is None:
+            read = (
+                client.async_get_tracked_collection_entries
+                if tracked
+                else client.async_get_collection_entries
+            )
+            return await read(name, limit=1)
+        iterator = client.async_subscribe_collection_entries(name)
+        generation = self._selection_generation
+        total_bytes = 0
+        deadline = monotonic() + MAP_SNAPSHOT_TIMEOUT
+        try:
+            for index in range(MAP_SNAPSHOT_MAX_PAGES):
+                remaining = deadline - monotonic()
+                if remaining <= 0:
+                    break
+                timeout = min(
+                    MAP_SNAPSHOT_IDLE_TIMEOUT if index else MAP_SNAPSHOT_FIRST_TIMEOUT,
+                    remaining,
+                )
+                try:
+                    async with asyncio.timeout(timeout):
+                        entry = await anext(iterator)
+                except StopAsyncIteration, TimeoutError:
+                    break
+                if self._closed or generation != self._selection_generation:
+                    break
+                total_bytes += len(entry.key) + len(entry.value)
+                if total_bytes > MAP_SNAPSHOT_MAX_BYTES:
+                    break
+                decode: Callable[
+                    [HermesCollectionEntry], SlamTile | SlamStructureTile
+                ] = decode_slam_structure_tile if structural else decode_slam_tile
+                tile = await self._hass.async_add_executor_job(decode, entry)
+                if tile.mission_id == mission_id:
+                    return (entry,)
+        finally:
+            await iterator.aclose()
+        return ()
+
     async def async_prime(self, client: MaticHermesClient) -> None:
         """Seed both map layers before relying on long-lived subscriptions.
 
@@ -675,12 +736,15 @@ class SlamMapStore:
         self._bootstrap_structure_seen = False
         self._bootstrap_failures = 0
         self._notify_listeners()
+        generation = self._selection_generation
         try:
             results = await asyncio.gather(
-                client.async_get_tracked_collection_entries(
-                    "map_compressed_rgb", limit=1
+                self._async_read_map_layer(
+                    client, "map_compressed_rgb", False, tracked=True
                 ),
-                client.async_get_tracked_collection_entries("map_integrated", limit=1),
+                self._async_read_map_layer(
+                    client, "map_integrated", True, tracked=True
+                ),
                 return_exceptions=True,
             )
         except asyncio.CancelledError:
@@ -688,6 +752,10 @@ class SlamMapStore:
             self._notify_listeners()
             raise
         if self._closed:
+            return
+        if generation != self._selection_generation:
+            self._bootstrap_state = "not_started"
+            self._notify_listeners()
             return
         for index, (result, structural) in enumerate(
             zip(results, (False, True), strict=True)
@@ -763,6 +831,7 @@ class SlamMapStore:
         if self._expected_mission_id == mission_id:
             return
         self._expected_mission_id = mission_id
+        self._selection_generation += 1
         self._cancel_candidate_expiry()
         self._cancel_candidate_refresh_retry()
         self._candidates = OrderedDict(

--- a/custom_components/matic_robot/slam_map_store.py
+++ b/custom_components/matic_robot/slam_map_store.py
@@ -714,7 +714,12 @@ class SlamMapStore:
                 decode: Callable[
                     [HermesCollectionEntry], SlamTile | SlamStructureTile
                 ] = decode_slam_structure_tile if structural else decode_slam_tile
-                tile = await self._hass.async_add_executor_job(decode, entry)
+                try:
+                    tile = await self._hass.async_add_executor_job(decode, entry)
+                except DecodeError:
+                    self._record_invalid()
+                    self._notify_listeners()
+                    continue
                 if tile.mission_id == mission_id:
                     return (entry,)
         finally:

--- a/custom_components/matic_robot/slam_map_store.py
+++ b/custom_components/matic_robot/slam_map_store.py
@@ -553,11 +553,12 @@ class SlamMapStore:
         except Exception:
             self._schedule_candidate_refresh_retry()
             return
-        if (
-            self._closed
-            or generation != self._selection_generation
-            or not self._needs_candidate_refresh()
-        ):
+        if self._closed:
+            return
+        if generation != self._selection_generation:
+            self._schedule_candidate_refresh_retry()
+            return
+        if not self._needs_candidate_refresh():
             return
         try:
             for entry in photo_entries:

--- a/tests/test_slam_map_store.py
+++ b/tests/test_slam_map_store.py
@@ -1675,3 +1675,38 @@ async def test_map_snapshot_pair_discards_selection_change(hass, bootstrap):
     assert store.tile_count == 0
     assert not store.live_session_verified
     await store.async_shutdown()
+
+
+async def test_map_snapshot_retries_for_changed_selected_floor(hass):
+    """A retained one-sided candidate still gets its missing layer after selection."""
+    store = SlamMapStore(hass, "retry-changed-selected-floor")
+    store.set_expected_mission_id(0x1234ABCD)
+    await store.async_add(synthetic_slam_entry())
+    await store.async_add_structure(synthetic_structure_entry())
+    candidate = await store.async_add(synthetic_slam_entry(mission_id=2))
+    store._candidates[candidate.mission_token].blocks_active = False
+    calls = 0
+    store._collection_client = SimpleNamespace()
+
+    async def snapshot(_client, _name, structural):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            store.set_expected_mission_id(2)
+        make = synthetic_structure_entry if structural else synthetic_slam_entry
+        return (make(mission_id=0x1234ABCD if calls <= 2 else 2),)
+
+    with (
+        patch.object(store, "_async_read_map_layer", side_effect=snapshot),
+        patch.object(slam_map_store_module, "CANDIDATE_REFRESH_RETRY_SECONDS", 0),
+    ):
+        await store._async_refresh_after_candidate_expiry(store._collection_client)
+        assert not store.live_session_verified
+        assert store._candidate_refresh_retry_cancel is not None
+        await asyncio.sleep(0)
+        await hass.async_block_till_done()
+    assert calls == 4
+    assert store.live_session_verified
+    assert store.mission_identity.mission_id == 2
+    assert store._candidate_refresh_retry_cancel is None
+    await store.async_shutdown()

--- a/tests/test_slam_map_store.py
+++ b/tests/test_slam_map_store.py
@@ -1529,3 +1529,146 @@ async def test_truncated_cache_stays_incomplete_until_verified_floor_replacement
     assert restored.live_session_verified
     assert not restored.health.truncated
     assert restored.health.layer_overlap == 1
+
+
+@pytest.mark.parametrize("bootstrap", [False, True])
+async def test_selected_floor_snapshot_skips_retained_other_floor_pages(
+    hass, bootstrap
+):
+    """The first acknowledged map pages may belong to another retained floor."""
+    store = SlamMapStore(hass, "selected-floor-snapshot")
+    store.set_expected_mission_id(0x1234ABCD)
+    await store.async_add(synthetic_slam_entry())
+    await store.async_add_structure(synthetic_structure_entry())
+    await store.async_add(synthetic_slam_entry(mission_id=2))
+    for candidate in store._candidates.values():
+        candidate.blocks_active = False
+    closed = []
+    consumed = defaultdict(int)
+
+    async def subscribe(name):
+        make = (
+            synthetic_structure_entry
+            if name == "map_integrated"
+            else synthetic_slam_entry
+        )
+        try:
+            for mission in (2, 3, 0x1234ABCD, 4):
+                consumed[name] += 1
+                yield make(mission_id=mission)
+        finally:
+            closed.append(name)
+
+    client = SimpleNamespace(async_subscribe_collection_entries=subscribe)
+    if bootstrap:
+        await store.async_prime(client)
+    else:
+        await store._async_refresh_after_candidate_expiry(client)
+    assert store.live_session_verified
+    assert store.mission_identity.mission_id == 0x1234ABCD
+    assert consumed == {"map_compressed_rgb": 3, "map_integrated": 3}
+    assert sorted(closed) == ["map_compressed_rgb", "map_integrated"]
+    assert store.tile_count == store.structure_tile_count == 1
+    await store.async_shutdown()
+
+
+@pytest.mark.parametrize("bound", ["pages", "bytes", "deadline", "idle", "end"])
+async def test_selected_floor_snapshot_bounds_unmatched_stream(hass, bound):
+    """A feed without selected-floor proof closes within finite resource limits."""
+    store = SlamMapStore(hass, "bounded-selected-floor-snapshot")
+    store.set_expected_mission_id(0x1234ABCD)
+    closed = False
+
+    async def subscribe(_name):
+        nonlocal closed
+        try:
+            if bound == "end":
+                return
+            yield synthetic_slam_entry(mission_id=2)
+            if bound == "idle":
+                await asyncio.Event().wait()
+            yield synthetic_slam_entry(mission_id=2, page_x=2)
+        finally:
+            closed = True
+
+    client = SimpleNamespace(async_subscribe_collection_entries=subscribe)
+    with (
+        patch.object(
+            slam_map_store_module,
+            "MAP_SNAPSHOT_MAX_PAGES",
+            1 if bound == "pages" else 3,
+        ),
+        patch.object(
+            slam_map_store_module,
+            "MAP_SNAPSHOT_MAX_BYTES",
+            1 if bound == "bytes" else 10**6,
+        ),
+        patch.object(
+            slam_map_store_module,
+            "MAP_SNAPSHOT_TIMEOUT",
+            0 if bound == "deadline" else 1,
+        ),
+        patch.object(slam_map_store_module, "MAP_SNAPSHOT_IDLE_TIMEOUT", 0.001),
+    ):
+        assert (
+            await store._async_read_map_layer(client, "map_compressed_rgb", False) == ()
+        )
+    assert closed or bound == "deadline"  # An unstarted generator has no finally body.
+    assert not store.live_session_verified
+    await store.async_shutdown()
+
+
+@pytest.mark.parametrize("change", ["floor", "close", "cancel"])
+async def test_selected_floor_snapshot_discards_changed_context(hass, change):
+    """An in-flight read cannot revalidate a changed selection or unloaded store."""
+    store = SlamMapStore(hass, "changed-selected-floor-snapshot")
+    store.set_expected_mission_id(0x1234ABCD)
+    closed = False
+
+    async def subscribe(_name):
+        nonlocal closed
+        try:
+            if change == "floor":
+                store.set_expected_mission_id(2)
+                store.set_expected_mission_id(0x1234ABCD)
+            elif change == "close":
+                store._closed = True
+            else:
+                raise asyncio.CancelledError
+            yield synthetic_slam_entry()
+        finally:
+            closed = True
+
+    client = SimpleNamespace(async_subscribe_collection_entries=subscribe)
+    if change == "cancel":
+        with pytest.raises(asyncio.CancelledError):
+            await store._async_read_map_layer(client, "map_compressed_rgb", False)
+    else:
+        assert (
+            await store._async_read_map_layer(client, "map_compressed_rgb", False) == ()
+        )
+    assert closed
+    assert not store.live_session_verified
+    await store.async_shutdown()
+
+
+@pytest.mark.parametrize("bootstrap", [False, True])
+async def test_map_snapshot_pair_discards_selection_change(hass, bootstrap):
+    """Even an ABA selection change invalidates both pending layer results."""
+    store = SlamMapStore(hass, "changed-snapshot-pair")
+    store.set_expected_mission_id(0x1234ABCD)
+
+    async def snapshot(*_args, **_kwargs):
+        store.set_expected_mission_id(2)
+        store.set_expected_mission_id(0x1234ABCD)
+        return (synthetic_slam_entry(),)
+
+    with patch.object(store, "_async_read_map_layer", side_effect=snapshot):
+        if bootstrap:
+            await store.async_prime(SimpleNamespace())
+            assert store.health.bootstrap_state == "not_started"
+        else:
+            await store._async_refresh_after_candidate_expiry(SimpleNamespace())
+    assert store.tile_count == 0
+    assert not store.live_session_verified
+    await store.async_shutdown()

--- a/tests/test_slam_map_store.py
+++ b/tests/test_slam_map_store.py
@@ -1553,6 +1553,8 @@ async def test_selected_floor_snapshot_skips_retained_other_floor_pages(
             else synthetic_slam_entry
         )
         try:
+            consumed[name] += 1
+            yield HermesCollectionEntry(b"malformed-retained-key", b"invalid")
             for mission in (2, 3, 0x1234ABCD, 4):
                 consumed[name] += 1
                 yield make(mission_id=mission)
@@ -1566,7 +1568,8 @@ async def test_selected_floor_snapshot_skips_retained_other_floor_pages(
         await store._async_refresh_after_candidate_expiry(client)
     assert store.live_session_verified
     assert store.mission_identity.mission_id == 0x1234ABCD
-    assert consumed == {"map_compressed_rgb": 3, "map_integrated": 3}
+    assert consumed == {"map_compressed_rgb": 4, "map_integrated": 4}
+    assert store.health.invalid_tiles == 2
     assert sorted(closed) == ["map_compressed_rgb", "map_integrated"]
     assert store.tile_count == store.structure_tile_count == 1
     await store.async_shutdown()


### PR DESCRIPTION
Map recovery can remain unavailable while the robot is stationary because the first cached page in each map collection may belong to a different retained floor. Startup and expired-candidate revalidation now acknowledge a bounded stream until they find a page for the selected floor, then close the temporary subscription. Malformed retained entries are counted and skipped within page, byte, and time limits. Reads close on completion, cancellation, or teardown; selection generation checks reject results across floor changes, including a change away and back, and retain the retry needed to recover the new selection. Existing truncation state remains intact.

Validation: 1,356 Python tests at 100% coverage; Ruff, formatting, strict MyPy, privacy check, and diff checks passed. Synthetic regressions cover preceding stale-floor pages, independent layers, finite reads, teardown/cancellation, and selection races. A read-only local probe confirmed that current-floor pages can follow other-floor pages in both tracked collections; installation and stationary recovery acceptance remain pending.
