### PR TITLE
Prevent suspended plans from adopting new OEM tasks

### DIFF
--- a/custom_components/matic_robot/client/api.py
+++ b/custom_components/matic_robot/client/api.py
@@ -678,6 +678,18 @@ class MaticHermesClient(AbstractAsyncContextManager["MaticHermesClient"]):
             await self.async_get_property("active_session_key")
         )
 
+    async def async_get_cleaning_session_identity(self) -> bytes | None:
+        """Keep the vetted session property opaque and in memory for ownership.
+
+        Empty bytes mean the native task ended; ``None`` means unknown. Never
+        expose this private identifier through entities, logs, or storage.
+        """
+        payload = await self.async_get_property("active_session_key")
+        present = _decode_presence_state(payload)
+        if present is None:
+            return None
+        return payload if present else b""
+
     async def async_get_cleaning_session_records(
         self,
     ) -> tuple[CleaningSessionRecord, ...]:

--- a/custom_components/matic_robot/client/api.py
+++ b/custom_components/matic_robot/client/api.py
@@ -1166,7 +1166,9 @@ class MaticHermesClient(AbstractAsyncContextManager["MaticHermesClient"]):
 
     async def async_send_user_command(self, command: UserCommand) -> None:
         """Send one live-verified command through the authenticated user channel."""
-        await self._async_send_user_payload(encode_user_command(command))
+        payload = encode_user_command(command)
+        _LOGGER.debug("Requesting Matic user command %s", command.name)
+        await self._async_send_user_payload(payload)
 
     async def async_start_coverage(
         self,

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -1025,7 +1025,13 @@ async def _async_dispatch_leg_command(
             "The robot's room map is unavailable", "room_plan_unavailable"
         )
     history_baseline = await _async_session_history_baseline(session_history)
-    identity_baseline = await _async_read_session_identity(session_identity)
+    identity_baseline: bytes | None = None
+    for attempt in range(ACTIVE_SESSION_UNKNOWN_ATTEMPTS):
+        identity_baseline = await _async_read_session_identity(session_identity)
+        if session_identity is None or identity_baseline is not None:
+            break
+        if attempt + 1 < ACTIVE_SESSION_UNKNOWN_ATTEMPTS:
+            await asyncio.sleep(ACTIVE_SESSION_UNKNOWN_RETRY_SECONDS)
     if session_identity is not None and identity_baseline is None:
         raise RoomTakenOverError(
             "The native task before dispatch could not be verified"

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -1110,6 +1110,10 @@ async def _async_run_room(
         nonlocal dispatch_attempted
         dispatch_attempted = True
 
+    def bind_native_identity(identity: bytes) -> None:
+        nonlocal native_identity
+        native_identity = identity
+
     try:
         if dispatch is None:
             dispatch = await _async_dispatch_leg_command(
@@ -1131,19 +1135,17 @@ async def _async_run_room(
         dispatched_at = dispatch.dispatched_at
         assert dispatched_at is not None
         try:
-            start_state = await _async_wait_for_vacuum_state(
+            start_state = await _async_wait_for_owned_start(
                 hass,
                 entity_id,
-                {"cleaning", "paused"},
                 call.data["start_timeout"],
                 cancel_event,
                 room,
+                session_identity,
+                bind_native_identity,
             )
         except TimeoutError as err:
             raise RoomStartTimeoutError from err
-        native_identity = await _async_read_session_identity(session_identity)
-        if session_identity is not None and not native_identity:
-            raise RoomTakenOverError("The started native task could not be identified")
         if start_state == "paused":
             await manager.async_mark_suspended(
                 serial_number, call.data["plan_id"], room, "paused"
@@ -1544,6 +1546,10 @@ async def _async_run_leg(
         nonlocal dispatch_attempted
         dispatch_attempted = True
 
+    def bind_native_identity(identity: bytes) -> None:
+        nonlocal native_identity
+        native_identity = identity
+
     try:
         if dispatch is None:
             dispatch = await _async_dispatch_leg_command(
@@ -1564,19 +1570,17 @@ async def _async_run_leg(
         history_baseline = dispatch.history_baseline
         dispatched_at = dispatch.dispatched_at
         try:
-            start_state = await _async_wait_for_vacuum_state(
+            start_state = await _async_wait_for_owned_start(
                 hass,
                 entity_id,
-                {"cleaning", "paused"},
                 call.data["start_timeout"],
                 cancel_event,
                 leg,
+                session_identity,
+                bind_native_identity,
             )
         except TimeoutError as err:
             raise RoomStartTimeoutError from err
-        native_identity = await _async_read_session_identity(session_identity)
-        if session_identity is not None and not native_identity:
-            raise RoomTakenOverError("The started native task could not be identified")
         if start_state == "paused":
             await manager.async_mark_suspended(
                 serial_number, call.data["plan_id"], active_room, "paused"
@@ -2671,6 +2675,72 @@ async def _async_read_session_identity(
         return await reader()
     except MaticError:
         return None
+
+
+async def _async_wait_for_owned_start(
+    hass: HomeAssistant,
+    entity_id: str,
+    timeout_seconds: int,
+    cancel_event: asyncio.Event | None,
+    rooms: CleaningRoom | Sequence[CleaningRoom],
+    reader: Callable[[], Awaitable[bytes | None]] | None,
+    bind_identity: Callable[[bytes], None],
+) -> str:
+    """Bind the dispatched task even while HA's activity/room update lags.
+
+    Publish ownership before the state waiter can fail, so timeout or unload
+    cleanup can stop the same accepted task. Never replace that identity with
+    a later OEM task. A successful HA state also needs a current native read.
+    """
+    if reader is None:
+        return await _async_wait_for_vacuum_state(
+            hass,
+            entity_id,
+            {"cleaning", "paused"},
+            timeout_seconds,
+            cancel_event,
+            rooms,
+        )
+    started = asyncio.create_task(
+        _async_wait_for_vacuum_state(
+            hass,
+            entity_id,
+            {"cleaning", "paused"},
+            timeout_seconds,
+            cancel_event,
+            rooms,
+        ),
+        eager_start=True,
+    )
+    expected: bytes | None = None
+    unknown_reads = 0
+    try:
+        while True:
+            identity = await _async_read_session_identity(reader)
+            if identity and expected is None:
+                expected = identity
+                bind_identity(identity)
+            elif identity is not None and expected and identity != expected:
+                raise RoomTakenOverError(
+                    "The dispatched native task ended or was replaced"
+                )
+            if started.done():
+                state = started.result()
+                if identity and identity == expected:
+                    return state
+                unknown_reads += 1
+                if unknown_reads >= ACTIVE_SESSION_UNKNOWN_ATTEMPTS:
+                    raise RoomTakenOverError(
+                        "The started native task could not be identified"
+                    )
+                await asyncio.sleep(ACTIVE_SESSION_UNKNOWN_RETRY_SECONDS)
+            else:
+                await asyncio.wait(
+                    {started}, timeout=ACTIVE_SESSION_UNKNOWN_RETRY_SECONDS
+                )
+    finally:
+        started.cancel()
+        await asyncio.gather(started, return_exceptions=True)
 
 
 async def _async_wait_for_owned_resume(

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
-from functools import wraps
+from functools import partial, wraps
 from time import monotonic
 from typing import Any
 
@@ -135,6 +135,8 @@ class _PreparedRoomDispatch:
     rooms: tuple[CleaningRoom, ...]
     history_baseline: frozenset[bytes] | None
     dispatched_at: datetime
+    native_identity_baseline: bytes | None = None
+    native_identity: bytes | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -1013,6 +1015,8 @@ async def _async_dispatch_leg_command(
     floor_is_current: Callable[[], bool] | None = None,
     floor_token: str | None = None,
     on_dispatch: Callable[[], None] | None = None,
+    session_identity: Callable[[], Awaitable[bytes | None]] | None = None,
+    on_identity: Callable[[bytes | None], None] | None = None,
 ) -> _PreparedRoomDispatch:
     """Issue one owned leg mission with its completion-history baseline."""
     leg = tuple(rooms)
@@ -1021,6 +1025,11 @@ async def _async_dispatch_leg_command(
             "The robot's room map is unavailable", "room_plan_unavailable"
         )
     history_baseline = await _async_session_history_baseline(session_history)
+    identity_baseline = await _async_read_session_identity(session_identity)
+    if session_identity is not None and identity_baseline is None:
+        raise RoomTakenOverError(
+            "The native task before dispatch could not be verified"
+        )
     if floor_is_current is not None and not floor_is_current():
         raise _validation_error(
             "The robot's room map is unavailable", "room_plan_unavailable"
@@ -1049,7 +1058,13 @@ async def _async_dispatch_leg_command(
         blocking=True,
         context=call.context,
     )
-    return _PreparedRoomDispatch(leg, history_baseline, dispatched_at)
+    observed = await _async_read_session_identity(session_identity)
+    identity = observed if observed and observed != identity_baseline else None
+    if on_identity is not None:
+        on_identity(identity)
+    return _PreparedRoomDispatch(
+        leg, history_baseline, dispatched_at, identity_baseline, identity
+    )
 
 
 async def _async_run_room(
@@ -1073,6 +1088,7 @@ async def _async_run_room(
     floor_is_current: Callable[[], bool] | None = None,
     floor_token: str | None = None,
     session_identity: Callable[[], Awaitable[bytes | None]] | None = None,
+    on_native_identity: Callable[[bytes | None], None] | None = None,
 ) -> bool:
     """Run one room and report whether native history verified completion."""
     if not room_name_is_unique:
@@ -1109,10 +1125,13 @@ async def _async_run_room(
     def mark_dispatch_attempted() -> None:
         nonlocal dispatch_attempted
         dispatch_attempted = True
+        bind_native_identity(None)
 
-    def bind_native_identity(identity: bytes) -> None:
+    def bind_native_identity(identity: bytes | None) -> None:
         nonlocal native_identity
         native_identity = identity
+        if on_native_identity is not None:
+            on_native_identity(identity)
 
     try:
         if dispatch is None:
@@ -1126,11 +1145,14 @@ async def _async_run_room(
                 floor_is_current=floor_is_current,
                 floor_token=floor_token,
                 on_dispatch=mark_dispatch_attempted,
+                session_identity=session_identity,
+                on_identity=bind_native_identity,
             )
         else:
             if dispatch.rooms != (room,):
                 raise ValueError("prepared room dispatch does not match the room")
             dispatch_attempted = True
+            bind_native_identity(dispatch.native_identity)
         history_baseline = dispatch.history_baseline
         dispatched_at = dispatch.dispatched_at
         assert dispatched_at is not None
@@ -1143,6 +1165,8 @@ async def _async_run_room(
                 room,
                 session_identity,
                 bind_native_identity,
+                dispatch.native_identity_baseline,
+                native_identity,
             )
         except TimeoutError as err:
             raise RoomStartTimeoutError from err
@@ -1171,8 +1195,12 @@ async def _async_run_room(
                 call.data["completion_timeout"]
             ) as mission_timeout:
                 while True:
-                    outcome = await _async_wait_for_room_outcome(
-                        hass, entity_id, room, cancel_event
+                    outcome = await _async_wait_with_native_identity(
+                        lambda: _async_wait_for_room_outcome(
+                            hass, entity_id, room, cancel_event
+                        ),
+                        session_identity,
+                        native_identity,
                     )
                     if outcome is RoomRunOutcome.HANDOFF_CANDIDATE:
                         if session_identity is not None:
@@ -1475,6 +1503,7 @@ async def _async_run_leg(
     floor_is_current: Callable[[], bool] | None = None,
     floor_token: str | None = None,
     session_identity: Callable[[], Awaitable[bytes | None]] | None = None,
+    on_native_identity: Callable[[bytes | None], None] | None = None,
 ) -> bool:
     """Run one mission leg and credit only natively verified rooms.
 
@@ -1505,6 +1534,7 @@ async def _async_run_leg(
             floor_is_current=floor_is_current,
             floor_token=floor_token,
             session_identity=session_identity,
+            on_native_identity=on_native_identity,
         )
     if not room_name_is_unique:
         raise _validation_error(
@@ -1545,10 +1575,13 @@ async def _async_run_leg(
     def mark_dispatch_attempted() -> None:
         nonlocal dispatch_attempted
         dispatch_attempted = True
+        bind_native_identity(None)
 
-    def bind_native_identity(identity: bytes) -> None:
+    def bind_native_identity(identity: bytes | None) -> None:
         nonlocal native_identity
         native_identity = identity
+        if on_native_identity is not None:
+            on_native_identity(identity)
 
     try:
         if dispatch is None:
@@ -1562,11 +1595,14 @@ async def _async_run_leg(
                 floor_is_current=floor_is_current,
                 floor_token=floor_token,
                 on_dispatch=mark_dispatch_attempted,
+                session_identity=session_identity,
+                on_identity=bind_native_identity,
             )
         else:
             if dispatch.rooms != tuple(leg):
                 raise ValueError("prepared leg dispatch does not match the leg")
             dispatch_attempted = True
+            bind_native_identity(dispatch.native_identity)
         history_baseline = dispatch.history_baseline
         dispatched_at = dispatch.dispatched_at
         try:
@@ -1578,6 +1614,8 @@ async def _async_run_leg(
                 leg,
                 session_identity,
                 bind_native_identity,
+                dispatch.native_identity_baseline,
+                native_identity,
             )
         except TimeoutError as err:
             raise RoomStartTimeoutError from err
@@ -1607,13 +1645,18 @@ async def _async_run_leg(
                 call.data["completion_timeout"]
             ) as mission_timeout:
                 while True:
-                    outcome, changed_room = await _async_wait_for_leg_outcome(
-                        hass,
-                        entity_id,
-                        leg,
-                        active_room,
-                        cancel_event,
-                        initial_observed=True,
+                    outcome, changed_room = await _async_wait_with_native_identity(
+                        partial(
+                            _async_wait_for_leg_outcome,
+                            hass,
+                            entity_id,
+                            leg,
+                            active_room,
+                            cancel_event,
+                            initial_observed=True,
+                        ),
+                        session_identity,
+                        native_identity,
                     )
                     if outcome is RoomRunOutcome.ROOM_CHANGED:
                         assert changed_room is not None
@@ -2326,6 +2369,8 @@ def _guard_native_commands(
     serial_number: str,
     reader: Callable[[], Awaitable[bytes | None]] | None,
     expected_identity: Callable[[], bytes | None],
+    *,
+    allow_ended_dock: bool = False,
 ) -> Callable[[int, UserCommand], Awaitable[None]] | None:
     """Recheck native ownership at cleanup, including cancellation/unload races."""
     if sender is None or reader is None:
@@ -2334,7 +2379,10 @@ def _guard_native_commands(
     async def send(token: int, command: UserCommand) -> None:
         expected = expected_identity()
         identity = await _async_read_session_identity(reader)
-        if not expected or identity != expected:
+        ended_dock = (
+            allow_ended_dock and command is UserCommand.DOCK and identity == b""
+        )
+        if not expected or (identity != expected and not ended_dock):
             # Revoke local ownership too, so outer abort cleanup and late
             # history reconciliation cannot act for this obsolete mission.
             await manager.async_replace_managed_motion(serial_number)
@@ -2677,6 +2725,51 @@ async def _async_read_session_identity(
         return None
 
 
+async def _async_wait_with_native_identity[T](
+    outcome: Callable[[], Awaitable[T]],
+    reader: Callable[[], Awaitable[bytes | None]] | None,
+    expected: bytes | None,
+) -> T:
+    """Notice replacement even when the OEM task keeps cleaning the same room."""
+    if reader is None:
+        return await outcome()
+
+    async def wait_for_outcome() -> T:
+        return await outcome()
+
+    changed = asyncio.create_task(wait_for_outcome(), eager_start=True)
+    unknown_reads = 0
+    try:
+        while True:
+            if changed.done():
+                changed.result()
+            identity = await _async_read_session_identity(reader)
+            if identity is None:
+                unknown_reads += 1
+                if unknown_reads >= ACTIVE_SESSION_UNKNOWN_ATTEMPTS:
+                    raise RoomTakenOverError(
+                        "The native task ownership could not be verified"
+                    )
+            elif identity and identity != expected:
+                raise RoomTakenOverError("The native cleaning task was replaced")
+            else:
+                # An ended session can precede HA's normal return update;
+                # its history still needs independent completion verification.
+                unknown_reads = 0
+                if changed.done():
+                    return changed.result()
+            if changed.done():
+                changed.result()
+                await asyncio.sleep(ACTIVE_SESSION_UNKNOWN_RETRY_SECONDS)
+            else:
+                await asyncio.wait(
+                    {changed}, timeout=ACTIVE_SESSION_UNKNOWN_RETRY_SECONDS
+                )
+    finally:
+        changed.cancel()
+        await asyncio.gather(changed, return_exceptions=True)
+
+
 async def _async_wait_for_owned_start(
     hass: HomeAssistant,
     entity_id: str,
@@ -2684,7 +2777,9 @@ async def _async_wait_for_owned_start(
     cancel_event: asyncio.Event | None,
     rooms: CleaningRoom | Sequence[CleaningRoom],
     reader: Callable[[], Awaitable[bytes | None]] | None,
-    bind_identity: Callable[[bytes], None],
+    bind_identity: Callable[[bytes | None], None],
+    identity_baseline: bytes | None,
+    expected: bytes | None,
 ) -> str:
     """Bind the dispatched task even while HA's activity/room update lags.
 
@@ -2712,35 +2807,52 @@ async def _async_wait_for_owned_start(
         ),
         eager_start=True,
     )
-    expected: bytes | None = None
-    unknown_reads = 0
     try:
-        while True:
-            identity = await _async_read_session_identity(reader)
-            if identity and expected is None:
-                expected = identity
-                bind_identity(identity)
-            elif identity is not None and expected and identity != expected:
-                raise RoomTakenOverError(
-                    "The dispatched native task ended or was replaced"
-                )
-            if started.done():
-                state = started.result()
-                if identity and identity == expected:
-                    return state
-                unknown_reads += 1
-                if unknown_reads >= ACTIVE_SESSION_UNKNOWN_ATTEMPTS:
-                    raise RoomTakenOverError(
-                        "The started native task could not be identified"
-                    )
-                await asyncio.sleep(ACTIVE_SESSION_UNKNOWN_RETRY_SECONDS)
-            else:
-                await asyncio.wait(
-                    {started}, timeout=ACTIVE_SESSION_UNKNOWN_RETRY_SECONDS
-                )
+        async with asyncio.timeout(timeout_seconds):
+            return await _async_confirm_started_identity(
+                started,
+                reader,
+                bind_identity,
+                identity_baseline,
+                expected,
+                cancel_event,
+            )
     finally:
         started.cancel()
         await asyncio.gather(started, return_exceptions=True)
+
+
+async def _async_confirm_started_identity(
+    started: asyncio.Task[str],
+    reader: Callable[[], Awaitable[bytes | None]],
+    bind_identity: Callable[[bytes | None], None],
+    identity_baseline: bytes | None,
+    expected: bytes | None,
+    cancel_event: asyncio.Event | None,
+) -> str:
+    """Wait for a new identity, never the task that preceded dispatch."""
+    unknown_reads = 0
+    while True:
+        if cancel_event is not None and cancel_event.is_set():
+            raise PlanCancelledError
+        identity = await _async_read_session_identity(reader)
+        if identity and identity != identity_baseline and expected is None:
+            expected = identity
+            bind_identity(identity)
+        elif identity is not None and expected and identity != expected:
+            raise RoomTakenOverError("The dispatched native task ended or was replaced")
+        if started.done():
+            state = started.result()
+            if identity and identity == expected:
+                return state
+            unknown_reads = unknown_reads + 1 if identity is None else 0
+            if unknown_reads >= ACTIVE_SESSION_UNKNOWN_ATTEMPTS:
+                raise RoomTakenOverError(
+                    "The started native task could not be identified"
+                )
+            await asyncio.sleep(ACTIVE_SESSION_UNKNOWN_RETRY_SECONDS)
+        else:
+            await asyncio.wait({started}, timeout=ACTIVE_SESSION_UNKNOWN_RETRY_SECONDS)
 
 
 async def _async_wait_for_owned_resume(
@@ -2942,6 +3054,20 @@ async def _async_execute_rooms(
         cancel_event = manager.prepare_run(serial_number)
         motion_token = manager.begin_managed_motion(serial_number)
         cleanup_stop_sent = False
+        native_identity: bytes | None = None
+
+        def bind_native_identity(identity: bytes | None) -> None:
+            nonlocal native_identity
+            native_identity = identity
+
+        outer_command = _guard_native_commands(
+            managed_user_command,
+            manager,
+            serial_number,
+            session_identity,
+            lambda: native_identity,
+            allow_ended_dock=True,
+        )
         try:
             # Publish ownership before the first suspending check. Otherwise
             # Stop can observe no run while this start waits for an old stop
@@ -2988,6 +3114,9 @@ async def _async_execute_rooms(
                             session_history,
                             floor_is_current=floor_is_current,
                             floor_token=floor_token,
+                            session_identity=session_identity,
+                            on_dispatch=lambda: bind_native_identity(None),
+                            on_identity=bind_native_identity,
                         )
                     except (HomeAssistantError, MaticError) as err:
                         _LOGGER.debug(
@@ -3029,6 +3158,7 @@ async def _async_execute_rooms(
                     floor_is_current=floor_is_current,
                     floor_token=floor_token,
                     session_identity=session_identity,
+                    on_native_identity=bind_native_identity,
                 )
                 if not completion_verified:
                     break
@@ -3039,7 +3169,7 @@ async def _async_execute_rooms(
                 if finish_room_event.is_set():
                     if prepared_dispatches:
                         await _async_cleanup_managed_motion(
-                            managed_user_command,
+                            outer_command,
                             motion_token,
                             dispatch_attempted=True,
                         )
@@ -3053,12 +3183,12 @@ async def _async_execute_rooms(
                 (call.data["return_to_base"] or finish_room_event.is_set())
                 and (current := hass.states.get(entity_id)) is not None
                 and current.state not in {"docked", "returning"}
-                and managed_user_command is not None
+                and outer_command is not None
                 and not cleanup_stop_sent
                 and not _stop_is_pending(manager, serial_number)
             ):
                 try:
-                    await managed_user_command(motion_token, UserCommand.DOCK)
+                    await outer_command(motion_token, UserCommand.DOCK)
                 except ManagedMotionReplacedError as err:
                     raise PlanCancelledError from err
                 except MaticError as err:
@@ -3119,7 +3249,7 @@ async def _async_execute_rooms(
                             )
                     if not session_ended:
                         await _async_cleanup_managed_motion(
-                            managed_user_command, motion_token, dispatch_attempted=True
+                            outer_command, motion_token, dispatch_attempted=True
                         )
             raise
         finally:

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -505,6 +505,9 @@ async def async_register_services(hass: HomeAssistant) -> None:
             session_history=(
                 entry.runtime_data.client.async_get_cleaning_session_records
             ),
+            session_identity=(
+                entry.runtime_data.client.async_get_cleaning_session_identity
+            ),
             confirm_room_completed=(
                 entry.runtime_data.coordinator.async_confirm_room_completed
             ),
@@ -585,6 +588,9 @@ async def async_register_services(hass: HomeAssistant) -> None:
             ),
             session_history=(
                 entry.runtime_data.client.async_get_cleaning_session_records
+            ),
+            session_identity=(
+                entry.runtime_data.client.async_get_cleaning_session_identity
             ),
             confirm_room_completed=(
                 entry.runtime_data.coordinator.async_confirm_room_completed
@@ -1066,6 +1072,7 @@ async def _async_run_room(
     prefetch_next: Callable[[], Awaitable[_PreparedRoomDispatch | None]] | None = None,
     floor_is_current: Callable[[], bool] | None = None,
     floor_token: str | None = None,
+    session_identity: Callable[[], Awaitable[bytes | None]] | None = None,
 ) -> bool:
     """Run one room and report whether native history verified completion."""
     if not room_name_is_unique:
@@ -1126,17 +1133,21 @@ async def _async_run_room(
             )
         except TimeoutError as err:
             raise RoomStartTimeoutError from err
+        native_identity = await _async_read_session_identity(session_identity)
+        if session_identity is not None and not native_identity:
+            raise RoomTakenOverError("The started native task could not be identified")
         if start_state == "paused":
             await manager.async_mark_suspended(
                 serial_number, call.data["plan_id"], room, "paused"
             )
-            await _async_wait_for_vacuum_state(
+            await _async_wait_for_owned_resume(
                 hass,
                 entity_id,
-                {"cleaning"},
                 call.data["completion_timeout"],
                 cancel_event,
                 room,
+                session_identity,
+                native_identity,
             )
         await manager.async_mark_resumed(serial_number, call.data["plan_id"], room)
         room_started = True
@@ -1182,6 +1193,8 @@ async def _async_run_room(
                                 entity_id,
                                 active_session,
                                 cancel_event,
+                                identity_reader=session_identity,
+                                expected_identity=native_identity,
                             )
                         )
                         if session_resolution is False:
@@ -1225,13 +1238,14 @@ async def _async_run_room(
                         room,
                         suspend_reason,
                     )
-                    await _async_wait_for_vacuum_state(
+                    await _async_wait_for_owned_resume(
                         hass,
                         entity_id,
-                        {"cleaning"},
                         call.data["completion_timeout"],
                         cancel_event,
                         room,
+                        session_identity,
+                        native_identity,
                     )
                     await manager.async_mark_resumed(
                         serial_number, call.data["plan_id"], room
@@ -1289,7 +1303,7 @@ async def _async_run_room(
             context=call.context,
         )
         raise _validation_error(
-            "The managed room was replaced by another cleaning task",
+            "The original native cleaning task could no longer be verified",
             "room_taken_over",
             {"room": room.name},
         ) from err
@@ -1459,6 +1473,7 @@ async def _async_run_leg(
     finish_room_event: asyncio.Event | None = None,
     floor_is_current: Callable[[], bool] | None = None,
     floor_token: str | None = None,
+    session_identity: Callable[[], Awaitable[bytes | None]] | None = None,
 ) -> bool:
     """Run one mission leg and credit only natively verified rooms.
 
@@ -1488,6 +1503,7 @@ async def _async_run_leg(
             prefetch_next=prefetch_next,
             floor_is_current=floor_is_current,
             floor_token=floor_token,
+            session_identity=session_identity,
         )
     if not room_name_is_unique:
         raise _validation_error(
@@ -1551,17 +1567,21 @@ async def _async_run_leg(
             )
         except TimeoutError as err:
             raise RoomStartTimeoutError from err
+        native_identity = await _async_read_session_identity(session_identity)
+        if session_identity is not None and not native_identity:
+            raise RoomTakenOverError("The started native task could not be identified")
         if start_state == "paused":
             await manager.async_mark_suspended(
                 serial_number, call.data["plan_id"], active_room, "paused"
             )
-            await _async_wait_for_vacuum_state(
+            await _async_wait_for_owned_resume(
                 hass,
                 entity_id,
-                {"cleaning"},
                 call.data["completion_timeout"],
                 cancel_event,
                 leg,
+                session_identity,
+                native_identity,
             )
         await manager.async_mark_resumed(
             serial_number, call.data["plan_id"], active_room
@@ -1618,7 +1638,12 @@ async def _async_run_leg(
                         if active_session is not None:
                             session_resolution = (
                                 await _async_wait_for_active_session_resolution(
-                                    hass, entity_id, active_session, cancel_event
+                                    hass,
+                                    entity_id,
+                                    active_session,
+                                    cancel_event,
+                                    identity_reader=session_identity,
+                                    expected_identity=native_identity,
                                 )
                             )
                             if session_resolution is True:
@@ -1660,13 +1685,14 @@ async def _async_run_leg(
                         active_room,
                         suspend_reason,
                     )
-                    await _async_wait_for_vacuum_state(
+                    await _async_wait_for_owned_resume(
                         hass,
                         entity_id,
-                        {"cleaning"},
                         call.data["completion_timeout"],
                         cancel_event,
                         leg,
+                        session_identity,
+                        native_identity,
                     )
                     await manager.async_mark_resumed(
                         serial_number, call.data["plan_id"], active_room
@@ -1738,7 +1764,7 @@ async def _async_run_leg(
             context=call.context,
         )
         raise _validation_error(
-            "The managed room was replaced by another cleaning task",
+            "The original native cleaning task could no longer be verified",
             "room_taken_over",
             {"room": active_room.name},
         ) from err
@@ -2214,6 +2240,9 @@ async def _async_wait_for_active_session_resolution(
     entity_id: str,
     reader: Callable[[], Awaitable[bool | None]] | None,
     cancel_event: asyncio.Event | None = None,
+    *,
+    identity_reader: Callable[[], Awaitable[bytes | None]] | None = None,
+    expected_identity: bytes | None = None,
 ) -> bool | None:
     """Wait for a returning task to finish or visibly resume.
 
@@ -2223,22 +2252,34 @@ async def _async_wait_for_active_session_resolution(
     enclosing room timeout bounds the wait while known-active firmware sessions
     return to their dock.
     """
-    if reader is None:
+    if reader is None and identity_reader is None:
         return None
     unknown_reads = 0
     while True:
         if cancel_event is not None and cancel_event.is_set():
             raise PlanCancelledError
+        identity = await _async_read_session_identity(identity_reader)
+        if identity_reader is not None:
+            if identity == b"":
+                return False
+            if identity is not None and identity != expected_identity:
+                raise RoomTakenOverError("The returning native task was replaced")
         state = hass.states.get(entity_id)
         if state is not None:
             if state.state == "error":
                 raise _validation_error(
                     "The selected Matic robot reported an error", "robot_error"
                 )
-            if state.state == "cleaning":
+            if state.state == "cleaning" and (
+                identity_reader is None or identity is not None
+            ):
                 return True
         try:
-            session_active = await reader()
+            if identity_reader is not None:
+                session_active = True if identity is not None else None
+            else:
+                assert reader is not None
+                session_active = await reader()
         except MaticError as err:
             _LOGGER.debug(
                 "Native Matic active-session resolution unavailable (%s)",
@@ -2250,6 +2291,10 @@ async def _async_wait_for_active_session_resolution(
         if session_active is None:
             unknown_reads += 1
             if unknown_reads >= ACTIVE_SESSION_UNKNOWN_ATTEMPTS:
+                if identity_reader is not None:
+                    raise RoomTakenOverError(
+                        "The returning native task ownership could not be verified"
+                    )
                 return None
         else:
             unknown_reads = 0
@@ -2585,6 +2630,78 @@ async def _async_periodic_refresh(
         await refresh()
 
 
+async def _async_read_session_identity(
+    reader: Callable[[], Awaitable[bytes | None]] | None,
+) -> bytes | None:
+    """Read an opaque identity without logging its value on transport failure."""
+    if reader is None:
+        return None
+    try:
+        return await reader()
+    except MaticError:
+        return None
+
+
+async def _async_wait_for_owned_resume(
+    hass: HomeAssistant,
+    entity_id: str,
+    timeout_seconds: int,
+    cancel_event: asyncio.Event | None,
+    rooms: CleaningRoom | Sequence[CleaningRoom],
+    reader: Callable[[], Awaitable[bytes | None]] | None,
+    expected: bytes | None,
+) -> None:
+    """Resume only the original native mission, including while docked.
+
+    A cleared session is terminal even when the last room state said low
+    charge. A new OEM task can clean the same room, so room/activity alone
+    cannot prove resumption. Unknown ownership is bounded and fails without
+    STOP or completion credit: cleanup must not cancel an independent task.
+    """
+    if reader is None or not expected:
+        raise RoomTakenOverError("The suspended native task could not be identified")
+    resumed = asyncio.create_task(
+        _async_wait_for_vacuum_state(
+            hass, entity_id, {"cleaning"}, timeout_seconds, cancel_event, rooms
+        )
+    )
+    unknown_reads = 0
+    try:
+        async with asyncio.timeout(timeout_seconds):
+            while True:
+                if cancel_event is not None and cancel_event.is_set():
+                    raise PlanCancelledError
+                identity = await _async_read_session_identity(reader)
+                if identity is None:
+                    unknown_reads += 1
+                    if unknown_reads >= ACTIVE_SESSION_UNKNOWN_ATTEMPTS:
+                        raise RoomTakenOverError(
+                            "The suspended native task ownership could not be verified"
+                        )
+                elif identity != expected:
+                    raise RoomTakenOverError(
+                        "The suspended native task ended or was replaced"
+                    )
+                else:
+                    unknown_reads = 0
+                    if resumed.done():
+                        # Propagate errors/cancellation before recording a resume.
+                        resumed.result()
+                        return
+                # Check again after the state transition, and keep checking
+                # session continuity during a potentially long charge interval.
+                if resumed.done():
+                    resumed.result()
+                    await asyncio.sleep(ACTIVE_SESSION_UNKNOWN_RETRY_SECONDS)
+                else:
+                    await asyncio.wait(
+                        {resumed}, timeout=ACTIVE_SESSION_UNKNOWN_RETRY_SECONDS
+                    )
+    finally:
+        resumed.cancel()
+        await asyncio.gather(resumed, return_exceptions=True)
+
+
 async def _async_wait_for_vacuum_state(
     hass: HomeAssistant,
     entity_id: str,
@@ -2690,7 +2807,7 @@ class RoomStoppedInPlaceError(RoomInterruptedError):
 
 
 class RoomTakenOverError(HomeAssistantError):
-    """An external task began cleaning another known mapped room."""
+    """The native task ended, changed, or could no longer be identified."""
 
 
 async def _async_execute_rooms(
@@ -2711,6 +2828,7 @@ async def _async_execute_rooms(
     mapped_room_names: tuple[str, ...] = (),
     floor_is_current: Callable[[], bool] | None = None,
     floor_token: str | None = None,
+    session_identity: Callable[[], Awaitable[bytes | None]] | None = None,
 ) -> None:
     """Execute every resolved room with safe cancellation semantics."""
     lock = manager.lock(serial_number)
@@ -2809,6 +2927,7 @@ async def _async_execute_rooms(
                     finish_room_event=finish_room_event,
                     floor_is_current=floor_is_current,
                     floor_token=floor_token,
+                    session_identity=session_identity,
                 )
                 if not completion_verified:
                     break

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -1097,6 +1097,14 @@ async def _async_run_room(
     dispatch: _PreparedRoomDispatch | None = prepared_dispatch
     history_baseline: frozenset[bytes] | None = None
     dispatched_at: datetime | None = None
+    native_identity: bytes | None = None
+    managed_user_command = _guard_native_commands(
+        managed_user_command,
+        manager,
+        serial_number,
+        session_identity,
+        lambda: native_identity,
+    )
 
     def mark_dispatch_attempted() -> None:
         nonlocal dispatch_attempted
@@ -1523,6 +1531,14 @@ async def _async_run_leg(
     stop_sent = False
     evidence: dict[str, tuple[str, int]] | None = None
     dispatch: _PreparedRoomDispatch | None = prepared_dispatch
+    native_identity: bytes | None = None
+    managed_user_command = _guard_native_commands(
+        managed_user_command,
+        manager,
+        serial_number,
+        session_identity,
+        lambda: native_identity,
+    )
 
     def mark_dispatch_attempted() -> None:
         nonlocal dispatch_attempted
@@ -2298,6 +2314,30 @@ async def _async_wait_for_active_session_resolution(
         except TimeoutError:
             continue
         raise PlanCancelledError
+
+
+def _guard_native_commands(
+    sender: Callable[[int, UserCommand], Awaitable[None]] | None,
+    manager: CleaningPlanManager,
+    serial_number: str,
+    reader: Callable[[], Awaitable[bytes | None]] | None,
+    expected_identity: Callable[[], bytes | None],
+) -> Callable[[int, UserCommand], Awaitable[None]] | None:
+    """Recheck native ownership at cleanup, including cancellation/unload races."""
+    if sender is None or reader is None:
+        return sender
+
+    async def send(token: int, command: UserCommand) -> None:
+        expected = expected_identity()
+        identity = await _async_read_session_identity(reader)
+        if not expected or identity != expected:
+            # Revoke local ownership too, so outer abort cleanup and late
+            # history reconciliation cannot act for this obsolete mission.
+            await manager.async_replace_managed_motion(serial_number)
+            raise ManagedMotionReplacedError("Native task ownership was lost")
+        await sender(token, command)
+
+    return send
 
 
 async def _async_cleanup_managed_motion(

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -1165,38 +1165,29 @@ async def _async_run_room(
                         hass, entity_id, room, cancel_event
                     )
                     if outcome is RoomRunOutcome.HANDOFF_CANDIDATE:
-                        session_active = await _async_active_session_state(
-                            active_session
-                        )
-                        if session_active is False or active_session is None:
-                            mission_timeout.reschedule(None)
-                            await manager.async_mark_verifying(
-                                serial_number, call.data["plan_id"], room
+                        if session_identity is not None:
+                            session_resolution = (
+                                await _async_wait_for_active_session_resolution(
+                                    hass,
+                                    entity_id,
+                                    active_session,
+                                    cancel_event,
+                                    identity_reader=session_identity,
+                                    expected_identity=native_identity,
+                                )
                             )
-                            completion_verified = await _async_verify_room_completion(
-                                session_history,
-                                history_baseline,
-                                room,
-                                dispatched_at,
-                                hass=hass,
-                                entity_id=entity_id,
-                                cancel_event=cancel_event,
+                        else:
+                            session_resolution = await _async_active_session_state(
+                                active_session
                             )
-                            break
-                        if session_active is None:
-                            raise RoomInterruptedError(
-                                f"{room.name} completion could not be verified"
-                            )
-                        session_resolution = (
-                            await _async_wait_for_active_session_resolution(
-                                hass,
-                                entity_id,
-                                active_session,
-                                cancel_event,
-                                identity_reader=session_identity,
-                                expected_identity=native_identity,
-                            )
-                        )
+                            if active_session is None:
+                                session_resolution = False
+                            elif session_resolution is True:
+                                session_resolution = (
+                                    await _async_wait_for_active_session_resolution(
+                                        hass, entity_id, active_session, cancel_event
+                                    )
+                                )
                         if session_resolution is False:
                             mission_timeout.reschedule(None)
                             await manager.async_mark_verifying(
@@ -1635,7 +1626,7 @@ async def _async_run_leg(
                         )
                         continue
                     if outcome is RoomRunOutcome.HANDOFF_CANDIDATE:
-                        if active_session is not None:
+                        if active_session is not None or session_identity is not None:
                             session_resolution = (
                                 await _async_wait_for_active_session_resolution(
                                     hass,

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -2312,20 +2312,21 @@ async def _async_wait_for_active_session_resolution(
     while True:
         if cancel_event is not None and cancel_event.is_set():
             raise PlanCancelledError
+        observed_state = hass.states.get(entity_id)
         identity = await _async_read_session_identity(identity_reader)
-        if identity_reader is not None:
-            if identity == b"":
-                return False
-            if identity is not None and identity != expected_identity:
-                raise RoomTakenOverError("The returning native task was replaced")
         state = hass.states.get(entity_id)
+        if identity_reader is not None:
+            if identity == b"" and state is observed_state:
+                return False
+            if identity and identity != expected_identity:
+                raise RoomTakenOverError("The returning native task was replaced")
         if state is not None:
             if state.state == "error":
                 raise _validation_error(
                     "The selected Matic robot reported an error", "robot_error"
                 )
             if state.state == "cleaning" and (
-                identity_reader is None or identity is not None
+                identity_reader is None or (identity and state is observed_state)
             ):
                 return True
         try:
@@ -2741,7 +2742,8 @@ async def _async_wait_with_native_identity[T](
     unknown_reads = 0
     try:
         while True:
-            if changed.done():
+            transition_observed = changed.done()
+            if transition_observed:
                 changed.result()
             identity = await _async_read_session_identity(reader)
             if identity is None:
@@ -2756,7 +2758,7 @@ async def _async_wait_with_native_identity[T](
                 # An ended session can precede HA's normal return update;
                 # its history still needs independent completion verification.
                 unknown_reads = 0
-                if changed.done():
+                if transition_observed:
                     return changed.result()
             if changed.done():
                 changed.result()
@@ -2835,6 +2837,7 @@ async def _async_confirm_started_identity(
     while True:
         if cancel_event is not None and cancel_event.is_set():
             raise PlanCancelledError
+        transition_observed = started.done()
         identity = await _async_read_session_identity(reader)
         if identity and identity != identity_baseline and expected is None:
             expected = identity
@@ -2843,7 +2846,7 @@ async def _async_confirm_started_identity(
             raise RoomTakenOverError("The dispatched native task ended or was replaced")
         if started.done():
             state = started.result()
-            if identity and identity == expected:
+            if transition_observed and identity and identity == expected:
                 return state
             unknown_reads = unknown_reads + 1 if identity is None else 0
             if unknown_reads >= ACTIVE_SESSION_UNKNOWN_ATTEMPTS:
@@ -2884,6 +2887,7 @@ async def _async_wait_for_owned_resume(
             while True:
                 if cancel_event is not None and cancel_event.is_set():
                     raise PlanCancelledError
+                transition_observed = resumed.done()
                 identity = await _async_read_session_identity(reader)
                 if identity is None:
                     unknown_reads += 1
@@ -2897,8 +2901,9 @@ async def _async_wait_for_owned_resume(
                     )
                 else:
                     unknown_reads = 0
-                    if resumed.done():
-                        # Propagate errors/cancellation before recording a resume.
+                    if transition_observed:
+                        # The identity read began after the observed resume.
+                        # Propagate errors/cancellation before recording it.
                         resumed.result()
                         return
                 # Check again after the state transition, and keep checking

--- a/custom_components/matic_robot/strings.json
+++ b/custom_components/matic_robot/strings.json
@@ -1187,7 +1187,7 @@
       "message": "{room} stopped without verified completion."
     },
     "room_taken_over": {
-      "message": "Another cleaning task replaced the managed run in {room}."
+      "message": "The original cleaning task in {room} could no longer be verified. The plan was interrupted."
     },
     "room_plan_unavailable": {
       "message": "The robot's room map is unavailable."

--- a/custom_components/matic_robot/translations/en.json
+++ b/custom_components/matic_robot/translations/en.json
@@ -1187,7 +1187,7 @@
       "message": "{room} stopped without verified completion."
     },
     "room_taken_over": {
-      "message": "Another cleaning task replaced the managed run in {room}."
+      "message": "The original cleaning task in {room} could no longer be verified. The plan was interrupted."
     },
     "room_plan_unavailable": {
       "message": "The robot's room map is unavailable."

--- a/docs/acceptance-0.4.md
+++ b/docs/acceptance-0.4.md
@@ -37,6 +37,7 @@ Release preparation targets `0.4.0rc1`; rerun affected gates before promotion.
 | Completion credit/events | Only positive native room evidence earns credit; events occur once | Installed baseline two-room pass: one credit/start/completion per room and one correct native finished event |
 | Floor round trip | Floor A → B → A scene/pose/rooms/history/actions agree; no duplicate Repairs | Earlier stable #54 proof; fresh 0.4 physical regression open |
 | Recovery | Honest reconnect/auth/reopen; no stale actions or command replay | Synthetic and prior live non-motion checks; interruption during motion open |
+| Recharge and OEM replacement | Resume only the original native session; an ended, replaced or unverifiable session releases the plan without Stop, credit or another dispatch | Automated single/multi-room pause, charge, replacement and unknown-identity cases pass; affected live acceptance remains open |
 | Accessibility | Keyboard/focus/labels/zoom/touch usable throughout | 567 browser checks; actual iPhone flows and guided owner VoiceOver pass; iPad waived; broader assistive-technology cases remain separate |
 | Support | Useful redacted diagnostics and discoverable recovery | Privacy tests; fresh live diagnostics connected with verified floor/session; reporter confirmation open |
 

--- a/docs/acceptance-0.4.md
+++ b/docs/acceptance-0.4.md
@@ -37,7 +37,7 @@ Release preparation targets `0.4.0rc1`; rerun affected gates before promotion.
 | Completion credit/events | Only positive native room evidence earns credit; events occur once | Installed baseline two-room pass: one credit/start/completion per room and one correct native finished event |
 | Floor round trip | Floor A → B → A scene/pose/rooms/history/actions agree; no duplicate Repairs | Earlier stable #54 proof; fresh 0.4 physical regression open |
 | Recovery | Honest reconnect/auth/reopen; no stale actions or command replay | Synthetic and prior live non-motion checks; interruption during motion open |
-| Recharge and OEM replacement | Resume only the original native session; an ended, replaced or unverifiable session releases the plan without Stop, credit or another dispatch | Automated single/multi-room pause, charge, replacement and unknown-identity cases pass; affected live acceptance remains open |
+| Recharge and OEM replacement | Resume only the original native session; an ended, replaced or unverifiable session releases the plan without Stop, credit or another dispatch | Automated single/multi-room pause, charge, replacement, unknown-identity and delayed-start cleanup cases pass; affected live acceptance remains open |
 | Accessibility | Keyboard/focus/labels/zoom/touch usable throughout | 567 browser checks; actual iPhone flows and guided owner VoiceOver pass; iPad waived; broader assistive-technology cases remain separate |
 | Support | Useful redacted diagnostics and discoverable recovery | Privacy tests; fresh live diagnostics connected with verified floor/session; reporter confirmation open |
 

--- a/docs/acceptance-0.4.md
+++ b/docs/acceptance-0.4.md
@@ -37,7 +37,7 @@ Release preparation targets `0.4.0rc1`; rerun affected gates before promotion.
 | Completion credit/events | Only positive native room evidence earns credit; events occur once | Installed baseline two-room pass: one credit/start/completion per room and one correct native finished event |
 | Floor round trip | Floor A → B → A scene/pose/rooms/history/actions agree; no duplicate Repairs | Earlier stable #54 proof; fresh 0.4 physical regression open |
 | Recovery | Honest reconnect/auth/reopen; no stale actions or command replay | Synthetic and prior live non-motion checks; interruption during motion open |
-| Recharge and OEM replacement | Resume only the original native session; an ended, replaced or unverifiable session releases the plan without Stop, credit or another dispatch | Automated single/multi-room pause, charge, replacement, unknown-identity and delayed-start cleanup cases pass; affected live acceptance remains open |
+| Recharge and OEM replacement | Resume only the original native session; an ended, replaced or unverifiable session releases the plan without Stop, credit or another dispatch | Automated single/multi-room cleaning, pause, charge, pre-existing/replaced sessions, unknown identity and delayed-start cleanup cases pass; affected live acceptance remains open |
 | Accessibility | Keyboard/focus/labels/zoom/touch usable throughout | 567 browser checks; actual iPhone flows and guided owner VoiceOver pass; iPad waived; broader assistive-technology cases remain separate |
 | Support | Useful redacted diagnostics and discoverable recovery | Privacy tests; fresh live diagnostics connected with verified floor/session; reporter confirmation open |
 

--- a/docs/release-notes-0.4.md
+++ b/docs/release-notes-0.4.md
@@ -33,6 +33,10 @@ not published releases.
 - Managed completion waits for positive native per-room evidence before
   crediting history. Native finished events use native history, and room starts
   are deduplicated.
+- Paused and recharging plans verify the original native session before
+  resuming. A new task started in the OEM app cannot inherit the old plan,
+  even when it cleans the same room. Lost ownership interrupts HA tracking
+  without sending a cleanup Stop to the independent task.
 
 ## Validation and known limits
 

--- a/tests/test_api_paths.py
+++ b/tests/test_api_paths.py
@@ -1651,10 +1651,13 @@ def test_decode_cleaning_session_skips_unusable_room_entries() -> None:
     assert session.duration_seconds == 600
 
 
-async def test_command_wrappers_encode_and_route(monkeypatch) -> None:
+async def test_command_wrappers_encode_and_route(monkeypatch, caplog) -> None:
     client = MaticHermesClient("robot.invalid", 16320)
     client._async_send_channel_payload = AsyncMock()
-    await client.async_send_user_command(UserCommand.STOP)
+    with caplog.at_level("DEBUG"):
+        await client.async_send_user_command(UserCommand.STOP)
+    assert "Requesting Matic user command STOP" in caplog.text
+    assert "robot.invalid" not in caplog.text
     await client.async_start_coverage(
         FloorPlan(
             1,

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -4137,7 +4137,11 @@ async def test_unknown_active_session_interrupts_without_room_credit(
 async def test_room_starting_paused_is_suspended_until_resume() -> None:
     services = SimpleNamespace(async_call=AsyncMock())
     bus = SimpleNamespace(async_fire=MagicMock())
-    hass = SimpleNamespace(services=services, bus=bus)
+    hass = SimpleNamespace(
+        services=services,
+        bus=bus,
+        states=SimpleNamespace(get=MagicMock(return_value=None)),
+    )
     manager = SimpleNamespace(
         async_mark_started=AsyncMock(),
         async_mark_completed=AsyncMock(),
@@ -4184,7 +4188,11 @@ async def test_room_starting_paused_is_suspended_until_resume() -> None:
 async def test_room_pause_and_resume_outcome() -> None:
     services = SimpleNamespace(async_call=AsyncMock())
     bus = SimpleNamespace(async_fire=MagicMock())
-    hass = SimpleNamespace(services=services, bus=bus)
+    hass = SimpleNamespace(
+        services=services,
+        bus=bus,
+        states=SimpleNamespace(get=MagicMock(return_value=None)),
+    )
     manager = SimpleNamespace(
         async_mark_started=AsyncMock(),
         async_mark_completed=AsyncMock(),

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -2475,7 +2475,7 @@ async def test_room_recharge_waits_for_resume_before_unverified_handoff() -> Non
                     RoomRunOutcome.HANDOFF_CANDIDATE,
                 ]
             ),
-        ),
+        ) as outcome,
     ):
         await _async_run_room(
             hass,
@@ -2485,7 +2485,9 @@ async def test_room_recharge_waits_for_resume_before_unverified_handoff() -> Non
             "serial",
             _room("Kitchen", "room-kitchen"),
             active_session=AsyncMock(return_value=False),
-            session_identity=AsyncMock(return_value=b"native-task"),
+            session_identity=AsyncMock(
+                side_effect=lambda: b"" if outcome.await_count >= 2 else b"native-task"
+            ),
         )
 
     manager.async_mark_suspended.assert_awaited_once_with(
@@ -3058,6 +3060,13 @@ async def test_leg_start_timeout_marks_failure_and_stops(hass) -> None:
 async def test_leg_paused_start_suspends_until_cleaning(hass) -> None:
     rooms = _leg_rooms()
     manager = _leg_manager()
+    resumed = asyncio.Event()
+
+    async def confirm_resume(*args):
+        if manager.async_mark_suspended.await_count:
+            resumed.set()
+
+    manager.async_mark_resumed.side_effect = confirm_resume
 
     async def send_command(_call) -> None:
         hass.states.async_set("vacuum.matic", "paused", {"current_area": "Kitchen"})
@@ -3067,7 +3076,7 @@ async def test_leg_paused_start_suspends_until_cleaning(hass) -> None:
             hass.states.async_set(
                 "vacuum.matic", "cleaning", {"current_area": "Kitchen"}
             )
-            await asyncio.sleep(0)
+            await resumed.wait()
             hass.states.async_set(
                 "vacuum.matic",
                 "returning",
@@ -3094,7 +3103,16 @@ async def test_leg_paused_start_suspends_until_cleaning(hass) -> None:
         "serial",
         rooms,
         session_history=history,
-        session_identity=AsyncMock(return_value=b"native-task"),
+        session_identity=AsyncMock(
+            side_effect=lambda: (
+                b""
+                if (
+                    hass.states.get("vacuum.matic").state == "returning"
+                    and not hass.states.get("vacuum.matic").attributes.get("low_charge")
+                )
+                else b"native-task"
+            )
+        ),
     )
 
     assert completed is True
@@ -3105,6 +3123,13 @@ async def test_leg_paused_start_suspends_until_cleaning(hass) -> None:
 async def test_leg_suspension_mid_leg_resumes(hass) -> None:
     rooms = _leg_rooms()
     manager = _leg_manager()
+    resumed = asyncio.Event()
+
+    async def confirm_resume(*args):
+        if manager.async_mark_suspended.await_count:
+            resumed.set()
+
+    manager.async_mark_resumed.side_effect = confirm_resume
 
     async def send_command(_call) -> None:
         hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Kitchen"})
@@ -3120,7 +3145,7 @@ async def test_leg_suspension_mid_leg_resumes(hass) -> None:
             hass.states.async_set(
                 "vacuum.matic", "cleaning", {"current_area": "Office"}
             )
-            await asyncio.sleep(0)
+            await resumed.wait()
             hass.states.async_set(
                 "vacuum.matic",
                 "returning",
@@ -3147,7 +3172,16 @@ async def test_leg_suspension_mid_leg_resumes(hass) -> None:
         "serial",
         rooms,
         session_history=history,
-        session_identity=AsyncMock(return_value=b"native-task"),
+        session_identity=AsyncMock(
+            side_effect=lambda: (
+                b""
+                if (
+                    hass.states.get("vacuum.matic").state == "returning"
+                    and not hass.states.get("vacuum.matic").attributes.get("low_charge")
+                )
+                else b"native-task"
+            )
+        ),
     )
 
     assert completed is True
@@ -4116,7 +4150,7 @@ async def test_room_starting_paused_is_suspended_until_resume() -> None:
         patch(
             "custom_components.matic_robot.services._async_wait_for_room_outcome",
             AsyncMock(return_value=RoomRunOutcome.HANDOFF_CANDIDATE),
-        ),
+        ) as outcome,
     ):
         await _async_run_room(
             hass,
@@ -4126,7 +4160,9 @@ async def test_room_starting_paused_is_suspended_until_resume() -> None:
             "serial",
             _room("Kitchen", "room-kitchen"),
             active_session=AsyncMock(return_value=False),
-            session_identity=AsyncMock(return_value=b"native-task"),
+            session_identity=AsyncMock(
+                side_effect=lambda: b"" if outcome.await_count >= 1 else b"native-task"
+            ),
         )
 
     manager.async_mark_suspended.assert_awaited_once()
@@ -4159,7 +4195,9 @@ async def test_room_pause_and_resume_outcome() -> None:
         "serial",
         room,
         active_session=AsyncMock(return_value=False),
-        session_identity=AsyncMock(return_value=b"native-task"),
+        session_identity=AsyncMock(
+            side_effect=lambda: b"" if outcome.await_count >= 2 else b"native-task"
+        ),
     )
     with (
         patch(
@@ -4174,7 +4212,7 @@ async def test_room_pause_and_resume_outcome() -> None:
                     RoomRunOutcome.HANDOFF_CANDIDATE,
                 ]
             ),
-        ),
+        ) as outcome,
     ):
         await run
 

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -2486,7 +2486,11 @@ async def test_room_recharge_waits_for_resume_before_unverified_handoff() -> Non
             _room("Kitchen", "room-kitchen"),
             active_session=AsyncMock(return_value=False),
             session_identity=AsyncMock(
-                side_effect=lambda: b"" if outcome.await_count >= 2 else b"native-task"
+                side_effect=lambda: (
+                    b""
+                    if not services.async_call.await_count or outcome.await_count >= 2
+                    else b"native-task"
+                )
             ),
         )
 
@@ -3106,7 +3110,8 @@ async def test_leg_paused_start_suspends_until_cleaning(hass) -> None:
         session_identity=AsyncMock(
             side_effect=lambda: (
                 b""
-                if (
+                if not hass.states.get("vacuum.matic")
+                or (
                     hass.states.get("vacuum.matic").state == "returning"
                     and not hass.states.get("vacuum.matic").attributes.get("low_charge")
                 )
@@ -3175,7 +3180,8 @@ async def test_leg_suspension_mid_leg_resumes(hass) -> None:
         session_identity=AsyncMock(
             side_effect=lambda: (
                 b""
-                if (
+                if not hass.states.get("vacuum.matic")
+                or (
                     hass.states.get("vacuum.matic").state == "returning"
                     and not hass.states.get("vacuum.matic").attributes.get("low_charge")
                 )
@@ -4161,7 +4167,11 @@ async def test_room_starting_paused_is_suspended_until_resume() -> None:
             _room("Kitchen", "room-kitchen"),
             active_session=AsyncMock(return_value=False),
             session_identity=AsyncMock(
-                side_effect=lambda: b"" if outcome.await_count >= 1 else b"native-task"
+                side_effect=lambda: (
+                    b""
+                    if not services.async_call.await_count or outcome.await_count >= 1
+                    else b"native-task"
+                )
             ),
         )
 
@@ -4196,7 +4206,11 @@ async def test_room_pause_and_resume_outcome() -> None:
         room,
         active_session=AsyncMock(return_value=False),
         session_identity=AsyncMock(
-            side_effect=lambda: b"" if outcome.await_count >= 2 else b"native-task"
+            side_effect=lambda: (
+                b""
+                if not services.async_call.await_count or outcome.await_count >= 2
+                else b"native-task"
+            )
         ),
     )
     with (

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -2485,6 +2485,7 @@ async def test_room_recharge_waits_for_resume_before_unverified_handoff() -> Non
             "serial",
             _room("Kitchen", "room-kitchen"),
             active_session=AsyncMock(return_value=False),
+            session_identity=AsyncMock(return_value=b"native-task"),
         )
 
     manager.async_mark_suspended.assert_awaited_once_with(
@@ -3093,6 +3094,7 @@ async def test_leg_paused_start_suspends_until_cleaning(hass) -> None:
         "serial",
         rooms,
         session_history=history,
+        session_identity=AsyncMock(return_value=b"native-task"),
     )
 
     assert completed is True
@@ -3145,6 +3147,7 @@ async def test_leg_suspension_mid_leg_resumes(hass) -> None:
         "serial",
         rooms,
         session_history=history,
+        session_identity=AsyncMock(return_value=b"native-task"),
     )
 
     assert completed is True
@@ -4123,6 +4126,7 @@ async def test_room_starting_paused_is_suspended_until_resume() -> None:
             "serial",
             _room("Kitchen", "room-kitchen"),
             active_session=AsyncMock(return_value=False),
+            session_identity=AsyncMock(return_value=b"native-task"),
         )
 
     manager.async_mark_suspended.assert_awaited_once()
@@ -4155,6 +4159,7 @@ async def test_room_pause_and_resume_outcome() -> None:
         "serial",
         room,
         active_session=AsyncMock(return_value=False),
+        session_identity=AsyncMock(return_value=b"native-task"),
     )
     with (
         patch(
@@ -5349,7 +5354,7 @@ async def test_leg_handles_unknown_and_resumed_native_session(
         hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Kitchen"})
         hass.async_create_task(return_later(), eager_start=True)
 
-    async def resolution(*args):
+    async def resolution(*args, **kwargs):
         nonlocal resolutions
         resolutions += 1
         if not resumes:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -751,6 +751,9 @@ async def test_clean_room_sequence_preserves_order_and_per_room_settings(hass) -
             client=SimpleNamespace(
                 async_has_active_cleaning_session=AsyncMock(return_value=False),
                 async_get_cleaning_session_records=AsyncMock(return_value=()),
+                async_get_cleaning_session_identity=AsyncMock(
+                    return_value=b"native-task"
+                ),
                 async_send_user_command=AsyncMock(),
             ),
             slam_map=SimpleNamespace(
@@ -859,6 +862,7 @@ async def test_intelligent_exact_preview_stop_and_reset_actions(hass) -> None:
     client = SimpleNamespace(
         async_has_active_cleaning_session=AsyncMock(return_value=False),
         async_get_cleaning_session_records=AsyncMock(return_value=()),
+        async_get_cleaning_session_identity=AsyncMock(return_value=b"native-task"),
         async_send_user_command=AsyncMock(),
     )
     entry = SimpleNamespace(

--- a/tests/test_session_ownership.py
+++ b/tests/test_session_ownership.py
@@ -829,3 +829,32 @@ async def test_return_does_not_accept_an_ended_read_from_before_new_cleaning(has
     with pytest.raises(RoomTakenOverError):
         await asyncio.wait_for(task, 1)
     assert reads == 2
+
+
+@pytest.mark.parametrize("transient", [None, MaticError("temporary read failure")])
+@pytest.mark.parametrize("baseline", [b"", ORIGINAL])
+async def test_dispatch_retries_a_transient_unknown_baseline(hass, transient, baseline):
+    from custom_components.matic_robot.services import _async_dispatch_leg_command
+
+    command = AsyncMock()
+    hass.services.async_register("vacuum", "send_command", command)
+    reader = AsyncMock(side_effect=[transient, baseline, REPLACEMENT])
+    identity_observed = []
+    call = ServiceCall(
+        hass, "matic_robot", "intelligent_clean", {"plan_id": "test-plan"}
+    )
+    prepared = await _async_dispatch_leg_command(
+        hass,
+        call,
+        "vacuum.matic",
+        [ROOM],
+        7,
+        None,
+        session_identity=reader,
+        on_identity=identity_observed.append,
+    )
+    command.assert_awaited_once()
+    assert prepared.native_identity_baseline == baseline
+    assert prepared.native_identity == REPLACEMENT
+    assert identity_observed == [REPLACEMENT]
+    assert reader.await_count == 3

--- a/tests/test_session_ownership.py
+++ b/tests/test_session_ownership.py
@@ -1,0 +1,299 @@
+"""A suspended native mission cannot adopt an independent OEM cleaning task."""
+
+import asyncio
+from dataclasses import replace
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from homeassistant.core import ServiceCall
+from homeassistant.exceptions import ServiceValidationError
+
+from custom_components.matic_robot.client.exceptions import MaticError
+from custom_components.matic_robot.plans import CleaningPlanManager, CleaningRoom
+from custom_components.matic_robot.services import (
+    PlanCancelledError,
+    RoomTakenOverError,
+    _async_execute_rooms,
+    _async_wait_for_owned_resume,
+)
+
+ROOM = CleaningRoom("room-kitchen", "Kitchen", "vacuum", "standard")
+ORIGINAL = b"synthetic-original-session"
+REPLACEMENT = b"synthetic-oem-session"
+
+
+@pytest.fixture(autouse=True)
+def fast_identity_polls(monkeypatch):
+    monkeypatch.setattr(
+        "custom_components.matic_robot.services.ACTIVE_SESSION_UNKNOWN_RETRY_SECONDS",
+        0.001,
+    )
+
+
+@pytest.mark.parametrize("multi_room", [False, True])
+@pytest.mark.parametrize("replacement", [b"", REPLACEMENT, None, MaticError("offline")])
+@pytest.mark.parametrize("suspension", ["low_charge", "paused"])
+async def test_lost_session_releases_plan_without_stop_credit_or_next_leg(
+    hass, multi_room, replacement, suspension
+):
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    suspended = asyncio.Event()
+    started = asyncio.Event()
+    original_suspend = manager.async_mark_suspended
+    original_resume = manager.async_mark_resumed
+
+    async def suspend(*args):
+        await original_suspend(*args)
+        suspended.set()
+
+    async def resume(*args):
+        await original_resume(*args)
+        started.set()
+
+    manager.async_mark_suspended = suspend
+    manager.async_mark_resumed = AsyncMock(side_effect=resume)
+    identity = ORIGINAL
+
+    async def read_identity():
+        if isinstance(identity, Exception):
+            raise identity
+        return identity
+
+    dispatched = []
+
+    async def send_command(call):
+        dispatched.append(call.data)
+        hass.states.async_set("vacuum.matic", "cleaning", {"current_area": ROOM.name})
+
+    hass.services.async_register("vacuum", "send_command", send_command)
+    rooms = [ROOM]
+    if multi_room:
+        rooms.append(replace(ROOM, room_id="room-office", name="Office"))
+    # A settings boundary would dispatch a second native mission on completion.
+    rooms.append(
+        replace(ROOM, room_id="room-study", name="Study", coverage_setting="quick")
+    )
+    sender = AsyncMock()
+    history = AsyncMock(return_value=())
+    call = ServiceCall(
+        hass,
+        "matic_robot",
+        "intelligent_clean",
+        {
+            "plan_id": "test-plan",
+            "start_timeout": 10,
+            "completion_timeout": 10,
+            "return_to_base": True,
+        },
+    )
+    runner = asyncio.create_task(
+        _async_execute_rooms(
+            hass,
+            call,
+            manager,
+            "vacuum.matic",
+            "serial",
+            rooms,
+            intelligent=False,
+            session_identity=read_identity,
+            session_history=history,
+            managed_user_command=sender,
+        )
+    )
+    await asyncio.wait_for(started.wait(), 1)
+    credit_before = manager.snapshot("serial")["last_completed_by_room"]
+    hass.states.async_set(
+        "vacuum.matic",
+        "returning" if suspension == "low_charge" else "paused",
+        {
+            "current_area": ROOM.name,
+            "low_charge": suspension == "low_charge",
+        },
+    )
+    await asyncio.wait_for(suspended.wait(), 1)
+    identity = replacement
+    # Identical target room must not disguise an independent OEM mission.
+    hass.states.async_set(
+        "vacuum.matic",
+        "cleaning" if replacement else "docked",
+        {
+            "current_area": ROOM.name,
+            "low_charge": False,
+        },
+    )
+    with pytest.raises(ServiceValidationError) as error:
+        await asyncio.wait_for(runner, 1)
+    assert error.value.translation_key == "room_taken_over"
+    assert len(dispatched) == 1
+    sender.assert_not_awaited()
+    history.assert_awaited_once()  # Baseline only; no new mission history credited.
+    manager.async_mark_resumed.assert_awaited_once()
+    snapshot = manager.snapshot("serial")
+    assert snapshot["active_plan"] is None
+    assert snapshot["last_completed_by_room"] == credit_before
+    assert snapshot.get("pending_native_reconciliation") is None
+    assert not manager.lock("serial").locked()
+    assert not manager.stop_pending("serial")
+    assert ORIGINAL.decode() not in str(snapshot)
+    assert REPLACEMENT.decode() not in str(snapshot)
+
+
+async def test_same_session_resumes_only_after_cleaning_in_target_room(hass):
+    hass.states.async_set("vacuum.matic", "docked", {"current_area": ROOM.name})
+    reader = AsyncMock(return_value=ORIGINAL)
+    resumed = asyncio.create_task(
+        _async_wait_for_owned_resume(
+            hass,
+            "vacuum.matic",
+            10,
+            None,
+            ROOM,
+            reader,
+            ORIGINAL,
+        )
+    )
+    await asyncio.sleep(0.005)
+    assert not resumed.done()
+    hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Hallway"})
+    await asyncio.sleep(0.005)
+    assert not resumed.done()
+    hass.states.async_set("vacuum.matic", "cleaning", {"current_area": ROOM.name})
+    await asyncio.wait_for(resumed, 1)
+
+
+async def test_unknown_read_at_resume_must_recover_identity_before_acceptance(hass):
+    hass.states.async_set("vacuum.matic", "cleaning", {"current_area": ROOM.name})
+    reader = AsyncMock(side_effect=[None, MaticError("offline"), ORIGINAL])
+    await _async_wait_for_owned_resume(
+        hass, "vacuum.matic", 10, None, ROOM, reader, ORIGINAL
+    )
+    assert reader.await_count == 3
+
+
+@pytest.mark.parametrize("expected,reader", [(None, AsyncMock()), (ORIGINAL, None)])
+async def test_unknown_original_identity_cannot_resume(hass, expected, reader):
+    with pytest.raises(RoomTakenOverError):
+        await _async_wait_for_owned_resume(
+            hass, "vacuum.matic", 10, None, ROOM, reader, expected
+        )
+
+
+@pytest.mark.parametrize("cancel_first", [False, True])
+async def test_resume_wait_honors_cancellation(hass, cancel_first):
+    hass.states.async_set("vacuum.matic", "docked")
+    cancel = asyncio.Event()
+    if cancel_first:
+        cancel.set()
+    resumed = asyncio.create_task(
+        _async_wait_for_owned_resume(
+            hass,
+            "vacuum.matic",
+            10,
+            cancel,
+            ROOM,
+            AsyncMock(return_value=ORIGINAL),
+            ORIGINAL,
+        )
+    )
+    await asyncio.sleep(0.005)
+    cancel.set()
+    with pytest.raises(PlanCancelledError):
+        await resumed
+
+
+async def test_resume_wait_propagates_robot_error_and_cleans_listener(hass):
+    hass.states.async_set("vacuum.matic", "error")
+    with pytest.raises(ServiceValidationError):
+        await _async_wait_for_owned_resume(
+            hass,
+            "vacuum.matic",
+            10,
+            None,
+            ROOM,
+            AsyncMock(return_value=ORIGINAL),
+            ORIGINAL,
+        )
+
+
+@pytest.mark.parametrize("identity, expected_result", [(ORIGINAL, True), (b"", False)])
+async def test_returning_session_checks_identity_before_accepting_cleaning(
+    hass, identity, expected_result
+):
+    from custom_components.matic_robot.services import (
+        _async_wait_for_active_session_resolution,
+    )
+
+    hass.states.async_set("vacuum.matic", "cleaning", {"current_area": ROOM.name})
+    presence = AsyncMock(return_value=True)
+    assert (
+        await _async_wait_for_active_session_resolution(
+            hass,
+            "vacuum.matic",
+            presence,
+            identity_reader=AsyncMock(return_value=identity),
+            expected_identity=ORIGINAL,
+        )
+        is expected_result
+    )
+    presence.assert_not_awaited()
+
+
+@pytest.mark.parametrize("identity", [REPLACEMENT, None])
+async def test_returning_session_replacement_or_unknown_cannot_resume(hass, identity):
+    from custom_components.matic_robot.services import (
+        _async_wait_for_active_session_resolution,
+    )
+
+    hass.states.async_set("vacuum.matic", "cleaning", {"current_area": ROOM.name})
+    with pytest.raises(RoomTakenOverError):
+        await _async_wait_for_active_session_resolution(
+            hass,
+            "vacuum.matic",
+            None,
+            identity_reader=AsyncMock(return_value=identity),
+            expected_identity=ORIGINAL,
+        )
+
+
+@pytest.mark.parametrize("multi_room", [False, True])
+async def test_started_task_with_unknown_identity_retires_without_stopping(
+    hass, multi_room
+):
+    from custom_components.matic_robot.services import _async_run_leg
+
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    sender = AsyncMock()
+    rooms = [ROOM]
+    if multi_room:
+        rooms.append(replace(ROOM, room_id="room-office", name="Office"))
+
+    async def send_command(call):
+        hass.states.async_set("vacuum.matic", "cleaning", {"current_area": ROOM.name})
+
+    hass.services.async_register("vacuum", "send_command", send_command)
+    call = ServiceCall(
+        hass,
+        "matic_robot",
+        "intelligent_clean",
+        {
+            "plan_id": "test-plan",
+            "start_timeout": 10,
+            "completion_timeout": 10,
+        },
+    )
+    with pytest.raises(ServiceValidationError):
+        await _async_run_leg(
+            hass,
+            call,
+            manager,
+            "vacuum.matic",
+            "serial",
+            rooms,
+            session_identity=AsyncMock(return_value=None),
+            managed_user_command=sender,
+        )
+    sender.assert_not_awaited()
+    assert manager.snapshot("serial")["active_plan"] is None

--- a/tests/test_session_ownership.py
+++ b/tests/test_session_ownership.py
@@ -405,3 +405,90 @@ async def test_unload_cleanup_rechecks_native_owner_before_stop(
     assert manager.snapshot("serial")["active_plan"] is None
     assert manager.snapshot("serial")["last_completed_by_room"] == credit_before
     assert not manager.lock("serial").locked()
+
+
+@pytest.mark.parametrize("multi_room", [False, True])
+@pytest.mark.parametrize(
+    "stale_state,delayed_identity", [("docked", False), ("cleaning", True)]
+)
+@pytest.mark.parametrize("final_identity", [ORIGINAL, REPLACEMENT, None, b""])
+async def test_start_timeout_stops_only_the_task_bound_before_ha_confirmation(
+    hass, multi_room, stale_state, delayed_identity, final_identity
+):
+    from custom_components.matic_robot.client.commands import UserCommand
+
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    sender, history = AsyncMock(), AsyncMock(return_value=())
+    dispatched = []
+    bound = asyncio.Event()
+    identity = ORIGINAL
+    reads = 0
+
+    async def read_identity():
+        nonlocal reads
+        reads += 1
+        if delayed_identity and reads <= 2:
+            return b"" if reads == 1 else None
+        bound.set()
+        return identity
+
+    async def dispatch(call):
+        dispatched.append(call.data)
+        # The native task accepted the command, but HA still has the old
+        # activity or an unrelated room. Neither confirms the new start.
+        hass.states.async_set("vacuum.matic", stale_state, {"current_area": "Hallway"})
+
+    hass.services.async_register("vacuum", "send_command", dispatch)
+    rooms = [ROOM]
+    if multi_room:
+        rooms.append(replace(ROOM, room_id="room-office", name="Office"))
+    rooms.append(
+        replace(ROOM, room_id="room-study", name="Study", coverage_setting="quick")
+    )
+    call = ServiceCall(
+        hass,
+        "matic_robot",
+        "intelligent_clean",
+        {
+            "plan_id": "test-plan",
+            "start_timeout": 0.03,
+            "completion_timeout": 10,
+            "return_to_base": True,
+        },
+    )
+    runner = asyncio.create_task(
+        _async_execute_rooms(
+            hass,
+            call,
+            manager,
+            "vacuum.matic",
+            "serial",
+            rooms,
+            intelligent=False,
+            session_identity=read_identity,
+            session_history=history,
+            managed_user_command=sender,
+        )
+    )
+    await asyncio.wait_for(bound.wait(), 1)
+    identity = final_identity
+    with pytest.raises(ServiceValidationError) as error:
+        await asyncio.wait_for(runner, 1)
+    assert error.value.translation_key == (
+        "room_taken_over"
+        if final_identity in (REPLACEMENT, b"")
+        else "plan_start_timeout"
+    )
+    if final_identity == ORIGINAL:
+        sender.assert_awaited_once()
+        assert sender.await_args.args[1] is UserCommand.STOP
+    else:
+        sender.assert_not_awaited()
+    assert len(dispatched) == 1
+    history.assert_awaited_once()
+    snapshot = manager.snapshot("serial")
+    assert snapshot["active_plan"] is None
+    assert not snapshot["last_completed_by_room"]
+    assert snapshot["native_reconciliation_pending"] is False
+    assert not manager.lock("serial").locked()

--- a/tests/test_session_ownership.py
+++ b/tests/test_session_ownership.py
@@ -32,8 +32,17 @@ def fast_identity_polls(monkeypatch):
 
 
 @pytest.mark.parametrize("multi_room", [False, True])
-@pytest.mark.parametrize("replacement", [b"", REPLACEMENT, None, MaticError("offline")])
-@pytest.mark.parametrize("suspension", ["low_charge", "paused"])
+@pytest.mark.parametrize(
+    "suspension,replacement",
+    [
+        (suspension, replacement)
+        for suspension in ("low_charge", "paused", "returning")
+        for replacement in (b"", REPLACEMENT, None, MaticError("offline"))
+        # A cleared session during an ordinary return permits history
+        # verification; its absence alone does not imply replacement.
+        if not (suspension == "returning" and replacement == b"")
+    ],
+)
 async def test_lost_session_releases_plan_without_stop_credit_or_next_leg(
     hass, multi_room, replacement, suspension
 ):
@@ -55,8 +64,12 @@ async def test_lost_session_releases_plan_without_stop_credit_or_next_leg(
     manager.async_mark_suspended = suspend
     manager.async_mark_resumed = AsyncMock(side_effect=resume)
     identity = ORIGINAL
+    returning = asyncio.Event()
 
     async def read_identity():
+        current = hass.states.get("vacuum.matic")
+        if current is not None and current.state == "returning":
+            returning.set()
         if isinstance(identity, Exception):
             raise identity
         return identity
@@ -77,6 +90,7 @@ async def test_lost_session_releases_plan_without_stop_credit_or_next_leg(
     )
     sender = AsyncMock()
     history = AsyncMock(return_value=())
+    presence = AsyncMock(return_value=None)
     call = ServiceCall(
         hass,
         "matic_robot",
@@ -98,6 +112,7 @@ async def test_lost_session_releases_plan_without_stop_credit_or_next_leg(
             rooms,
             intelligent=False,
             session_identity=read_identity,
+            active_session=presence,
             session_history=history,
             managed_user_command=sender,
         )
@@ -106,13 +121,15 @@ async def test_lost_session_releases_plan_without_stop_credit_or_next_leg(
     credit_before = manager.snapshot("serial")["last_completed_by_room"]
     hass.states.async_set(
         "vacuum.matic",
-        "returning" if suspension == "low_charge" else "paused",
+        "paused" if suspension == "paused" else "returning",
         {
             "current_area": ROOM.name,
             "low_charge": suspension == "low_charge",
         },
     )
-    await asyncio.wait_for(suspended.wait(), 1)
+    await asyncio.wait_for(
+        (returning if suspension == "returning" else suspended).wait(), 1
+    )
     identity = replacement
     # Identical target room must not disguise an independent OEM mission.
     hass.states.async_set(
@@ -128,6 +145,7 @@ async def test_lost_session_releases_plan_without_stop_credit_or_next_leg(
     assert error.value.translation_key == "room_taken_over"
     assert len(dispatched) == 1
     sender.assert_not_awaited()
+    presence.assert_not_awaited()
     history.assert_awaited_once()  # Baseline only; no new mission history credited.
     manager.async_mark_resumed.assert_awaited_once()
     snapshot = manager.snapshot("serial")

--- a/tests/test_session_ownership.py
+++ b/tests/test_session_ownership.py
@@ -36,11 +36,11 @@ def fast_identity_polls(monkeypatch):
     "suspension,replacement",
     [
         (suspension, replacement)
-        for suspension in ("low_charge", "paused", "returning")
+        for suspension in ("low_charge", "paused", "returning", "cleaning")
         for replacement in (b"", REPLACEMENT, None, MaticError("offline"))
         # A cleared session during an ordinary return permits history
         # verification; its absence alone does not imply replacement.
-        if not (suspension == "returning" and replacement == b"")
+        if not (suspension in ("returning", "cleaning") and replacement == b"")
     ],
 )
 async def test_lost_session_releases_plan_without_stop_credit_or_next_leg(
@@ -67,6 +67,8 @@ async def test_lost_session_releases_plan_without_stop_credit_or_next_leg(
     returning = asyncio.Event()
 
     async def read_identity():
+        if not dispatched:
+            return b""
         current = hass.states.get("vacuum.matic")
         if current is not None and current.state == "returning":
             returning.set()
@@ -121,15 +123,18 @@ async def test_lost_session_releases_plan_without_stop_credit_or_next_leg(
     credit_before = manager.snapshot("serial")["last_completed_by_room"]
     hass.states.async_set(
         "vacuum.matic",
-        "paused" if suspension == "paused" else "returning",
+        "paused"
+        if suspension == "paused"
+        else ("cleaning" if suspension == "cleaning" else "returning"),
         {
             "current_area": ROOM.name,
             "low_charge": suspension == "low_charge",
         },
     )
-    await asyncio.wait_for(
-        (returning if suspension == "returning" else suspended).wait(), 1
-    )
+    if suspension != "cleaning":
+        await asyncio.wait_for(
+            (returning if suspension == "returning" else suspended).wait(), 1
+        )
     identity = replacement
     # Identical target room must not disguise an independent OEM mission.
     hass.states.async_set(
@@ -310,7 +315,9 @@ async def test_started_task_with_unknown_identity_retires_without_stopping(
             "vacuum.matic",
             "serial",
             rooms,
-            session_identity=AsyncMock(return_value=None),
+            session_identity=AsyncMock(
+                side_effect=lambda: None if hass.states.get("vacuum.matic") else b""
+            ),
             managed_user_command=sender,
         )
     sender.assert_not_awaited()
@@ -344,6 +351,7 @@ async def test_unload_cleanup_rechecks_native_owner_before_stop(
     reader = AsyncMock(return_value=ORIGINAL)
     sender = AsyncMock()
     dispatched = []
+    reader.side_effect = lambda: reader.return_value if dispatched else b""
 
     async def dispatch(call):
         dispatched.append(call.data)
@@ -427,6 +435,8 @@ async def test_start_timeout_stops_only_the_task_bound_before_ha_confirmation(
 
     async def read_identity():
         nonlocal reads
+        if not dispatched:
+            return b""
         reads += 1
         if delayed_identity and reads <= 2:
             return b"" if reads == 1 else None
@@ -492,3 +502,229 @@ async def test_start_timeout_stops_only_the_task_bound_before_ha_confirmation(
     assert not snapshot["last_completed_by_room"]
     assert snapshot["native_reconciliation_pending"] is False
     assert not manager.lock("serial").locked()
+
+
+@pytest.mark.parametrize("multi_room", [False, True])
+@pytest.mark.parametrize(
+    "dispatch_result", ["rejected", "unchanged", "new_task", "cancelled"]
+)
+async def test_existing_oem_task_is_not_adopted_by_a_managed_start(
+    hass, multi_room, dispatch_result
+):
+    from custom_components.matic_robot.client.commands import UserCommand
+
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    identity = ORIGINAL
+    started, command_returned = asyncio.Event(), asyncio.Event()
+    original_resume = manager.async_mark_resumed
+
+    async def resume(*args):
+        await original_resume(*args)
+        started.set()
+
+    manager.async_mark_resumed = resume
+    hass.states.async_set("vacuum.matic", "cleaning", {"current_area": ROOM.name})
+    sender, history = AsyncMock(), AsyncMock(return_value=())
+    commands = []
+
+    async def dispatch(call):
+        commands.append(call.data)
+        command_returned.set()
+        if dispatch_result == "rejected":
+            raise MaticError("command rejected")
+
+    hass.services.async_register("vacuum", "send_command", dispatch)
+    rooms = [ROOM]
+    if multi_room:
+        rooms.append(replace(ROOM, room_id="room-office", name="Office"))
+    call = ServiceCall(
+        hass,
+        "matic_robot",
+        "intelligent_clean",
+        {
+            "plan_id": "test-plan",
+            "start_timeout": 0.03,
+            "completion_timeout": 10,
+            "return_to_base": True,
+        },
+    )
+    runner = asyncio.create_task(
+        _async_execute_rooms(
+            hass,
+            call,
+            manager,
+            "vacuum.matic",
+            "serial",
+            rooms,
+            intelligent=False,
+            session_identity=AsyncMock(side_effect=lambda: identity),
+            session_history=history,
+            managed_user_command=sender,
+        )
+    )
+    await asyncio.wait_for(command_returned.wait(), 1)
+    if dispatch_result == "new_task":
+        # The unchanged old HA state must not count as the new mission.
+        await asyncio.sleep(0.005)
+        assert not started.is_set()
+        identity = REPLACEMENT
+        await asyncio.wait_for(started.wait(), 1)
+        await manager.async_cancel_and_wait("serial")
+        await runner
+        sender.assert_awaited_once()
+        assert sender.await_args.args[1] is UserCommand.STOP
+    elif dispatch_result == "cancelled":
+        await asyncio.sleep(0.005)
+        await manager.async_cancel_and_wait("serial")
+        await runner
+        assert not started.is_set()
+        sender.assert_not_awaited()
+    else:
+        with pytest.raises(ServiceValidationError) as error:
+            await runner
+        assert error.value.translation_key == (
+            "robot_command_failed"
+            if dispatch_result == "rejected"
+            else "plan_start_timeout"
+        )
+        assert not started.is_set()
+        sender.assert_not_awaited()
+    assert len(commands) == 1
+    history.assert_awaited_once()
+    assert all(
+        value["runs"] == 0 and value["at"] is None
+        for value in manager.snapshot("serial")["last_completed_by_room"].values()
+    )
+    assert manager.snapshot("serial")["active_plan"] is None
+    assert not manager.lock("serial").locked()
+
+
+@pytest.mark.parametrize("multi_room", [False, True])
+async def test_unknown_pre_dispatch_identity_sends_no_cleaning_command(
+    hass, multi_room
+):
+    from custom_components.matic_robot.services import _async_run_leg
+
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    command, sender = AsyncMock(), AsyncMock()
+    hass.services.async_register("vacuum", "send_command", command)
+    rooms = [ROOM]
+    if multi_room:
+        rooms.append(replace(ROOM, room_id="room-office", name="Office"))
+    call = ServiceCall(
+        hass,
+        "matic_robot",
+        "intelligent_clean",
+        {
+            "plan_id": "test-plan",
+            "start_timeout": 10,
+            "completion_timeout": 10,
+        },
+    )
+    with pytest.raises(ServiceValidationError) as error:
+        await _async_run_leg(
+            hass,
+            call,
+            manager,
+            "vacuum.matic",
+            "serial",
+            rooms,
+            session_identity=AsyncMock(return_value=None),
+            managed_user_command=sender,
+        )
+    assert error.value.translation_key == "room_taken_over"
+    command.assert_not_awaited()
+    sender.assert_not_awaited()
+
+
+@pytest.mark.parametrize("multi_room", [False, True])
+async def test_unexpected_outer_abort_cannot_stop_a_replacement(
+    hass, monkeypatch, multi_room
+):
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    identity = b""
+    commands = []
+    sender = AsyncMock()
+
+    async def dispatch(call):
+        nonlocal identity
+        commands.append(call.data)
+        identity = ORIGINAL
+        hass.states.async_set("vacuum.matic", "cleaning", {"current_area": ROOM.name})
+
+    async def fail_after_replacement(*args, **kwargs):
+        nonlocal identity
+        identity = REPLACEMENT
+        raise RuntimeError("unexpected observer failure")
+
+    hass.services.async_register("vacuum", "send_command", dispatch)
+    for waiter in ("_async_wait_for_room_outcome", "_async_wait_for_leg_outcome"):
+        monkeypatch.setattr(
+            "custom_components.matic_robot.services." + waiter, fail_after_replacement
+        )
+    rooms = [ROOM]
+    if multi_room:
+        rooms.append(replace(ROOM, room_id="room-office", name="Office"))
+    call = ServiceCall(
+        hass,
+        "matic_robot",
+        "intelligent_clean",
+        {
+            "plan_id": "test-plan",
+            "start_timeout": 10,
+            "completion_timeout": 10,
+            "return_to_base": True,
+        },
+    )
+    with pytest.raises(RuntimeError, match="unexpected observer failure"):
+        await _async_execute_rooms(
+            hass,
+            call,
+            manager,
+            "vacuum.matic",
+            "serial",
+            rooms,
+            intelligent=False,
+            session_identity=AsyncMock(side_effect=lambda: identity),
+            managed_user_command=sender,
+        )
+    sender.assert_not_awaited()
+    assert len(commands) == 1
+    assert manager.snapshot("serial")["active_plan"] is None
+    assert manager.snapshot("serial")["native_reconciliation_pending"] is False
+    assert not manager.lock("serial").locked()
+
+
+@pytest.mark.parametrize(
+    "identity,allowed",
+    [(b"", True), (ORIGINAL, True), (REPLACEMENT, False), (None, False)],
+)
+async def test_final_dock_cannot_interrupt_an_independent_native_task(
+    hass, identity, allowed
+):
+    from custom_components.matic_robot.client.commands import UserCommand
+    from custom_components.matic_robot.plans import ManagedMotionReplacedError
+    from custom_components.matic_robot.services import _guard_native_commands
+
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    token = manager.begin_managed_motion("serial")
+    sender = AsyncMock()
+    guarded = _guard_native_commands(
+        sender,
+        manager,
+        "serial",
+        AsyncMock(return_value=identity),
+        lambda: ORIGINAL,
+        allow_ended_dock=True,
+    )
+    if allowed:
+        await guarded(token, UserCommand.DOCK)
+        sender.assert_awaited_once_with(token, UserCommand.DOCK)
+    else:
+        with pytest.raises(ManagedMotionReplacedError):
+            await guarded(token, UserCommand.DOCK)
+        sender.assert_not_awaited()

--- a/tests/test_session_ownership.py
+++ b/tests/test_session_ownership.py
@@ -728,3 +728,104 @@ async def test_final_dock_cannot_interrupt_an_independent_native_task(
         with pytest.raises(ManagedMotionReplacedError):
             await guarded(token, UserCommand.DOCK)
         sender.assert_not_awaited()
+
+
+@pytest.mark.parametrize("phase", ["start", "resume", "return", "outcome"])
+@pytest.mark.parametrize("after_transition", [REPLACEMENT, None, ORIGINAL])
+async def test_state_transition_requires_a_new_identity_read(
+    hass, phase, after_transition
+):
+    from custom_components.matic_robot.services import (
+        _async_wait_for_active_session_resolution,
+        _async_wait_for_owned_start,
+        _async_wait_with_native_identity,
+    )
+
+    read_started, release_read, transition = (
+        asyncio.Event(),
+        asyncio.Event(),
+        asyncio.Event(),
+    )
+    reads = 0
+
+    async def reader():
+        nonlocal reads
+        reads += 1
+        if reads == 1:
+            # This request captured the old identity before the state changed,
+            # but its response arrives after the new cleaning state.
+            read_started.set()
+            await release_read.wait()
+            return ORIGINAL
+        return after_transition
+
+    async def outcome():
+        await transition.wait()
+        return "transition"
+
+    hass.states.async_set("vacuum.matic", "docked", {"current_area": ROOM.name})
+    if phase == "start":
+        waiter = _async_wait_for_owned_start(
+            hass, "vacuum.matic", 10, None, ROOM, reader, lambda _: None, b"", ORIGINAL
+        )
+    elif phase == "resume":
+        waiter = _async_wait_for_owned_resume(
+            hass, "vacuum.matic", 10, None, ROOM, reader, ORIGINAL
+        )
+    elif phase == "return":
+        waiter = _async_wait_for_active_session_resolution(
+            hass,
+            "vacuum.matic",
+            None,
+            identity_reader=reader,
+            expected_identity=ORIGINAL,
+        )
+    else:
+        waiter = _async_wait_with_native_identity(outcome, reader, ORIGINAL)
+    task = asyncio.create_task(waiter)
+    await asyncio.wait_for(read_started.wait(), 1)
+    hass.states.async_set("vacuum.matic", "cleaning", {"current_area": ROOM.name})
+    transition.set()
+    await hass.async_block_till_done()
+    release_read.set()
+    if after_transition == ORIGINAL:
+        await asyncio.wait_for(task, 1)
+    else:
+        with pytest.raises(RoomTakenOverError):
+            await asyncio.wait_for(task, 1)
+    assert reads >= 2
+
+
+async def test_return_does_not_accept_an_ended_read_from_before_new_cleaning(hass):
+    from custom_components.matic_robot.services import (
+        _async_wait_for_active_session_resolution,
+    )
+
+    read_started, release_read = asyncio.Event(), asyncio.Event()
+    reads = 0
+
+    async def reader():
+        nonlocal reads
+        reads += 1
+        if reads == 1:
+            read_started.set()
+            await release_read.wait()
+            return b""
+        return REPLACEMENT
+
+    hass.states.async_set("vacuum.matic", "returning")
+    task = asyncio.create_task(
+        _async_wait_for_active_session_resolution(
+            hass,
+            "vacuum.matic",
+            None,
+            identity_reader=reader,
+            expected_identity=ORIGINAL,
+        )
+    )
+    await asyncio.wait_for(read_started.wait(), 1)
+    hass.states.async_set("vacuum.matic", "cleaning", {"current_area": ROOM.name})
+    release_read.set()
+    with pytest.raises(RoomTakenOverError):
+        await asyncio.wait_for(task, 1)
+    assert reads == 2

--- a/tests/test_session_ownership.py
+++ b/tests/test_session_ownership.py
@@ -151,7 +151,7 @@ async def test_lost_session_releases_plan_without_stop_credit_or_next_leg(
     snapshot = manager.snapshot("serial")
     assert snapshot["active_plan"] is None
     assert snapshot["last_completed_by_room"] == credit_before
-    assert snapshot.get("pending_native_reconciliation") is None
+    assert snapshot["native_reconciliation_pending"] is False
     assert not manager.lock("serial").locked()
     assert not manager.stop_pending("serial")
     assert ORIGINAL.decode() not in str(snapshot)
@@ -315,3 +315,93 @@ async def test_started_task_with_unknown_identity_retires_without_stopping(
         )
     sender.assert_not_awaited()
     assert manager.snapshot("serial")["active_plan"] is None
+
+
+@pytest.mark.parametrize("multi_room", [False, True])
+@pytest.mark.parametrize("identity", [ORIGINAL, REPLACEMENT, None])
+@pytest.mark.parametrize("suspension", ["paused", "low_charge"])
+async def test_unload_cleanup_rechecks_native_owner_before_stop(
+    hass, multi_room, identity, suspension
+):
+    from custom_components.matic_robot.client.commands import UserCommand
+
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    started, suspended = asyncio.Event(), asyncio.Event()
+    original_resume = manager.async_mark_resumed
+    original_suspend = manager.async_mark_suspended
+
+    async def resume(*args):
+        await original_resume(*args)
+        started.set()
+
+    async def suspend(*args):
+        await original_suspend(*args)
+        suspended.set()
+
+    manager.async_mark_resumed = resume
+    manager.async_mark_suspended = suspend
+    reader = AsyncMock(return_value=ORIGINAL)
+    sender = AsyncMock()
+    dispatched = []
+
+    async def dispatch(call):
+        dispatched.append(call.data)
+        hass.states.async_set("vacuum.matic", "cleaning", {"current_area": ROOM.name})
+
+    hass.services.async_register("vacuum", "send_command", dispatch)
+    rooms = [ROOM]
+    if multi_room:
+        rooms.append(replace(ROOM, room_id="room-office", name="Office"))
+    rooms.append(
+        replace(ROOM, room_id="room-study", name="Study", coverage_setting="quick")
+    )
+    call = ServiceCall(
+        hass,
+        "matic_robot",
+        "intelligent_clean",
+        {
+            "plan_id": "test-plan",
+            "start_timeout": 10,
+            "completion_timeout": 10,
+            "return_to_base": True,
+        },
+    )
+    runner = asyncio.create_task(
+        _async_execute_rooms(
+            hass,
+            call,
+            manager,
+            "vacuum.matic",
+            "serial",
+            rooms,
+            intelligent=False,
+            session_identity=reader,
+            managed_user_command=sender,
+        )
+    )
+    await asyncio.wait_for(started.wait(), 1)
+    credit_before = manager.snapshot("serial")["last_completed_by_room"]
+    hass.states.async_set(
+        "vacuum.matic",
+        "paused" if suspension == "paused" else "returning",
+        {
+            "current_area": ROOM.name,
+            "low_charge": suspension == "low_charge",
+        },
+    )
+    await asyncio.wait_for(suspended.wait(), 1)
+    # Replace the native session and unload before the next polling interval.
+    reader.return_value = identity
+    await asyncio.wait_for(manager.async_cancel_and_wait("serial"), 1)
+    await runner
+    if identity == ORIGINAL:
+        assert sender.await_count == 1
+        assert sender.await_args.args[1] is UserCommand.STOP
+    else:
+        sender.assert_not_awaited()
+        assert manager.snapshot("serial")["native_reconciliation_pending"] is False
+    assert len(dispatched) == 1
+    assert manager.snapshot("serial")["active_plan"] is None
+    assert manager.snapshot("serial")["last_completed_by_room"] == credit_before
+    assert not manager.lock("serial").locked()

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -102,6 +102,20 @@ async def test_active_cleaning_session_reads_only_presence() -> None:
     ]
 
 
+async def test_active_session_identity_distinguishes_tasks_end_and_unknown() -> None:
+    client = MaticHermesClient("192.0.2.1", 16320)
+    first, second = b"\x0a\x05first", b"\x0a\x06second"
+    client.async_get_property = AsyncMock(
+        side_effect=(first, first, second, b"tombstone-value!", b"", b"\x0a\xff")
+    )
+    assert await client.async_get_cleaning_session_identity() == first
+    assert await client.async_get_cleaning_session_identity() == first
+    assert await client.async_get_cleaning_session_identity() == second
+    assert await client.async_get_cleaning_session_identity() == b""
+    assert await client.async_get_cleaning_session_identity() == b""
+    assert await client.async_get_cleaning_session_identity() is None
+
+
 async def test_cleaning_session_records_keep_opaque_keys_in_memory() -> None:
     def timestamp(value: int) -> bytes:
         return _bfield(1, _vfield(1, value))


### PR DESCRIPTION
A cancelled native task could leave a managed plan suspended for charging. Starting another task in the OEM app in a planned room then made Home Assistant treat that independent task as the old plan resuming.

Each managed dispatch now records the prior opaque native session property and binds only a newly observed identity. Identity is retained before HA confirms the start, checked throughout cleaning and suspension with fresh identity reads after state transitions, and rechecked for cleanup, unload, abort and final docking. A replaced or repeatedly unreadable task interrupts tracking without credit or another dispatch; cleanup cannot Stop an independent OEM task. Prefetched legs carry their own baseline and identity. Debug logs record symbolic user-command names without payloads or identifiers; session identities stay in memory.

Validation: 1,459 Python tests pass at 100% coverage. Regressions cover single/multi-room recharge and pause, same-room OEM replacement, existing OEM tasks at dispatch, delayed identity responses across state transitions, delayed/rejected starts, cancellation, unload, unexpected abort and final docking. Ruff, formatting, mypy, public-tree privacy and source/wheel/sdist byte parity pass. Read-only live probes confirmed the existing property is stable during a paused task. Installation and affected physical acceptance remain pending.
