### PR TITLE
Fix native vacuum and mop completion results

### DIFF
--- a/custom_components/matic_robot/client/api.py
+++ b/custom_components/matic_robot/client/api.py
@@ -54,6 +54,7 @@ from .history import (
 )
 from .mission import MissionClientState, decode_mission_client_state
 from .models import (
+    CleaningModeResult,
     CleaningSchedule,
     CleaningSession,
     CleaningSessionRecord,
@@ -101,7 +102,6 @@ MAX_HERMES_MESSAGE_BYTES = 16 * 1024 * 1024
 _COLLECTION_MAX_BYTES = 64 * 1024 * 1024
 _DISPLAYED_MISSION_LIMIT = 256
 _SESSION_COMPLETED_STATUS = 0
-_ROOM_MODE_NON_COMPLETION_STATUS = 1
 _ROOM_MODE_COMPLETED_STATUS = 2
 # Verified from the native KabukiDisplayedError mapping in the Matic client:
 # 205 = BAG_MISSING and 206 = BAG_FULL.  These are error-list values, not
@@ -1874,11 +1874,9 @@ def _decode_cleaning_session(payload: bytes) -> CleaningSession | None:
     ended_at = _decode_nested_timestamp(summary, 4)
     rooms: list[str] = []
     seen_rooms: set[str] = set()
-    room_durations: dict[str, int] = {}
-    room_mode_statuses: dict[str, set[int]] = {}
-    rooms_with_unknown_status: set[str] = set()
-    room_vacuum_statuses: dict[str, set[int]] = {}
-    rooms_without_vacuum_status: set[str] = set()
+    statuses: dict[tuple[int, str], int | None] = {}
+    durations: dict[tuple[int, str], int | None] = {}
+    modes: set[int] = set()
     try:
         fields = _bounded_fields(
             summary,
@@ -1890,6 +1888,7 @@ def _decode_cleaning_session(payload: bytes) -> CleaningSession | None:
     for group in fields:
         if group.number not in (6, 7) or not isinstance(group.value, bytes):
             continue
+        modes.add(group.number)
         try:
             room_fields = _bounded_fields(
                 group.value,
@@ -1918,25 +1917,42 @@ def _decode_cleaning_session(payload: bytes) -> CleaningSession | None:
                     return None
                 seen_rooms.add(name)
                 rooms.append(name)
-            status_fields = [field for field in detail_fields if field.number in (5, 6)]
-            vacuum_fields = [field for field in status_fields if field.number == 5]
+            key = (group.number, name)
+            if key in statuses:
+                # Duplicate map entries cannot supply unambiguous room proof.
+                statuses[key] = None
+                durations[key] = None
+                continue
+            status_fields = [field for field in detail_fields if field.number == 5]
+            status = 0 if not status_fields else None
             if (
-                len(vacuum_fields) == 1
-                and vacuum_fields[0].wire_type == 0
-                and isinstance(vacuum_fields[0].value, int)
+                len(status_fields) == 1
+                and status_fields[0].wire_type == 0
+                and isinstance(status_fields[0].value, int)
+                and status_fields[0].value in (0, 1, 2)
             ):
-                room_vacuum_statuses.setdefault(name, set()).add(vacuum_fields[0].value)
-            else:
-                rooms_without_vacuum_status.add(name)
-            statuses = room_mode_statuses.setdefault(name, set())
-            for field in status_fields:
-                if field.wire_type == 0 and isinstance(field.value, int):
-                    statuses.add(field.value)
-                else:
-                    rooms_with_unknown_status.add(name)
+                status = status_fields[0].value
+            statuses[key] = status
+            durations[key] = None
             try:
                 duration = first_bytes(details, 4)
-                room_durations[name] = first_varint(duration, 1)
+                seconds_fields = [
+                    field
+                    for field in _bounded_fields(
+                        duration,
+                        max_bytes=_TELEMETRY_NESTED_MAX_BYTES,
+                        max_fields=_TELEMETRY_NESTED_MAX_FIELDS,
+                    )
+                    if field.number == 1
+                ]
+                if not seconds_fields:
+                    durations[key] = 0
+                elif (
+                    len(seconds_fields) == 1
+                    and seconds_fields[0].wire_type == 0
+                    and isinstance(seconds_fields[0].value, int)
+                ):
+                    durations[key] = seconds_fields[0].value
             except DecodeError:
                 pass
 
@@ -1959,39 +1975,49 @@ def _decode_cleaning_session(payload: bytes) -> CleaningSession | None:
         and isinstance(status_fields[0].value, int)
     ):
         completion_status = status_fields[0].value
+    # SessionSummary groups 6/7 contain vacuum/mop AreaModeSummary maps.
+    # Within each map value field 5 is status (0/1/2); field 6 is a setting,
+    # not another mode. Omitted status is protobuf's unattempted default.
     room_completion: dict[str, bool | None] = {}
     for name in rooms:
-        statuses = room_mode_statuses.get(name, set())
-        # Mixed mode statuses occur in confirmed interrupted sessions. Until
-        # the requested mode can be verified, one completed mode is not proof
-        # that the whole commanded room finished.
-        if (
-            statuses == {_ROOM_MODE_COMPLETED_STATUS}
-            and name not in rooms_with_unknown_status
-        ):
+        results = [statuses.get((mode, name)) for mode in modes]
+        if all(status == _ROOM_MODE_COMPLETED_STATUS for status in results):
             room_completion[name] = True
-        elif (
-            statuses == {_ROOM_MODE_NON_COMPLETION_STATUS}
-            and name not in rooms_with_unknown_status
-        ):
+        elif any(status in (0, 1) for status in results):
             room_completion[name] = False
         else:
             room_completion[name] = None
     completed_rooms = tuple(name for name in rooms if room_completion.get(name) is True)
-    # Confirmed vacuum-only runs finish with field 5 == 2 even when field 6
-    # is 1; confirmed interrupted vacuum runs have field 5 == 1 and field 6
-    # == 2. Preserve this command-specific proof instead of merging the fields.
-    # Other cleaning modes still require the conservative whole-room result.
     vacuum_completed_rooms = tuple(
         name
         for name in rooms
         if completion_status == _SESSION_COMPLETED_STATUS
-        and room_vacuum_statuses.get(name) == {_ROOM_MODE_COMPLETED_STATUS}
-        and name not in rooms_without_vacuum_status
-        and name not in rooms_with_unknown_status
-        and room_mode_statuses[name]
-        <= {_ROOM_MODE_COMPLETED_STATUS, _ROOM_MODE_NON_COMPLETION_STATUS}
+        and statuses.get((6, name)) == _ROOM_MODE_COMPLETED_STATUS
     )
+    mop_completed_rooms = tuple(
+        name
+        for name in rooms
+        if completion_status == _SESSION_COMPLETED_STATUS
+        and statuses.get((7, name)) == _ROOM_MODE_COMPLETED_STATUS
+    )
+    combined_completed_rooms = tuple(
+        name for name in vacuum_completed_rooms if name in mop_completed_rooms
+    )
+    mode_results = tuple(
+        CleaningModeResult(
+            room=name,
+            cleaning_mode="vacuum" if mode == 6 else "mop",
+            status={0: "unattempted", 1: "partial", 2: "completed", None: None}[status],
+            duration_seconds=durations[(mode, name)],
+        )
+        for (mode, name), status in statuses.items()
+    )
+    room_durations: dict[str, int] = {}
+    for result in mode_results:
+        if result.duration_seconds is not None:
+            room_durations[result.room] = (
+                room_durations.get(result.room, 0) + result.duration_seconds
+            )
     completed: bool | None
     if completion_status not in (None, _SESSION_COMPLETED_STATUS):
         completed = False
@@ -2012,6 +2038,9 @@ def _decode_cleaning_session(payload: bytes) -> CleaningSession | None:
         completed=completed,
         completed_rooms=completed_rooms,
         vacuum_completed_rooms=vacuum_completed_rooms,
+        mop_completed_rooms=mop_completed_rooms,
+        combined_completed_rooms=combined_completed_rooms,
+        mode_results=mode_results,
     )
 
 

--- a/custom_components/matic_robot/client/models.py
+++ b/custom_components/matic_robot/client/models.py
@@ -214,6 +214,16 @@ class CleaningSchedule:
 
 
 @dataclass(frozen=True, slots=True)
+class CleaningModeResult:
+    """One room's native result for one cleaning mode."""
+
+    room: str
+    cleaning_mode: str
+    status: str | None
+    duration_seconds: int | None
+
+
+@dataclass(frozen=True, slots=True)
 class CleaningSession:
     """One native session with visited and verified-completed rooms separated."""
 
@@ -225,6 +235,42 @@ class CleaningSession:
     completed: bool | None
     completed_rooms: tuple[str, ...] = ()
     vacuum_completed_rooms: tuple[str, ...] = ()
+    mop_completed_rooms: tuple[str, ...] = ()
+    combined_completed_rooms: tuple[str, ...] = ()
+    mode_results: tuple[CleaningModeResult, ...] = ()
+
+    def completed_rooms_for_mode(self, mode: str | None) -> tuple[str, ...]:
+        """Require explicit evidence for every mode in a native dispatch."""
+        if self.mode_results:
+            return {
+                "vacuum": self.vacuum_completed_rooms,
+                "mop": self.mop_completed_rooms,
+                "vacuum_and_mop": self.combined_completed_rooms,
+            }.get(mode or "", ())
+        # Locally tracked sessions predate native per-mode evidence.
+        if mode == "vacuum" and self.vacuum_completed_rooms:
+            return self.vacuum_completed_rooms
+        return self.completed_rooms
+
+    def room_durations_for_mode(self, mode: str | None) -> tuple[tuple[str, int], ...]:
+        """Sum only the requested native modes, retaining tracked-session data."""
+        if not self.mode_results:
+            return self.room_durations
+        durations: dict[str, int | None] = {}
+        for result in self.mode_results:
+            if mode not in (result.cleaning_mode, "vacuum_and_mop"):
+                continue
+            previous = durations.get(result.room, 0)
+            duration = result.duration_seconds
+            # A second mode must not conceal a missing or unusable duration.
+            durations[result.room] = (
+                previous + duration
+                if previous is not None and duration is not None and duration > 0
+                else None
+            )
+        return tuple(
+            (name, value) for name, value in durations.items() if value is not None
+        )
 
 
 @dataclass(frozen=True, slots=True)

--- a/custom_components/matic_robot/client/models.py
+++ b/custom_components/matic_robot/client/models.py
@@ -225,7 +225,7 @@ class CleaningModeResult:
 
 @dataclass(frozen=True, slots=True)
 class CleaningSession:
-    """One native session with visited and verified-completed rooms separated."""
+    """One session's room scope, visited rooms, and native mode outcomes."""
 
     started_at: str | None
     ended_at: str | None
@@ -238,6 +238,18 @@ class CleaningSession:
     mop_completed_rooms: tuple[str, ...] = ()
     combined_completed_rooms: tuple[str, ...] = ()
     mode_results: tuple[CleaningModeResult, ...] = ()
+
+    @property
+    def visited_rooms(self) -> tuple[str, ...]:
+        """Keep requested but unattempted native rooms out of activity outputs."""
+        if not self.mode_results:
+            return self.rooms
+        visited = {
+            result.room
+            for result in self.mode_results
+            if result.status in ("partial", "completed")
+        }
+        return tuple(name for name in self.rooms if name in visited)
 
     def completed_rooms_for_mode(self, mode: str | None) -> tuple[str, ...]:
         """Require explicit evidence for every mode in a native dispatch."""

--- a/custom_components/matic_robot/coordinator.py
+++ b/custom_components/matic_robot/coordinator.py
@@ -677,7 +677,7 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
                 "ended_at": session.ended_at,
                 "duration_seconds": session.duration_seconds,
                 "completed": session.completed,
-                "rooms": list(session.rooms),
+                "rooms": list(session.visited_rooms),
                 "completed_rooms": list(session.completed_rooms),
                 "room_durations": dict(session.room_durations),
                 "firmware_version": version,

--- a/custom_components/matic_robot/llm.py
+++ b/custom_components/matic_robot/llm.py
@@ -399,15 +399,7 @@ def _bounded_native_room_evidence(
     remaining_bytes: int,
 ) -> tuple[list[JsonObjectType], int, int, int]:
     """Normalize and bound one session's room evidence across the response."""
-    visited = (
-        {
-            result.room
-            for result in session.mode_results
-            if result.status in ("partial", "completed")
-        }
-        if session.mode_results
-        else set(session.rooms)
-    )
+    visited = set(session.visited_rooms)
     completed = set(session.completed_rooms)
     durations: dict[str, int] = {}
     for room, duration in session.room_durations:

--- a/custom_components/matic_robot/llm.py
+++ b/custom_components/matic_robot/llm.py
@@ -399,7 +399,15 @@ def _bounded_native_room_evidence(
     remaining_bytes: int,
 ) -> tuple[list[JsonObjectType], int, int, int]:
     """Normalize and bound one session's room evidence across the response."""
-    visited = set(session.rooms)
+    visited = (
+        {
+            result.room
+            for result in session.mode_results
+            if result.status in ("partial", "completed")
+        }
+        if session.mode_results
+        else set(session.rooms)
+    )
     completed = set(session.completed_rooms)
     durations: dict[str, int] = {}
     for room, duration in session.room_durations:
@@ -420,6 +428,16 @@ def _bounded_native_room_evidence(
                 "duration_seconds": durations.get(room),
             }
         )
+        modes: JsonObjectType = {
+            result.cleaning_mode: {
+                "status": result.status,
+                "duration_seconds": result.duration_seconds,
+            }
+            for result in session.mode_results
+            if result.room == room
+        }
+        if modes:
+            evidence[-1]["modes"] = modes
         remaining_items -= 1
         remaining_bytes -= room_bytes
     return evidence, remaining_items, remaining_bytes, len(ordered_rooms)

--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -1597,7 +1597,11 @@ def _reconcile_pending_native_history(
         vacuum_proven = pending.get("cleaning_mode") == "vacuum" and target in {
             _native_room_key(name) for name in session.vacuum_completed_rooms
         }
-        if session.completed is not True and not vacuum_proven:
+        if (
+            not session.mode_results
+            and session.completed is not True
+            and not vacuum_proven
+        ):
             continue
         started = dt_util.parse_datetime(session.started_at or "")
         ended = dt_util.parse_datetime(session.ended_at or "")
@@ -1612,13 +1616,18 @@ def _reconcile_pending_native_history(
         native_rooms = tuple(_native_room_key(name) for name in session.rooms)
         if native_rooms != (target,):
             continue
-        completed_rooms = {_native_room_key(name) for name in session.completed_rooms}
-        if target not in completed_rooms and not vacuum_proven:
+        completed_rooms = {
+            _native_room_key(name)
+            for name in session.completed_rooms_for_mode(pending.get("cleaning_mode"))
+        }
+        if target not in completed_rooms:
             continue
         duration = next(
             (
                 value
-                for name, value in session.room_durations
+                for name, value in session.room_durations_for_mode(
+                    pending.get("cleaning_mode")
+                )
                 if _native_room_key(name) == target
                 and isinstance(value, int)
                 and not isinstance(value, bool)

--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -1693,18 +1693,10 @@ def _import_native_room_activity(
 ) -> bool:
     """Record where the robot worked, which is not proof that it finished.
 
-    The robot marks the room it occupied when a session ended exactly the way
-    it marks a room it cleaned to the end, and it reports a stopped session as
-    completed, so its record cannot establish completion by itself.  Observed
-    live on firmware v172.12: a room entered sixty seconds before a stop and a
-    room cleaned for thirty-one minutes were recorded identically, and a clean
-    stopped after forty-five seconds still reported its room as completed.
-
-    Native evidence is therefore imported as a cleaning opportunity.  Rotation
-    fairness stays current for cleaning this integration did not manage - a
-    room the robot has just worked in does not keep monopolising short runs -
-    while "last cleaned" and completion counts continue to come only from runs
-    whose end was actually verified.
+    Native partial or completed modes establish activity, while unattempted or
+    unknown modes do not. External runs have no matching managed dispatch, so
+    this importer updates rotation opportunities without completion credit.
+    Legacy summaries retain their conservative completed-room activity subset.
     """
     room_lookup: dict[str, tuple[str, str] | None] = {}
     for room in floor_plan.rooms:
@@ -1717,7 +1709,10 @@ def _import_native_room_activity(
         timestamp = _latest_timestamp(session.ended_at)
         if timestamp is None or not isinstance(session.ended_at, str):
             continue
-        for worked_name in session.completed_rooms:
+        worked_rooms = (
+            session.visited_rooms if session.mode_results else session.completed_rooms
+        )
+        for worked_name in worked_rooms:
             mapped_room = room_lookup.get(_native_room_key(worked_name))
             if mapped_room is None:
                 continue

--- a/custom_components/matic_robot/sensor.py
+++ b/custom_components/matic_robot/sensor.py
@@ -517,7 +517,7 @@ class MaticStateSensor(MaticEntity, SensorEntity):
                 "latest_started_at": latest.started_at,
                 "latest_ended_at": latest.ended_at,
                 "latest_duration_seconds": latest.duration_seconds,
-                "latest_rooms": list(latest.rooms),
+                "latest_rooms": list(latest.visited_rooms),
                 "latest_completed_rooms": list(latest.completed_rooms),
                 "latest_room_durations": dict(latest.room_durations),
                 "latest_completed": latest.completed,

--- a/custom_components/matic_robot/sensor.py
+++ b/custom_components/matic_robot/sensor.py
@@ -443,6 +443,7 @@ class MaticStateSensor(MaticEntity, SensorEntity):
             "latest_rooms",
             "latest_completed_rooms",
             "latest_room_durations",
+            "latest_mode_results",
         }
     )
 
@@ -512,7 +513,7 @@ class MaticStateSensor(MaticEntity, SensorEntity):
             latest = state.telemetry.latest_session
             if latest is None:
                 return None
-            return {
+            attributes: dict[str, object] = {
                 "latest_started_at": latest.started_at,
                 "latest_ended_at": latest.ended_at,
                 "latest_duration_seconds": latest.duration_seconds,
@@ -521,6 +522,17 @@ class MaticStateSensor(MaticEntity, SensorEntity):
                 "latest_room_durations": dict(latest.room_durations),
                 "latest_completed": latest.completed,
             }
+            if latest.mode_results:
+                attributes["latest_mode_results"] = [
+                    {
+                        "room": result.room,
+                        "cleaning_mode": result.cleaning_mode,
+                        "status": result.status,
+                        "duration_seconds": result.duration_seconds,
+                    }
+                    for result in latest.mode_results
+                ]
+            return attributes
         return None
 
 

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -1934,7 +1934,6 @@ async def _async_verify_leg_completion(
     if reader is None or baseline is None:
         return None
     targets = {room.name.strip().casefold(): room.room_id for room in rooms}
-    modes = {room.name.strip().casefold(): room.cleaning_mode for room in rooms}
     evidence: dict[str, tuple[str, int]] | None = None
     matched_key: bytes | None = None
     try:
@@ -1988,33 +1987,29 @@ async def _async_verify_leg_completion(
                     session = matches[0].session
                     ended_at = session.ended_at
                     assert isinstance(ended_at, str)
-                    durations = {
-                        name.strip().casefold(): duration
-                        for name, duration in session.room_durations
-                    }
-                    completed_names = {
-                        name.strip().casefold() for name in session.completed_rooms
-                    }
-                    vacuum_completed_names = {
-                        name.strip().casefold()
-                        for name in session.vacuum_completed_rooms
-                    }
                     evidence = {}
-                    for name, room_id in targets.items():
+                    for room in rooms:
+                        name = room.name.strip().casefold()
+                        durations = {
+                            name.strip().casefold(): duration
+                            for name, duration in session.room_durations_for_mode(
+                                room.cleaning_mode
+                            )
+                        }
+                        completed_names = {
+                            name.strip().casefold()
+                            for name in session.completed_rooms_for_mode(
+                                room.cleaning_mode
+                            )
+                        }
                         duration = durations.get(name)
                         if (
-                            (
-                                name in completed_names
-                                or (
-                                    modes[name] == CleaningMode.VACUUM
-                                    and name in vacuum_completed_names
-                                )
-                            )
+                            name in completed_names
                             and isinstance(duration, int)
                             and not isinstance(duration, bool)
                             and duration > 0
                         ):
-                            evidence[room_id] = (ended_at, duration)
+                            evidence[room.room_id] = (ended_at, duration)
                     # Native history can publish timestamps before per-room results.
                     # Keep polling the same record until complete or the bounded window
                     # expires; never combine evidence from different physical sessions.
@@ -2248,7 +2243,9 @@ async def _async_verify_room_completion(
                     rooms = [name.strip().casefold() for name in session.rooms]
                     durations = [
                         duration
-                        for name, duration in session.room_durations
+                        for name, duration in session.room_durations_for_mode(
+                            room.cleaning_mode
+                        )
                         if name.strip().casefold() == target and duration > 0
                     ]
                     if rooms == [target] and len(durations) == 1:
@@ -2658,7 +2655,12 @@ async def _async_expire_native_reconciliation(
 
 
 def _session_confirms_room_mode(session: CleaningSession, room: CleaningRoom) -> bool:
-    """Use explicit vacuum evidence only for a known vacuum-only dispatch."""
+    """Require the requested mode's native proof, including partial sessions."""
+    if session.mode_results:
+        return _area_key(room.name) in {
+            _area_key(name)
+            for name in session.completed_rooms_for_mode(room.cleaning_mode)
+        }
     return session.completed is True or (
         room.cleaning_mode == CleaningMode.VACUUM
         and _area_key(room.name)
@@ -2689,7 +2691,7 @@ def _native_completion_match(
         rooms = [_area_key(name) for name in session.rooms]
         durations = [
             duration
-            for name, duration in session.room_durations
+            for name, duration in session.room_durations_for_mode(room.cleaning_mode)
             if _area_key(name) == target and duration > 0
         ]
         if rooms == [target] and len(durations) == 1:

--- a/custom_components/matic_robot/session_tracking.py
+++ b/custom_components/matic_robot/session_tracking.py
@@ -143,7 +143,7 @@ class CleaningSessionTracker:
         if native_session is None:
             return tracked
         if _sessions_overlap(native_session, tracked):
-            if native_session.completed is False:
+            if native_session.mode_results or native_session.completed is False:
                 return native_session
             if tracked.completed is True:
                 return tracked
@@ -156,6 +156,9 @@ class CleaningSessionTracker:
                 completed=native_session.completed,
                 completed_rooms=native_session.completed_rooms,
                 vacuum_completed_rooms=native_session.vacuum_completed_rooms,
+                mop_completed_rooms=native_session.mop_completed_rooms,
+                combined_completed_rooms=native_session.combined_completed_rooms,
+                mode_results=native_session.mode_results,
             )
         native_started = _parse_timestamp(native_session.started_at)
         tracked_started = _parse_timestamp(tracked.started_at)

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -298,13 +298,13 @@ runs, while **last cleaned**, per-room durations, and completion counts still
 come only from runs whose end was verified. A room worked on but not verified
 stays due.
 
-The `matic_robot_cleaning_finished` event and the local-sessions sensor pass
-the robot's own session report through unchanged, including its `completed` and
-`completed_rooms` fields. Those are what the robot said, not proof: it reports
-a room it was stopped in, and a stopped session, exactly the way it reports
-finished ones. Automations that need a room to have actually been cleaned
-should use the `matic_robot_room_completed` event or the room's **last
-cleaned** sensor, both of which come only from verified runs.
+The `matic_robot_cleaning_finished` event and local-sessions sensor expose the
+native session summary. The sensor and MCP history also separate vacuum and
+mop outcomes, including partial and unattempted results. Automations that need
+verified managed completion should use `matic_robot_room_completed` or the
+room's **last cleaned** sensor. A combined clean requires completion evidence
+and positive duration for both modes; visiting a room or ending a mission is
+not enough. See [native cleaning results](native-cleaning-results.md).
 
 A task that ends where the robot stood was stopped, not finished, and is
 recorded as interrupted: the robot reports a room it was stopped in exactly the

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -286,17 +286,12 @@ cancelled, timed-out, or restart-interrupted rooms remain due, but a confirmed
 start moves them behind rooms that waited longer so one problem room cannot
 monopolize short runs. Saved room order breaks ties.
 
-Rotation fairness also follows the robot itself. Firmware cleans without Home
-Assistant in two ordinary cases — it resumes its own task after an error, and
-the vendor app can start one. The robot records which rooms such a run touched,
-but that record cannot prove a room was finished: the robot marks the room it
-occupied when a session ended exactly the way it marks a room cleaned to the
-end, and it reports a stopped session as completed. Each time a session
-finishes, the integration therefore imports that evidence as a cleaning
-*opportunity*: a room the robot has just worked in stops monopolising short
-runs, while **last cleaned**, per-room durations, and completion counts still
-come only from runs whose end was verified. A room worked on but not verified
-stays due.
+Rotation fairness also follows cleaning started outside Home Assistant. Native
+partial or completed mode results establish that the robot worked in a room;
+unattempted and unknown results do not. Those results update the room's latest
+cleaning *opportunity*, so a room recently worked on does not monopolise short
+runs. **Last cleaned**, per-room durations, and completion counts still require
+a verified managed dispatch. Partial work alone leaves the room due.
 
 The `matic_robot_cleaning_finished` event and local-sessions sensor expose the
 native session summary. The sensor and MCP history also separate vacuum and
@@ -306,10 +301,9 @@ room's **last cleaned** sensor. A combined clean requires completion evidence
 and positive duration for both modes; visiting a room or ending a mission is
 not enough. See [native cleaning results](native-cleaning-results.md).
 
-A task that ends where the robot stood was stopped, not finished, and is
-recorded as interrupted: the robot reports a room it was stopped in exactly the
-way it reports a finished one, so the return to the dock is what separates
-them. Late reconciliation is never scheduled for such a run.
+Ending in place does not establish completion. Managed runs without safe
+completion evidence remain interrupted or unverified, and an ambiguous native
+session identity prevents late reconciliation.
 
 Room history advances only after the managed runner positively matches the end
 of the commanded room. Returning, idle, or docked state alone is not completion:

--- a/docs/native-cleaning-results.md
+++ b/docs/native-cleaning-results.md
@@ -6,6 +6,10 @@ separate vacuum and mop results for each room. Each mode reports `completed`,
 An absent mode has no result. Unattempted does not establish a cause: the
 integration does not infer an obstruction or the absence of moppable floor.
 The additional sensor attribute `latest_mode_results` is excluded from recorder.
+The shared visited-room list excludes unattempted and unknown results in the
+sensor, finished event, and MCP response. Partial or completed native work
+updates rotation opportunity; an external run does not earn managed completion
+credit merely from this activity import.
 
 A managed vacuum-only dispatch requires explicit vacuum completion; mop-only
 requires mop completion; vacuum-and-mop requires both. A completed vacuum mode

--- a/docs/native-cleaning-results.md
+++ b/docs/native-cleaning-results.md
@@ -1,0 +1,34 @@
+# Native cleaning results
+
+The local cleaning-sessions sensor and administrator-only MCP history retain
+separate vacuum and mop results for each room. Each mode reports `completed`,
+`partial`, `unattempted`, or an unknown status, plus its recorded duration.
+An absent mode has no result. Unattempted does not establish a cause: the
+integration does not infer an obstruction or the absence of moppable floor.
+The additional sensor attribute `latest_mode_results` is excluded from recorder.
+
+A managed vacuum-only dispatch requires explicit vacuum completion; mop-only
+requires mop completion; vacuum-and-mop requires both. A completed vacuum mode
+cannot satisfy a combined dispatch with partial or absent mop evidence. Each
+requested mode also needs a positive duration. Combined duration adds the two
+mode durations; it never replaces vacuum time with mop time.
+
+The native record must still be new, overlap the managed dispatch, and match
+unambiguous room names. A partially completed multi-room mission credits only
+its verified subset and cannot automatically advance to the next settings leg.
+Missing, duplicate, malformed, and unknown results remain uncredited. Existing
+managed records are not retroactively rewritten by this decoder correction.
+
+## Protocol evidence
+
+The official app's `AreaModeSummary` encoder and conversion model establish
+that SessionSummary groups 6 and 7 contain vacuum and mop maps. Map-value field
+5 is a per-mode status: protobuf default 0 is unattempted, 1 is partial, and 2
+is completed. Field 6 is a cleaning setting, not a second mode status. This
+mapping also matches a physical mixed-outcome session and the app's displayed
+per-mode results. No cleaning commands change.
+
+Synthetic coverage includes separate and combined modes, partial multi-room
+missions, an absent mode, omitted zero status/duration, settings independent of
+status, ambiguous/unknown values, missing duration, and restart reconciliation.
+See `tests/test_native_completion_modes.py`.

--- a/docs/release-notes-0.4.md
+++ b/docs/release-notes-0.4.md
@@ -33,6 +33,9 @@ not published releases.
 - Managed completion waits for positive native per-room evidence before
   crediting history. Native finished events use native history, and room starts
   are deduplicated.
+- Native history separates vacuum and mop outcomes and durations. Combined
+  cleaning credits only rooms with evidence for both modes; partial and
+  unattempted results remain visible in the local sensor and MCP history.
 - Paused and recharging plans verify the original native session before
   resuming. A new task started in the OEM app cannot inherit the old plan,
   even when it cleans the same room. Lost ownership interrupts HA tracking

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1171,3 +1171,38 @@ async def test_finished_event_observed_native_run_ignores_host_clock_skew(hass):
     await hass.async_block_till_done()
     assert len(events) == 1
     assert events[0].data["completed"] is True
+
+
+async def test_native_finished_event_excludes_unattempted_room_scope(hass):
+    from pytest_homeassistant_custom_component.common import async_capture_events
+
+    from custom_components.matic_robot.client.models import CleaningModeResult
+    from custom_components.matic_robot.const import EVENT_CLEANING_FINISHED
+
+    client = _client()
+    events = async_capture_events(hass, EVENT_CLEANING_FINISHED)
+    with patch(
+        "custom_components.matic_robot.coordinator.dt_util.utcnow",
+        return_value=datetime(2026, 7, 20, 1, 45, tzinfo=UTC),
+    ):
+        coordinator = _coordinator(hass, client)
+    session = CleaningSession(
+        "2026-07-20T02:00:00+00:00",
+        "2026-07-20T02:30:00+00:00",
+        1800,
+        ("Study", "Store", "Unknown"),
+        (("Study", 30),),
+        False,
+        mode_results=(
+            CleaningModeResult("Study", "mop", "partial", 30),
+            CleaningModeResult("Store", "mop", "unattempted", 0),
+            CleaningModeResult("Unknown", "mop", None, None),
+        ),
+    )
+    client.async_get_telemetry.return_value = RobotTelemetry(latest_session=session)
+    await coordinator._async_update_data()
+    await hass.async_block_till_done()
+    assert len(events) == 1
+    assert events[0].data["rooms"] == ["Study"]
+    assert events[0].data["completed_rooms"] == []
+    assert events[0].data["completed"] is False

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -2051,3 +2051,36 @@ async def test_room_statistics_sensors_use_verified_managed_runs() -> None:
     assert duration.native_value == 600
     assert last_cleaned.native_value is not None
     assert last_cleaned.native_value.isoformat() == "2026-01-01T08:10:00+00:00"
+
+
+def test_native_session_exposes_unrecorded_per_mode_outcomes():
+    from custom_components.matic_robot.client.models import CleaningModeResult
+
+    entry = _entry()
+    coordinator = entry.runtime_data.coordinator
+    latest = coordinator.data.telemetry.latest_session
+    coordinator.data = replace(
+        coordinator.data,
+        telemetry=replace(
+            coordinator.data.telemetry,
+            latest_session=replace(
+                latest,
+                mode_results=(CleaningModeResult("Study", "mop", "partial", 20),),
+            ),
+        ),
+    )
+    description = next(
+        item
+        for item in sensor.STATE_DESCRIPTIONS
+        if item.key == "local_cleaning_sessions"
+    )
+    attributes = sensor.MaticStateSensor(entry, description).extra_state_attributes
+    assert attributes["latest_mode_results"] == [
+        {
+            "room": "Study",
+            "cleaning_mode": "mop",
+            "status": "partial",
+            "duration_seconds": 20,
+        }
+    ]
+    assert "latest_mode_results" in sensor.MaticStateSensor._unrecorded_attributes

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -2065,7 +2065,12 @@ def test_native_session_exposes_unrecorded_per_mode_outcomes():
             coordinator.data.telemetry,
             latest_session=replace(
                 latest,
-                mode_results=(CleaningModeResult("Study", "mop", "partial", 20),),
+                rooms=("Study", "Store", "Unknown"),
+                mode_results=(
+                    CleaningModeResult("Study", "mop", "partial", 20),
+                    CleaningModeResult("Store", "mop", "unattempted", 0),
+                    CleaningModeResult("Unknown", "mop", None, None),
+                ),
             ),
         ),
     )
@@ -2075,7 +2080,8 @@ def test_native_session_exposes_unrecorded_per_mode_outcomes():
         if item.key == "local_cleaning_sessions"
     )
     attributes = sensor.MaticStateSensor(entry, description).extra_state_attributes
-    assert attributes["latest_mode_results"] == [
+    assert attributes["latest_rooms"] == ["Study"]
+    assert attributes["latest_mode_results"][:1] == [
         {
             "room": "Study",
             "cleaning_mode": "mop",

--- a/tests/test_native_completion_modes.py
+++ b/tests/test_native_completion_modes.py
@@ -17,35 +17,49 @@ from custom_components.matic_robot.services import (
 from tests.wire_builders import _bfield, _vfield
 
 
-def _session_payload(statuses: bytes, global_status: bytes = b"") -> bytes:
+def _session_payload(
+    statuses: bytes | None,
+    global_status: bytes = b"",
+    mop_statuses: bytes | None = None,
+) -> bytes:
     now = int(dt_util.utcnow().timestamp())
-    room = _bfield(3, b"Study") + _bfield(4, _vfield(1, 30)) + statuses
     summary = (
         _bfield(3, _bfield(1, _vfield(1, now - 60)))
         + _bfield(4, _bfield(1, _vfield(1, now - 5)))
-        + _bfield(6, _bfield(1, _bfield(2, room)))
         + global_status
     )
+    for group, status in ((6, statuses), (7, mop_statuses)):
+        if status is not None:
+            room = _bfield(3, b"Study") + _bfield(4, _vfield(1, 30)) + status
+            summary += _bfield(group, _bfield(1, _bfield(2, room)))
     return _bfield(5, summary)
 
 
-@pytest.mark.parametrize("vacuum_status,other_status", [(2, 1), (1, 2)])
+@pytest.mark.parametrize("vacuum_status", [None, 0, 1, 2, 99])
+@pytest.mark.parametrize("mop_status", [None, 0, 1, 2, 99])
 @pytest.mark.parametrize("mode", ["vacuum", "mop", "vacuum_and_mop"])
 async def test_native_mode_proof_matches_only_the_dispatched_mode(
-    vacuum_status, other_status, mode
+    vacuum_status, mop_status, mode
 ):
+    def status(value):
+        return None if value is None else _vfield(5, value) + _vfield(6, 1)
+
     session = _decode_cleaning_session(
-        _session_payload(_vfield(5, vacuum_status) + _vfield(6, other_status))
+        _session_payload(status(vacuum_status), mop_statuses=status(mop_status))
     )
     assert session is not None
-    assert session.completed is None
-    assert session.completed_rooms == ()
     assert session.vacuum_completed_rooms == (("Study",) if vacuum_status == 2 else ())
+    assert session.mop_completed_rooms == (("Study",) if mop_status == 2 else ())
     record = CleaningSessionRecord(b"synthetic-new", session)
     reader = AsyncMock(return_value=(record,))
     room = CleaningRoom("study", "Study", mode, "standard")
     dispatched = dt_util.utcnow() - timedelta(seconds=90)
-    expected = vacuum_status == 2 and mode == "vacuum"
+    expected = {
+        "vacuum": vacuum_status == 2,
+        "mop": mop_status == 2,
+        "vacuum_and_mop": vacuum_status == mop_status == 2,
+    }[mode]
+    duration = 60 if mode == "vacuum_and_mop" else 30
     assert (
         await _async_verify_room_completion(
             reader, frozenset(), room, dispatched, attempts=1
@@ -55,10 +69,15 @@ async def test_native_mode_proof_matches_only_the_dispatched_mode(
     leg = await _async_verify_leg_completion(
         reader, frozenset(), [room], dispatched, attempts=1
     )
-    assert leg == ({"study": (session.ended_at, 30)} if expected else {})
+    assert leg == (
+        {"study": (session.ended_at, duration)}
+        if expected
+        else None
+        if vacuum_status is mop_status is None
+        else {}
+    )
     native = _native_completion_match((record,), frozenset(), room, dispatched)
-    assert native == ((record, 30) if expected else None)
-    # The same completed history key must never credit a later dispatch.
+    assert native == ((record, duration) if expected else None)
     assert (
         _native_completion_match((record,), frozenset({record.key}), room, dispatched)
         is None
@@ -69,21 +88,40 @@ async def test_native_mode_proof_matches_only_the_dispatched_mode(
     "statuses,global_status",
     [
         (_vfield(6, 2), b""),
-        (_vfield(5, 3) + _vfield(6, 2), b""),
-        (_vfield(5, 2) + _vfield(6, 3), b""),
-        (_vfield(5, 2) + _bfield(6, b"malformed"), b""),
-        (_bfield(5, b"malformed") + _vfield(6, 2), b""),
-        (_vfield(5, 2) + _vfield(5, 2) + _vfield(6, 1), b""),
-        (_vfield(5, 2) + _vfield(6, 1), _vfield(5, 2)),
-        (_vfield(5, 2) + _vfield(6, 1), _bfield(5, b"malformed")),
+        (_vfield(5, 3), b""),
+        (_bfield(5, b"malformed"), b""),
+        (_vfield(5, 2) + _vfield(5, 2), b""),
+        (_vfield(5, 2), _vfield(5, 2)),
+        (_vfield(5, 2), _bfield(5, b"malformed")),
     ],
 )
-def test_vacuum_proof_rejects_unknown_ambiguous_and_failed_results(
-    statuses, global_status
+@pytest.mark.parametrize("group", [6, 7])
+def test_mode_proof_rejects_unknown_ambiguous_and_failed_results(
+    statuses, global_status, group
 ):
-    session = _decode_cleaning_session(_session_payload(statuses, global_status))
+    session = _decode_cleaning_session(
+        _session_payload(
+            statuses if group == 6 else None,
+            global_status,
+            mop_statuses=statuses if group == 7 else None,
+        )
+    )
     assert session is not None
     assert session.vacuum_completed_rooms == ()
+    assert session.mop_completed_rooms == ()
+    assert session.combined_completed_rooms == ()
+
+
+@pytest.mark.parametrize(
+    "setting",
+    [b"", _vfield(6, 1), _vfield(6, 2), _vfield(6, 99), _bfield(6, b"unknown")],
+)
+def test_coverage_setting_is_not_cleaning_status(setting):
+    session = _decode_cleaning_session(_session_payload(_vfield(5, 2) + setting))
+    assert session.completed is True
+    assert session.mode_results[0].status == "completed"
+    assert session.vacuum_completed_rooms == ("Study",)
+    assert session.combined_completed_rooms == ()
 
 
 @pytest.mark.parametrize(
@@ -151,3 +189,135 @@ async def test_restart_reconciliation_retains_only_known_vacuum_dispatch(hass, m
     assert restarted.snapshot("synthetic-serial")["plan_history"]["synthetic-plan"][
         "rooms"
     ]["study"].get("completed_runs", 0) == (1 if mode == "vacuum" else 0)
+
+
+async def test_seven_room_partial_session_credits_only_completed_requested_modes():
+    from custom_components.matic_robot.client.wire import first_bytes
+    from custom_components.matic_robot.llm import _bounded_native_room_evidence
+
+    # Synthetic names, intervals and durations; omitted status is native zero.
+    rows = [
+        ("Study", 2, 1, 120, 20),
+        ("Gallery", 2, 2, 100, 70),
+        ("Store", 0, None, 0, None),
+        ("Atrium", 2, 2, 160, 80),
+        ("Den", 2, 2, 110, 50),
+        ("Pantry", 2, 0, 60, 0),
+        ("Utility", 0, 0, 0, 0),
+    ]
+    summary = first_bytes(_session_payload(None), 5)
+    for group, status_index, duration_index in ((6, 1, 3), (7, 2, 4)):
+        for row in rows:
+            if row[status_index] is None:
+                continue
+            status = _vfield(5, row[status_index]) if row[status_index] else b""
+            duration = _vfield(1, row[duration_index]) if row[duration_index] else b""
+            detail = (
+                _bfield(3, row[0].encode())
+                + _bfield(4, duration)
+                + status
+                + _vfield(6, 1)
+            )
+            summary += _bfield(group, _bfield(1, _bfield(2, detail)))
+    session = _decode_cleaning_session(_bfield(5, summary))
+    assert session.completed is False
+    assert session.completed_rooms == ("Gallery", "Atrium", "Den")
+    assert session.vacuum_completed_rooms == (
+        "Study",
+        "Gallery",
+        "Atrium",
+        "Den",
+        "Pantry",
+    )
+    assert session.mop_completed_rooms == ("Gallery", "Atrium", "Den")
+    reader = AsyncMock(return_value=(CleaningSessionRecord(b"synthetic-leg", session),))
+    rooms = [
+        CleaningRoom(row[0].lower(), row[0], "vacuum_and_mop", "standard")
+        for row in rows
+    ]
+    evidence = await _async_verify_leg_completion(
+        reader, frozenset(), rooms, dt_util.utcnow() - timedelta(seconds=90), attempts=1
+    )
+    assert evidence == {
+        "gallery": (session.ended_at, 170),
+        "atrium": (session.ended_at, 240),
+        "den": (session.ended_at, 160),
+    }
+    readout, _, _, count = _bounded_native_room_evidence(session, 20, 5000)
+    assert count == 7
+    reported = {item["room"]: item for item in readout}
+    assert reported["Study"]["modes"] == {
+        "vacuum": {"status": "completed", "duration_seconds": 120},
+        "mop": {"status": "partial", "duration_seconds": 20},
+    }
+    assert reported["Store"]["visited"] is False
+    assert reported["Utility"]["visited"] is False
+    assert reported["Pantry"]["visited"] is True
+    assert reported["Pantry"]["completed"] is False
+    assert reported["Pantry"]["modes"]["mop"]["status"] == "unattempted"
+
+
+@pytest.mark.parametrize("group", [6, 7])
+def test_duplicate_room_results_cannot_credit_or_double_duration(group):
+    from custom_components.matic_robot.client.wire import first_bytes
+
+    payload = _session_payload(_vfield(5, 2))
+    summary = first_bytes(payload, 5)
+    duplicated = first_bytes(summary, 6)
+    session = _decode_cleaning_session(
+        _bfield(5, summary + _bfield(group, duplicated) + _bfield(group, duplicated))
+    )
+    assert session.completed is None
+    assert session.completed_rooms == ()
+    assert session.mode_results[-1].status is None
+    assert session.mode_results[-1].duration_seconds is None
+    assert session.completed_rooms_for_mode("vacuum" if group == 6 else "mop") == ()
+
+
+@pytest.mark.parametrize(
+    "duration",
+    [None, b"", _bfield(1, b"bad"), _vfield(1, 5) + _vfield(1, 6), b"\x0a\xff"],
+)
+async def test_combined_completion_requires_usable_duration_for_both_modes(duration):
+    from custom_components.matic_robot.client.wire import first_bytes
+
+    summary = first_bytes(_session_payload(_vfield(5, 2)), 5)
+    mop = _bfield(3, b"Study") + _vfield(5, 2)
+    if duration is not None:
+        mop += _bfield(4, duration)
+    session = _decode_cleaning_session(
+        _bfield(5, summary + _bfield(7, _bfield(1, _bfield(2, mop))))
+    )
+    reader = AsyncMock(
+        return_value=(CleaningSessionRecord(b"synthetic-duration", session),)
+    )
+    room = CleaningRoom("study", "Study", "vacuum_and_mop", "standard")
+    assert (
+        await _async_verify_leg_completion(
+            reader,
+            frozenset(),
+            [room],
+            dt_util.utcnow() - timedelta(seconds=90),
+            attempts=1,
+        )
+        == {}
+    )
+    assert session.room_durations_for_mode("mop") == ()
+    assert session.room_durations_for_mode("vacuum") == (("Study", 30),)
+
+
+def test_legacy_session_preserves_explicit_vacuum_evidence():
+    from custom_components.matic_robot.client.models import CleaningSession
+
+    session = CleaningSession(
+        None,
+        None,
+        30,
+        ("Study",),
+        (("Study", 30),),
+        None,
+        vacuum_completed_rooms=("Study",),
+    )
+    assert session.completed_rooms_for_mode("vacuum") == ("Study",)
+    assert session.completed_rooms_for_mode("vacuum_and_mop") == ()
+    assert session.room_durations_for_mode("vacuum") == (("Study", 30),)

--- a/tests/test_native_completion_modes.py
+++ b/tests/test_native_completion_modes.py
@@ -191,7 +191,7 @@ async def test_restart_reconciliation_retains_only_known_vacuum_dispatch(hass, m
     ]["study"].get("completed_runs", 0) == (1 if mode == "vacuum" else 0)
 
 
-async def test_seven_room_partial_session_credits_only_completed_requested_modes():
+async def test_seven_room_partial_session_credits_only_completed_requested_modes(hass):
     from custom_components.matic_robot.client.wire import first_bytes
     from custom_components.matic_robot.llm import _bounded_native_room_evidence
 
@@ -255,6 +255,33 @@ async def test_seven_room_partial_session_credits_only_completed_requested_modes
     assert reported["Pantry"]["visited"] is True
     assert reported["Pantry"]["completed"] is False
     assert reported["Pantry"]["modes"]["mop"]["status"] == "unattempted"
+
+    from types import SimpleNamespace
+
+    from custom_components.matic_robot.client.models import FloorPlan, Room
+    from custom_components.matic_robot.plans import CleaningPlanManager
+
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    floor = FloorPlan(
+        1,
+        "synthetic",
+        b"synthetic",
+        tuple(
+            Room(row[0].lower(), row[0], row[0].lower(), b"synthetic-room", ())
+            for row in rows
+        ),
+    )
+    records = (CleaningSessionRecord(b"synthetic-leg", session),)
+    assert await manager.async_import_native_history("synthetic", floor, records)
+    history = manager._robot("synthetic")["rooms"]
+    for name in ("study", "gallery", "atrium", "den", "pantry"):
+        assert history[name]["last_opportunity"] == session.ended_at
+        assert not history[name].get("last_completed")
+        assert history[name].get("completed_runs", 0) == 0
+    for name in ("store", "utility"):
+        assert not history.get(name, {}).get("last_opportunity")
+    assert not await manager.async_import_native_history("synthetic", floor, records)
 
 
 @pytest.mark.parametrize("group", [6, 7])

--- a/tests/test_session_tracking.py
+++ b/tests/test_session_tracking.py
@@ -7,7 +7,10 @@ from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
 from custom_components.matic_robot import session_tracking as session_tracking_module
-from custom_components.matic_robot.client.models import CleaningSession
+from custom_components.matic_robot.client.models import (
+    CleaningModeResult,
+    CleaningSession,
+)
 from custom_components.matic_robot.session_tracking import (
     CleaningSessionTracker,
     _build_session,
@@ -242,6 +245,12 @@ def test_session_preference_uses_newest_and_richer_source() -> None:
         completed_rooms=("Office",),
     )
     assert tracker.preferred_session(overlapping_native) is tracked
+    native_modes = replace(
+        overlapping_native,
+        completed=None,
+        mode_results=(CleaningModeResult("Study", "mop", None, 20),),
+    )
+    assert tracker.preferred_session(native_modes) is native_modes
 
     interrupted = CleaningSession(
         tracked.started_at,

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -383,46 +383,42 @@ def test_decode_room_completion_statuses_fail_closed() -> None:
     assert session.completed_rooms == ("Kitchen",)
     assert session.completed is False
 
-    # A confirmed cancelled native record mixed non-complete and complete
-    # mode statuses. Neither ordering proves completion of the whole room.
+    # Vacuum and mop statuses live in separate groups; the setting is ignored.
     for status_pair in [(1, 2), (2, 1), (2, 3)]:
-        ambiguous = details(b"Office", 90, (5, status_pair[0]), (6, status_pair[1]))
-        ambiguous_session = _decode_cleaning_session(
-            _bfield(5, _bfield(6, _bfield(1, _bfield(2, ambiguous))))
+        vacuum = details(b"Study", 90, (5, status_pair[0]), (6, 1))
+        mop = details(b"Study", 50, (5, status_pair[1]), (6, 1))
+        mixed = _decode_cleaning_session(
+            _bfield(
+                5,
+                _bfield(6, _bfield(1, _bfield(2, vacuum)))
+                + _bfield(7, _bfield(1, _bfield(2, mop))),
+            )
         )
-        assert ambiguous_session is not None
-        assert ambiguous_session.completed is None
-        assert ambiguous_session.completed_rooms == ()
+        assert mixed is not None
+        assert mixed.completed is (None if 3 in status_pair else False)
+        assert mixed.completed_rooms == ()
+        assert mixed.room_durations == (("Study", 140),)
 
-    malformed_complete = details(b"Office", 90, (5, 2)) + _bfield(6, b"unknown")
-    malformed_complete_session = _decode_cleaning_session(
-        _bfield(5, _bfield(6, _bfield(1, _bfield(2, malformed_complete))))
-    )
-    assert malformed_complete_session is not None
-    assert malformed_complete_session.completed is None
-    assert malformed_complete_session.completed_rooms == ()
+    for status in (
+        _vfield(5, 3),
+        _bfield(5, b"unknown"),
+        _vfield(5, 2) + _vfield(5, 2),
+    ):
+        unknown = details(b"Study", 90) + status
+        session = _decode_cleaning_session(
+            _bfield(5, _bfield(6, _bfield(1, _bfield(2, unknown))))
+        )
+        assert session is not None
+        assert session.completed is None
+        assert session.completed_rooms == ()
 
-    unknown = details(b"Office", 90, (5, 3))
-    unknown_session = _decode_cleaning_session(
-        _bfield(5, _bfield(6, _bfield(1, _bfield(2, unknown))))
-    )
-    assert unknown_session is not None
-    assert unknown_session.completed is None
-    assert unknown_session.completed_rooms == ()
-
-    malformed = details(b"Office", 90, (5, 1)) + _bfield(6, b"unknown")
-    malformed_session = _decode_cleaning_session(
-        _bfield(5, _bfield(6, _bfield(1, _bfield(2, malformed))))
-    )
-    assert malformed_session is not None
-    assert malformed_session.completed is None
-
-    missing = details(b"Office", 90)
-    missing_session = _decode_cleaning_session(
+    missing = details(b"Study", 90)
+    session = _decode_cleaning_session(
         _bfield(5, _bfield(6, _bfield(1, _bfield(2, missing))))
     )
-    assert missing_session is not None
-    assert missing_session.completed is None
+    assert session is not None
+    assert session.completed is False
+    assert session.mode_results[0].status == "unattempted"
 
 
 def test_decode_auxiliary_states() -> None:


### PR DESCRIPTION
Fix native history decoding so vacuum and mop outcomes stay separate, combined cleans require evidence for both modes, and durations add correctly. Unattempted rooms no longer appear visited; partial work affects rotation priority without earning completion credit.

Validation: 1,548 tests at 100% coverage; lint, types, privacy, artifact parity, and read-only verification against a retained native session.
