### PR TITLE
Add local command and raw-state activity diagnostics

### DIFF
--- a/custom_components/matic_robot/__init__.py
+++ b/custom_components/matic_robot/__init__.py
@@ -6,11 +6,11 @@ import asyncio
 import logging
 from dataclasses import dataclass
 from datetime import datetime
-from typing import cast
+from typing import Any, cast
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT
-from homeassistant.core import Event, HomeAssistant
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import dt as dt_util
@@ -36,6 +36,7 @@ from .const import (
     DATA_LLM_API,
     DATA_PLAN_MANAGER,
     DOMAIN,
+    EVENT_ACTIVITY_OBSERVED,
     EVENT_CLEANING_FINISHED,
     PLATFORMS,
 )
@@ -93,6 +94,13 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: MaticConfigEntry) -> bool:
     """Set up an unofficial Matic robot integration from a config entry."""
+
+    @callback
+    def _async_observe_activity(observation: dict[str, Any]) -> None:
+        hass.bus.async_fire(
+            EVENT_ACTIVITY_OBSERVED, {"entry_id": entry.entry_id, **observation}
+        )
+
     offset = dt_util.now().utcoffset()
     client = MaticHermesClient(
         entry.data[CONF_HOST],
@@ -103,6 +111,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: MaticConfigEntry) -> boo
         credential=HermesCredential.from_storage(entry.data[CONF_HERMES_CREDENTIAL])
         if CONF_HERMES_CREDENTIAL in entry.data
         else None,
+        observation_callback=_async_observe_activity,
         timezone_identifier=hass.config.time_zone,
         seconds_from_gmt=int(offset.total_seconds()) if offset is not None else 0,
     )

--- a/custom_components/matic_robot/client/api.py
+++ b/custom_components/matic_robot/client/api.py
@@ -70,6 +70,7 @@ from .models import (
     RobotTrajectory,
     WifiNetwork,
 )
+from .observations import ActivityJournal, ObservationCallback
 from .proto.hermes_auth_grpc import HermesAuthStub
 from .proto.hermes_auth_pb2 import TokenRequest
 from .proto.hermes_bot_info_grpc import HermesDiscoveryRPCStub
@@ -323,6 +324,7 @@ class MaticHermesClient(AbstractAsyncContextManager["MaticHermesClient"]):
         credential: HermesCredential | None = None,
         timezone_identifier: str = "UTC",
         seconds_from_gmt: int = 0,
+        observation_callback: ObservationCallback | None = None,
     ) -> None:
         self._host = host
         self._port = port
@@ -336,6 +338,7 @@ class MaticHermesClient(AbstractAsyncContextManager["MaticHermesClient"]):
         self._connect_lock = asyncio.Lock()
         self._endpoint_health: dict[str, str] = {}
         self._command_health: dict[str, str] = {}
+        self.activity_journal = ActivityJournal(observation_callback)
 
     async def __aenter__(self) -> MaticHermesClient:
         await self.async_connect()
@@ -543,19 +546,27 @@ class MaticHermesClient(AbstractAsyncContextManager["MaticHermesClient"]):
             payload = await self.async_get_property("kabuki_state")
 
         try:
-            return _decode_operational_state(payload)
+            state = _decode_operational_state(payload)
+            self.activity_journal.observe_state(state, "poll")
+            return state
         except DecodeError as err:
             raise CannotConnectError("Hermes returned malformed robot state") from err
 
     async def async_subscribe_state(self) -> AsyncIterator[RobotOperationalState]:
         """Yield live snapshots from the local ``kabuki_state`` property."""
-        async for entry in self.async_subscribe_collection_entries("kabuki_state"):
-            try:
-                yield _decode_operational_state(entry.value)
-            except DecodeError as err:
-                raise CannotConnectError(
-                    "Hermes returned malformed subscribed robot state"
-                ) from err
+        self.activity_journal.record("state_stream_started", source="push")
+        try:
+            async for entry in self.async_subscribe_collection_entries("kabuki_state"):
+                try:
+                    state = _decode_operational_state(entry.value)
+                    self.activity_journal.observe_state(state, "push")
+                    yield state
+                except DecodeError as err:
+                    raise CannotConnectError(
+                        "Hermes returned malformed subscribed robot state"
+                    ) from err
+        finally:
+            self.activity_journal.record("state_stream_ended", source="push")
 
     async def async_get_floor_plan(
         self, *, expected_mission_id: int | None = None
@@ -1168,7 +1179,7 @@ class MaticHermesClient(AbstractAsyncContextManager["MaticHermesClient"]):
         """Send one live-verified command through the authenticated user channel."""
         payload = encode_user_command(command)
         _LOGGER.debug("Requesting Matic user command %s", command.name)
-        await self._async_send_user_payload(payload)
+        await self._async_send_user_payload(payload, command_name=command.name)
 
     async def async_start_coverage(
         self,
@@ -1188,7 +1199,8 @@ class MaticHermesClient(AbstractAsyncContextManager["MaticHermesClient"]):
                 cleaning_mode=cleaning_mode,
                 coverage_setting=coverage_setting,
                 ordered=ordered,
-            )
+            ),
+            command_name="START_COVERAGE",
         )
 
     async def async_start_custom_coverage(
@@ -1206,7 +1218,8 @@ class MaticHermesClient(AbstractAsyncContextManager["MaticHermesClient"]):
                 circles=circles,
                 cleaning_mode=cleaning_mode,
                 coverage_setting=coverage_setting,
-            )
+            ),
+            command_name="START_CUSTOM_COVERAGE",
         )
 
     async def async_set_binary_setting(self, setting: str, enabled: bool) -> None:
@@ -1239,14 +1252,46 @@ class MaticHermesClient(AbstractAsyncContextManager["MaticHermesClient"]):
             b"\x0a\x05\x0d" + struct.pack("<f", rounded),
         )
 
-    async def _async_send_user_payload(self, payload: bytes) -> None:
+    async def _async_send_user_payload(
+        self, payload: bytes, *, command_name: str
+    ) -> None:
         """Send an encoded command through the authenticated user channel."""
-        await self._async_send_channel_payload("user_command", payload)
+        await self._async_send_channel_payload(
+            "user_command", payload, command_name=command_name
+        )
 
     async def _async_send_channel_payload(
-        self, channel_name: str, payload: bytes
+        self, channel_name: str, payload: bytes, *, command_name: str | None = None
     ) -> None:
-        """Send encoded bytes through one authenticated Hermes channel."""
+        """Observe every outgoing channel write, including internal cleanup."""
+        fields = {"channel": channel_name, "command": command_name or channel_name}
+        command_id = self.activity_journal.record("command_requested", **fields)
+        try:
+            outcome = await self._async_transmit_channel_payload(
+                channel_name, payload, command_id
+            )
+        except asyncio.CancelledError:
+            self.activity_journal.record(
+                "command_result", command_id=command_id, outcome="cancelled", **fields
+            )
+            raise
+        except Exception as err:
+            self.activity_journal.record(
+                "command_result",
+                command_id=command_id,
+                outcome="failed",
+                error_type=type(err).__name__,
+                **fields,
+            )
+            raise
+        self.activity_journal.record(
+            "command_result", command_id=command_id, outcome=outcome, **fields
+        )
+
+    async def _async_transmit_channel_payload(
+        self, channel_name: str, payload: bytes, command_id: int
+    ) -> str:
+        """Send unchanged bytes; record when transport transmission begins."""
         if self._channel is None:
             await self.async_connect()
         channel = self._channel
@@ -1267,6 +1312,9 @@ class MaticHermesClient(AbstractAsyncContextManager["MaticHermesClient"]):
                 async with HermesStub(channel).SendToChannel.open(
                     metadata=metadata
                 ) as stream:
+                    self.activity_journal.record(
+                        "command_sending", command_id=command_id, channel=channel_name
+                    )
                     await stream.send_message(request, end=True)
                     response = await stream.recv_message()
         except MaticError as err:
@@ -1287,6 +1335,8 @@ class MaticHermesClient(AbstractAsyncContextManager["MaticHermesClient"]):
                 channel_name,
                 response.ByteSize(),
             )
+
+        return self._command_health[channel_name]
 
     @property
     def command_health(self) -> dict[str, str]:

--- a/custom_components/matic_robot/client/observations.py
+++ b/custom_components/matic_robot/client/observations.py
@@ -1,0 +1,75 @@
+"""Bounded, payload-free command and raw-state evidence for local diagnosis."""
+
+from __future__ import annotations
+
+import logging
+from collections import deque
+from collections.abc import Callable
+from copy import deepcopy
+from datetime import UTC, datetime
+from typing import Any, Literal
+from uuid import uuid4
+
+from .models import RobotOperationalState
+
+_LOGGER = logging.getLogger(__name__)
+MAX_OBSERVATIONS = 512
+ObservationCallback = Callable[[dict[str, Any]], None]
+
+
+class ActivityJournal:
+    """Order observations within one client lifetime, without retaining payloads.
+
+    Timestamps are local receipt times, not robot event times. Separate poll and
+    push cursors avoid mistaking a slower poll for a reversal in the push stream.
+    Transport acknowledgement is not proof that a command was executed.
+    """
+
+    def __init__(self, callback: ObservationCallback | None = None) -> None:
+        self._callback = callback
+        self._session = uuid4().hex
+        self._sequence = 0
+        self._events: deque[dict[str, Any]] = deque(maxlen=MAX_OBSERVATIONS)
+        self._states: dict[str, tuple[tuple[int, ...], tuple[int, ...]]] = {}
+        self.record("started")
+
+    @property
+    def snapshot(self) -> list[dict[str, Any]]:
+        """Return detached records, oldest first; older evidence is evicted."""
+        return deepcopy(list(self._events))
+
+    def record(self, kind: str, **fields: Any) -> int:
+        """Record only fields constructed by the client's observation sites."""
+        self._sequence += 1
+        event = {
+            "observation_session": self._session,
+            "sequence": self._sequence,
+            "observed_at": datetime.now(UTC).isoformat(),
+            "kind": kind,
+            **fields,
+        }
+        self._events.append(event)
+        if self._callback is not None:
+            try:
+                self._callback(deepcopy(event))
+            except Exception:
+                # Observer failures must not alter robot commands or disclose
+                # an exception message that might contain private material.
+                _LOGGER.warning("Matic activity observer failed")
+        return self._sequence
+
+    def observe_state(
+        self, state: RobotOperationalState, source: Literal["poll", "push"]
+    ) -> None:
+        """Record raw code changes before HA error confirmation or filtering."""
+        signature = (state.state_codes, state.error_codes)
+        if self._states.get(source) == signature:
+            return
+        self._states[source] = signature
+        self.record(
+            "state",
+            source=source,
+            state_codes=list(state.state_codes),
+            error_codes=list(state.error_codes),
+            activity=state.activity,
+        )

--- a/custom_components/matic_robot/const.py
+++ b/custom_components/matic_robot/const.py
@@ -37,6 +37,7 @@ DATA_LLM_API: Final = "llm_api"
 EVENT_FIRMWARE_CHANGED: Final = f"{DOMAIN}_firmware_changed"
 EVENT_FIRMWARE_ANALYZED: Final = f"{DOMAIN}_firmware_analyzed"
 EVENT_CLEANING_FINISHED: Final = f"{DOMAIN}_cleaning_finished"
+EVENT_ACTIVITY_OBSERVED: Final = f"{DOMAIN}_activity_observed"
 EVENT_CUES: Final = f"{DOMAIN}_cues"
 
 CUES_EVENT_TYPES: Final = (

--- a/custom_components/matic_robot/diagnostics.py
+++ b/custom_components/matic_robot/diagnostics.py
@@ -23,6 +23,7 @@ async def async_get_config_entry_diagnostics(
     command_health = entry.runtime_data.client.command_health
     bag_observation = getattr(entry.runtime_data.coordinator, "bag_observation", None)
     return {
+        "activity_observations": entry.runtime_data.client.activity_journal.snapshot,
         "entry": {
             "port": entry.data.get("port"),
             "credential_configured": CONF_HERMES_CREDENTIAL in entry.data,

--- a/custom_components/matic_robot/llm.py
+++ b/custom_components/matic_robot/llm.py
@@ -18,6 +18,7 @@ from .client.exceptions import MaticError
 from .client.models import CleaningSession
 from .const import (
     DOMAIN,
+    EVENT_ACTIVITY_OBSERVED,
     EVENT_CLEANING_FINISHED,
     EVENT_CUES,
     EVENT_FIRMWARE_ANALYZED,
@@ -33,6 +34,7 @@ MAX_NATIVE_HISTORY_ROOM_EVIDENCE = 64
 MAX_NATIVE_HISTORY_ROOM_EVIDENCE_BYTES = 32 * 1024
 _ADMIN_ERROR = "Administrator access is required for Matic operational tools"
 _MATIC_EVENT_TYPES = (
+    EVENT_ACTIVITY_OBSERVED,
     EVENT_CLEANING_FINISHED,
     EVENT_CUES,
     EVENT_FIRMWARE_CHANGED,
@@ -46,6 +48,17 @@ _MATIC_EVENT_TYPES = (
     f"{DOMAIN}_room_reconciled",
 )
 _SAFE_EVENT_FIELDS = (
+    "observation_session",
+    "sequence",
+    "observed_at",
+    "kind",
+    "source",
+    "command_id",
+    "command",
+    "channel",
+    "outcome",
+    "error_type",
+    "activity",
     "entry_id",
     "device_id",
     "entity_id",
@@ -105,6 +118,11 @@ class MaticOperationsAPI(llm.API):
                 data[key] = value
             elif isinstance(value, str):
                 data[key] = value[:256]
+        if event.event_type == EVENT_ACTIVITY_OBSERVED:
+            for key in ("state_codes", "error_codes"):
+                codes = event.data.get(key)
+                if isinstance(codes, list) and all(type(code) is int for code in codes):
+                    data[key] = codes[:256]
         if event.event_type == EVENT_CLEANING_FINISHED:
             rooms = event.data.get("rooms")
             completed_rooms = event.data.get("completed_rooms")
@@ -440,7 +458,8 @@ class MaticGetRecentEventsTool(_MaticTool):
 
     name = "MaticGetRecentEvents"
     description = (
-        "Inspect recent allowlisted Matic room, cleaning, Cues, and firmware events "
+        "Inspect recent allowlisted Matic command, raw-state, room, cleaning, Cues, "
+        "and firmware events "
         "retained during the current Home Assistant process."
     )
     parameters = vol.Schema(

--- a/custom_components/matic_robot/manifest.json
+++ b/custom_components/matic_robot/manifest.json
@@ -25,7 +25,7 @@
     "protobuf>=6",
     "voluptuous>=0.15"
   ],
-  "version": "0.4.2",
+  "version": "0.4.3",
   "zeroconf": [
     "_matic_hermes._tcp.local."
   ]

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@
 | Find a sensor or control | [Entities](entities.md) |
 | Build an automation | [Actions, events, and examples](automation.md) |
 | Understand cleaning history | [Cleaning results](native-cleaning-results.md) |
+| Investigate unexpected docking or stopping | [Activity diagnostics](activity-diagnostics.md) |
 | Check my setup | [Compatibility](acceptance-0.4.md) |
 | Understand stored data | [Privacy](privacy.md) |
 

--- a/docs/activity-diagnostics.md
+++ b/docs/activity-diagnostics.md
@@ -1,0 +1,41 @@
+# Investigating interrupted cleaning
+
+[Documentation](README.md) · [Privacy](privacy.md)
+
+When the robot briefly reports returning to dock or stops before finishing a
+plan, download the integration diagnostics soon afterward. `activity_observations`
+contains the last 512 command and state observations from the current integration
+load. Older observations are evicted; reloading or restarting clears this buffer.
+The administrator-only `MaticGetRecentEvents` tool also shows recent observations
+among its last 64 operational events.
+
+The integration emits `matic_robot_activity_observed` events locally. Home
+Assistant Recorder can retain these across restarts according to its event
+exclusions and retention settings. No debug logging needs to be enabled.
+
+## Reading the evidence
+
+- `observation_session` identifies one integration load. `sequence` orders its
+  observations, and `observed_at` is the Home Assistant receipt time in UTC.
+- `command_requested` identifies the integration's intended command, including
+  internal cleanup. Later records refer to its sequence as `command_id`.
+- `command_sending` means transmission began. A subsequent failure or cancellation
+  does not prove that the robot received nothing.
+- `command_result` reports transport acknowledgement, no acknowledgement,
+  failure, or cancellation. Acknowledgement does not prove execution.
+- `state` records changes in raw `state_codes` and `error_codes`, before Home
+  Assistant error confirmation. `source` distinguishes poll and push observations;
+  a slower poll can arrive after a newer push observation.
+- `state_stream_started` and `state_stream_ended` mark subscription attempts and
+  gaps. A started stream is not proof that a snapshot has arrived.
+
+A returning state without a corresponding integration command shows that this
+integration did not request docking during that observed interval. It cannot
+distinguish an OEM-app command, a physical control, or an internal robot decision.
+Check for subscription gaps, missing sequences, and restarts before drawing that
+conclusion. These observations do not recover activity from before installation.
+
+For a controlled reproduction, supervise one plan with presence automation
+temporarily disabled and avoid OEM-app or physical-control input. Note any
+intervention, then restore the automation after the test. Report observed
+movement separately from the robot's displayed activity.

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -77,4 +77,5 @@ IDs where possible; subsequent user-assigned names are preserved.
 Administrator-only MCP tools provide live runner status, plan order/settings,
 recent native history, and recent events: `MaticGetOperations`, `MaticGetPlan`,
 `MaticGetNativeHistory`, and `MaticGetRecentEvents`.
+Recent events include the [command and raw-state observation trail](activity-diagnostics.md).
 Dust-bag observations are currently available through `MaticGetOperations` only.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -15,6 +15,7 @@ analytics, or maintainer cloud service.
 | Current photographic map and saved map history | Private integration storage; history is capped at 12 scenes and 48 MiB |
 | Firmware endpoint summaries | Private storage, up to 52 snapshots; sizes, hashes, and field shapes without payload values |
 | Activity and enabled entity states | Home Assistant Recorder, according to its configuration |
+| Command names, transport outcomes, and raw state transitions with timestamps | Last 512 observations in memory; local events follow Recorder retention |
 
 Room lists, Wi-Fi SSID, schedules, detailed session results, and plan history are
 live template attributes but are excluded from Recorder. Opt-in room statistics
@@ -50,7 +51,9 @@ The integration offers no recording, clip-sharing, or clip-deletion controls.
 
 **Download diagnostics** creates a report only when requested. It contains
 software/protocol versions, state and error codes, counters, and endpoint/map
-health. It omits credentials, addresses, serials, certificate identity, names,
+health, plus the bounded [command and state observation trail](activity-diagnostics.md).
+Observations contain no command payloads or exception messages.
+The report omits credentials, addresses, serials, certificate identity, names,
 room/map content, Wi-Fi identities, schedules, and detailed cleaning history.
 Review any report before sharing it.
 

--- a/docs/release-notes-0.4.3.md
+++ b/docs/release-notes-0.4.3.md
@@ -1,0 +1,17 @@
+# 0.4.3 — Activity diagnostics
+
+🧭 **Investigate unexpected docking and stopping** with a local timeline of
+integration commands and raw robot state changes, including brief subscription
+updates between normal polls.
+
+🔎 **Distinguish command attempts from transport results.** The timeline includes
+internal cleanup commands, transmission starts, acknowledgements, failures,
+cancellations, and subscription gaps. It does not change cleaning behavior or
+claim to identify commands sent through the OEM app.
+
+🔒 **Keep the evidence local.** Diagnostics retain the latest 512 observations
+without payloads, room names, maps, credentials, or exception messages. Home
+Assistant events follow Recorder retention settings.
+
+See [Activity diagnostics](activity-diagnostics.md) for interpretation and a
+controlled reproduction procedure.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "matic-home-assistant"
-version = "0.4.2"
+version = "0.4.3"
 description = "Unofficial local-only Home Assistant integration for Matic robot vacuums"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_activity_observations.py
+++ b/tests/test_activity_observations.py
@@ -1,0 +1,157 @@
+"""Command causality, raw transition retention, and privacy regressions."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import replace
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from homeassistant.core import Event
+
+from custom_components.matic_robot.client.api import MaticHermesClient
+from custom_components.matic_robot.client.commands import UserCommand
+from custom_components.matic_robot.client.exceptions import CannotConnectError
+from custom_components.matic_robot.client.models import RobotOperationalState
+from custom_components.matic_robot.client.observations import (
+    MAX_OBSERVATIONS,
+    ActivityJournal,
+)
+from custom_components.matic_robot.const import EVENT_ACTIVITY_OBSERVED
+from custom_components.matic_robot.llm import MaticOperationsAPI
+from tests.test_api_paths import _OpenMethod, _Stream
+
+
+def test_raw_transitions_are_bounded_detached_and_payload_free() -> None:
+    delivered = []
+    journal = ActivityJournal(delivered.append)
+    state = RobotOperationalState(
+        80,
+        (101, 119),
+        (),
+        False,
+        False,
+        False,
+        False,
+        True,
+        False,
+        current_area="private-room",
+        software_version="private-version",
+    )
+    journal.observe_state(state, "push")
+    journal.observe_state(state, "push")
+    journal.observe_state(replace(state, battery_percentage=79), "push")
+    assert len(journal.snapshot) == 2
+    docking = replace(state, state_codes=(104, 105, 223, 119), returning=True)
+    journal.observe_state(docking, "push")
+    journal.observe_state(state, "poll")
+    journal.observe_state(docking, "push")
+    assert len(journal.snapshot) == 4  # Slow poll must not reset the push cursor.
+    journal.observe_state(replace(docking, error_codes=(205,)), "push")
+    assert journal.snapshot[-1]["error_codes"] == [205]
+    assert "private" not in json.dumps(journal.snapshot)
+    delivered[-1]["state_codes"].append(999)
+    snapshot = journal.snapshot
+    snapshot[-1]["error_codes"].clear()
+    assert journal.snapshot[-1]["error_codes"] == [205]
+    assert 999 not in journal.snapshot[-1]["state_codes"]
+    for i in range(MAX_OBSERVATIONS):
+        journal.observe_state(replace(state, state_codes=(i,)), "push")
+    assert len(journal.snapshot) == MAX_OBSERVATIONS
+    assert journal.snapshot[0]["sequence"] > 1
+    assert journal.snapshot[-1]["sequence"] > journal.snapshot[0]["sequence"]
+    assert (
+        ActivityJournal().snapshot[0]["observation_session"]
+        != snapshot[0]["observation_session"]
+    )
+
+
+@pytest.mark.parametrize(
+    "response,outcome",
+    [(None, "unacknowledged"), (SimpleNamespace(ByteSize=lambda: 4), "acknowledged")],
+)
+async def test_command_transport_records_attempt_send_and_result(
+    monkeypatch, response, outcome
+) -> None:
+    delivered = []
+    client = MaticHermesClient(
+        "robot.invalid", 16320, observation_callback=delivered.append
+    )
+    client._channel = object()
+    stream = _Stream(response=response)
+    monkeypatch.setattr(
+        "custom_components.matic_robot.client.api.HermesStub",
+        lambda _: SimpleNamespace(SendToChannel=_OpenMethod(stream)),
+    )
+    await client.async_send_user_command(UserCommand.STOP)
+    attempt, sending, result = delivered[1:]
+    assert attempt["command"] == "STOP"
+    assert sending["command_id"] == result["command_id"] == attempt["sequence"]
+    assert result["outcome"] == outcome
+    assert stream.request.value == bytes.fromhex("7a040a022200")
+    assert "payload" not in json.dumps(delivered)
+    assert "robot.invalid" not in json.dumps(delivered)
+
+
+@pytest.mark.parametrize(
+    "error,outcome",
+    [
+        (CannotConnectError("private-secret"), "failed"),
+        (asyncio.CancelledError(), "cancelled"),
+    ],
+)
+async def test_connection_failure_and_cancellation_never_claim_sent(
+    error, outcome
+) -> None:
+    client = MaticHermesClient("robot.invalid", 16320)
+    client.async_connect = AsyncMock(side_effect=error)
+    with pytest.raises(type(error)):
+        await client.async_send_user_command(UserCommand.DOCK)
+    events = client.activity_journal.snapshot
+    assert [event["kind"] for event in events] == [
+        "started",
+        "command_requested",
+        "command_result",
+    ]
+    assert events[-1]["outcome"] == outcome
+    assert "private-secret" not in json.dumps(events)
+
+
+async def test_observer_failure_cannot_block_a_command(monkeypatch, caplog) -> None:
+    def broken(_event):
+        raise RuntimeError("private-secret")
+
+    client = MaticHermesClient("robot.invalid", 16320, observation_callback=broken)
+    client._channel = object()
+    stream = _Stream()
+    monkeypatch.setattr(
+        "custom_components.matic_robot.client.api.HermesStub",
+        lambda _: SimpleNamespace(SendToChannel=_OpenMethod(stream)),
+    )
+    await client.async_send_user_command(UserCommand.STOP)
+    assert stream.request is not None
+    assert "private-secret" not in caplog.text
+
+
+def test_mcp_keeps_only_bounded_integer_raw_codes() -> None:
+    api = MaticOperationsAPI(SimpleNamespace())
+    api._async_capture_event(
+        Event(
+            EVENT_ACTIVITY_OBSERVED,
+            {
+                "kind": "state",
+                "source": "push",
+                "sequence": 2,
+                "state_codes": list(range(300)),
+                "error_codes": ["private"],
+                "payload": "private",
+                "room_name": "private",
+            },
+        )
+    )
+    event = api.recent_events[-1]
+    assert event["data"]["state_codes"] == list(range(256))
+    assert "error_codes" not in event["data"]
+    assert "private" not in json.dumps(event)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -38,6 +38,7 @@ async def test_diagnostics_redact_access_material_but_keep_local_context() -> No
         entry_id="synthetic-entry",
         runtime_data=SimpleNamespace(
             client=SimpleNamespace(
+                activity_journal=SimpleNamespace(snapshot=[]),
                 endpoint_health={"current_version": "ok", "wifi_status": "failure"},
                 command_health={
                     "user_command": "acknowledged",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -804,7 +804,9 @@ async def test_restart_recovery_does_not_import_for_replacement_marker(hass) -> 
 async def test_setup_registers_services_without_media_view() -> None:
     hass = SimpleNamespace(
         http=SimpleNamespace(register_view=MagicMock()),
-        bus=SimpleNamespace(async_listen=MagicMock(return_value=MagicMock())),
+        bus=SimpleNamespace(
+            async_listen=MagicMock(return_value=MagicMock()), async_fire=MagicMock()
+        ),
         services=SimpleNamespace(async_register=MagicMock()),
         data={},
     )
@@ -918,7 +920,9 @@ async def test_setup_refreshes_before_forwarding_platforms(
     hass = SimpleNamespace(
         config=SimpleNamespace(time_zone="America/Los_Angeles"),
         config_entries=SimpleNamespace(async_forward_entry_setups=AsyncMock()),
-        bus=SimpleNamespace(async_listen=MagicMock(return_value=MagicMock())),
+        bus=SimpleNamespace(
+            async_listen=MagicMock(return_value=MagicMock()), async_fire=MagicMock()
+        ),
         data={
             DOMAIN: {
                 DATA_PLAN_MANAGER: plans,
@@ -997,7 +1001,9 @@ async def test_setup_refreshes_before_forwarding_platforms(
     )
 
     with (
-        patch("custom_components.matic_robot.MaticHermesClient", return_value=client),
+        patch(
+            "custom_components.matic_robot.MaticHermesClient", return_value=client
+        ) as client_factory,
         patch(
             "custom_components.matic_robot.MaticCoordinator",
             return_value=coordinator,
@@ -1021,6 +1027,11 @@ async def test_setup_refreshes_before_forwarding_platforms(
         ),
     ):
         assert await async_setup_entry(hass, entry) is True
+        client_factory.call_args.kwargs["observation_callback"]({"kind": "started"})
+        hass.bus.async_fire.assert_called_with(
+            "matic_robot_activity_observed",
+            {"entry_id": entry.entry_id, "kind": "started"},
+        )
     assert len(setup_scheduled) == 1
     await setup_scheduled[0]
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -151,7 +151,7 @@ async def test_api_registration_event_capture_and_admin_gate() -> None:
     hass = _hass(_entry())
     api = MaticOperationsAPI(hass)
     api.async_start()
-    assert hass.bus.async_listen.call_count == 11
+    assert hass.bus.async_listen.call_count == 12
 
     event_callback = hass.bus.async_listen.call_args_list[0].args[1]
     event_callback(
@@ -297,7 +297,7 @@ async def test_api_registration_event_capture_and_admin_gate() -> None:
     with patch("custom_components.matic_robot.llm.llm.async_register_api") as register:
         registered = async_register_matic_llm_api(hass)
     register.assert_called_once_with(hass, registered)
-    assert hass.bus.async_listen.call_count == 22
+    assert hass.bus.async_listen.call_count == 24
 
 
 async def test_operations_and_robot_resolution() -> None:

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -28,7 +28,7 @@ def test_release_versions_and_links_are_consistent() -> None:
     hacs = json.loads((ROOT / "hacs.json").read_text())
     project = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]
 
-    assert manifest["version"] == "0.4.2"
+    assert manifest["version"] == "0.4.3"
     assert project["version"] == manifest["version"]
     assert hacs["homeassistant"] == "2026.7.0"
     assert manifest["documentation"].startswith("https://github.com/")


### PR DESCRIPTION
Unexpected docking states and early mission stops are difficult to attribute when HA service events omit internal integration commands. Add one local observation timeline at the Hermes transport and raw-state read boundaries, including command attempts, transmission starts, transport outcomes, cancellation, and subscription gaps.

Expose the latest 512 payload-free observations in diagnostics and allowlisted recent events through MCP. Emit local HA events for Recorder retention. Preserve command bytes, cleaning behavior, TLS validation, and error propagation; retain no payloads, room identifiers, map data, credentials, or exception messages.

Validation: 1,563 Python tests passed with 100% coverage; Ruff, formatting, strict mypy, privacy, and release metadata checks passed. Candidate version is 0.4.3 for an RC installation. Supervised reproduction of the robot behavior remains a separate live gate.
