### PR TITLE
Fix cleaning result scope and expose command evidence

### DIFF
--- a/custom_components/matic_robot/coordinator.py
+++ b/custom_components/matic_robot/coordinator.py
@@ -680,7 +680,7 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
                 "rooms": list(session.visited_rooms),
                 "completed_rooms": list(session.completed_rooms),
                 "completion_scope": (
-                    "vacuum_and_mop" if session.mode_results else "legacy"
+                    "native_room_summary" if session.mode_results else "legacy"
                 ),
                 **{
                     f"{label}_completed_room_count": sum(

--- a/custom_components/matic_robot/coordinator.py
+++ b/custom_components/matic_robot/coordinator.py
@@ -679,6 +679,22 @@ class MaticCoordinator(DataUpdateCoordinator[RobotState]):
                 "completed": session.completed,
                 "rooms": list(session.visited_rooms),
                 "completed_rooms": list(session.completed_rooms),
+                "completion_scope": (
+                    "vacuum_and_mop" if session.mode_results else "legacy"
+                ),
+                **{
+                    f"{label}_completed_room_count": sum(
+                        duration > 0
+                        for room, duration in session.room_durations_for_mode(mode)
+                        if room in session.completed_rooms_for_mode(mode)
+                    )
+                    for label, mode in (
+                        ("vacuum", "vacuum"),
+                        ("mop", "mop"),
+                        ("combined", "vacuum_and_mop"),
+                    )
+                    if session.mode_results
+                },
                 "room_durations": dict(session.room_durations),
                 "firmware_version": version,
             },

--- a/custom_components/matic_robot/llm.py
+++ b/custom_components/matic_robot/llm.py
@@ -16,6 +16,7 @@ from homeassistant.util.json import JsonObjectType
 
 from .client.exceptions import MaticError
 from .client.models import CleaningSession
+from .client.observations import MAX_OBSERVATIONS
 from .const import (
     DOMAIN,
     EVENT_ACTIVITY_OBSERVED,
@@ -32,6 +33,20 @@ MAX_RECENT_EVENTS = 64
 MAX_NATIVE_HISTORY_RESULTS = 20
 MAX_NATIVE_HISTORY_ROOM_EVIDENCE = 64
 MAX_NATIVE_HISTORY_ROOM_EVIDENCE_BYTES = 32 * 1024
+MAX_ACTIVITY_RESULTS = 128
+_ACTIVITY_FIELDS = (
+    "observation_session",
+    "sequence",
+    "observed_at",
+    "kind",
+    "source",
+    "command_id",
+    "command",
+    "channel",
+    "outcome",
+    "error_type",
+    "activity",
+)
 _ADMIN_ERROR = "Administrator access is required for Matic operational tools"
 _MATIC_EVENT_TYPES = (
     EVENT_ACTIVITY_OBSERVED,
@@ -87,6 +102,10 @@ _SAFE_EVENT_FIELDS = (
     "ended_at",
     "duration_seconds",
     "completed",
+    "completion_scope",
+    "vacuum_completed_room_count",
+    "mop_completed_room_count",
+    "combined_completed_room_count",
 )
 
 
@@ -162,7 +181,12 @@ class MaticOperationsAPI(llm.API):
                 "Rooms in one leg share a native mission and should not dock "
                 "between them. A settings change starts another leg, where current "
                 "firmware may briefly touch the dock during handoff. Treat native "
-                "room completion and duration evidence as the completion authority."
+                "per-mode results as reported work, using the requested cleaning mode. "
+                "An intentional stop and successful docking are a successful stop "
+                "outcome, not proof that every room finished. An interruption label "
+                "alone does not establish a robot fault or the cause of a stop. "
+                "Use MaticGetActivity to correlate integration commands and raw "
+                "states; it cannot identify OEM-app or physical input."
             ),
             llm_context=llm_context,
             tools=[
@@ -170,6 +194,7 @@ class MaticOperationsAPI(llm.API):
                 MaticGetPlanTool(self),
                 MaticGetNativeHistoryTool(self),
                 MaticGetRecentEventsTool(self),
+                MaticGetActivityTool(self),
             ],
         )
 
@@ -332,7 +357,8 @@ class MaticGetNativeHistoryTool(_MaticTool):
     name = "MaticGetNativeHistory"
     description = (
         "Read recent native Matic cleaning records without opaque keys or map data, "
-        "including visited rooms, verified completed rooms, and room durations."
+        "including per-mode room results and durations. Supply cleaning_mode to "
+        "evaluate a vacuum-only, mop-only, or combined run correctly."
     )
     parameters = vol.Schema(
         {
@@ -340,6 +366,7 @@ class MaticGetNativeHistoryTool(_MaticTool):
             vol.Optional("limit", default=5): vol.All(
                 vol.Coerce(int), vol.Range(min=1, max=MAX_NATIVE_HISTORY_RESULTS)
             ),
+            vol.Optional("cleaning_mode"): vol.In(("vacuum", "mop", "vacuum_and_mop")),
         }
     )
 
@@ -373,6 +400,7 @@ class MaticGetNativeHistoryTool(_MaticTool):
                     record.session,
                     remaining_room_items,
                     remaining_room_bytes,
+                    cleaning_mode=args.get("cleaning_mode"),
                 )
             )
             sessions.append(
@@ -387,6 +415,12 @@ class MaticGetNativeHistoryTool(_MaticTool):
                         "room_evidence_returned": len(room_evidence),
                         "room_evidence_truncated": len(room_evidence) < total_rooms,
                         "completed": record.session.completed,
+                        "completion_scope": args.get("cleaning_mode")
+                        or (
+                            "vacuum_and_mop"
+                            if record.session.mode_results
+                            else "legacy"
+                        ),
                     },
                 )
             )
@@ -396,9 +430,15 @@ class MaticGetNativeHistoryTool(_MaticTool):
                 "read_only": True,
                 "robot": _entry_name(entry),
                 "completion_authority": (
-                    "Only returned room_evidence entries with completed true and a "
-                    "positive duration prove room completion; the global completed "
-                    "field and omitted evidence do not."
+                    "Room completed and duration_seconds apply to completion_scope. "
+                    "Without cleaning_mode, per-mode records use vacuum_and_mop; "
+                    "false does not mean a vacuum-only or mop-only run failed. "
+                    "Read each requested mode's status and positive duration. "
+                    "Native results report work, not why cleaning ended; stopped "
+                    "rooms can also be reported completed. Managed room_completed "
+                    "events require additional run and terminal-state verification. "
+                    "The global completed field, docking, and omitted evidence "
+                    "do not prove plan completion."
                 ),
                 "room_evidence_limits": {
                     "max_items_across_response": MAX_NATIVE_HISTORY_ROOM_EVIDENCE,
@@ -415,12 +455,21 @@ def _bounded_native_room_evidence(
     session: CleaningSession,
     remaining_items: int,
     remaining_bytes: int,
+    *,
+    cleaning_mode: str | None = None,
 ) -> tuple[list[JsonObjectType], int, int, int]:
     """Normalize and bound one session's room evidence across the response."""
     visited = set(session.visited_rooms)
-    completed = set(session.completed_rooms)
+    completed = set(session.completed_rooms_for_mode(cleaning_mode))
     durations: dict[str, int] = {}
-    for room, duration in session.room_durations:
+    room_durations = (
+        session.room_durations_for_mode(cleaning_mode)
+        if cleaning_mode is not None
+        else session.room_durations
+    )
+    if cleaning_mode is None:
+        completed = set(session.completed_rooms)
+    for room, duration in room_durations:
         durations.setdefault(room, duration)
     ordered_rooms = list(
         dict.fromkeys((*session.rooms, *session.completed_rooms, *durations.keys()))
@@ -491,6 +540,119 @@ class MaticGetRecentEventsTool(_MaticTool):
                 "events": events,
             },
         )
+
+
+class MaticGetActivityTool(_MaticTool):
+    """Read the robot's bounded command journal without a network request."""
+
+    name = "MaticGetActivity"
+    description = (
+        "Inspect integration-issued commands and raw robot state observations, "
+        "with sequence coverage, retention limits, and pagination. No robot command "
+        "is sent. Use this to investigate who requested a stop or docking; external "
+        "app, physical, and internal robot actions have no command provenance here."
+    )
+    parameters = vol.Schema(
+        {
+            vol.Optional("robot"): vol.All(cv.string, vol.Length(min=1, max=128)),
+            vol.Optional("kind", default="commands"): vol.In(
+                ("all", "commands", "states", "stream")
+            ),
+            vol.Optional("limit", default=50): vol.All(
+                vol.Coerce(int), vol.Range(min=1, max=MAX_ACTIVITY_RESULTS)
+            ),
+            vol.Optional("before_sequence"): vol.All(vol.Coerce(int), vol.Range(min=1)),
+            vol.Optional("observation_session"): vol.All(
+                cv.string, vol.Match(r"^[a-f0-9]{32}$")
+            ),
+        }
+    )
+
+    @override
+    async def async_call(
+        self,
+        hass: HomeAssistant,
+        tool_input: llm.ToolInput,
+        llm_context: llm.LLMContext,
+    ) -> JsonObjectType:
+        """Return a detached page and the full available observation window."""
+        args = self.parameters(tool_input.tool_args)
+        entry = _resolve_entry(hass, args.get("robot"))
+        observations = [
+            _activity_observation(item)
+            for item in entry.runtime_data.client.activity_journal.snapshot
+        ]
+        first, last = observations[0], observations[-1]
+        session = last["observation_session"]
+        if "before_sequence" in args and "observation_session" not in args:
+            raise HomeAssistantError("Pagination requires observation_session")
+        if args.get("observation_session", session) != session:
+            raise HomeAssistantError(
+                "The activity journal restarted; read the new observation window"
+            )
+        kind = args["kind"]
+        prefixes = {
+            "commands": "command_",
+            "states": "state",
+            "stream": "state_stream_",
+        }
+        matching = [
+            item
+            for item in reversed(observations)
+            if (
+                kind == "all"
+                or (kind == "states" and item["kind"] == "state")
+                or (kind != "states" and item["kind"].startswith(prefixes[kind]))
+            )
+            and item["sequence"] < args.get("before_sequence", last["sequence"] + 1)
+        ]
+        page = matching[: args["limit"]]
+        has_more = len(matching) > len(page)
+        return cast(
+            JsonObjectType,
+            {
+                "read_only": True,
+                "robot": _entry_name(entry),
+                "retention": "current integration load; oldest observations evicted",
+                "observation_session": session,
+                "buffer_limit": MAX_OBSERVATIONS,
+                "retained_observations": len(observations),
+                "first_available_sequence": first["sequence"],
+                "last_available_sequence": last["sequence"],
+                "earliest_observed_at": first["observed_at"],
+                "latest_observed_at": last["observed_at"],
+                "older_observations_evicted": first["sequence"] > 1,
+                "kind": kind,
+                "observations": page,
+                "has_more": has_more,
+                "next_before_sequence": page[-1]["sequence"] if has_more else None,
+                "interpretation": (
+                    "Only this integration's commands are recorded. Absence applies "
+                    "only inside the available sequence window after all matching "
+                    "pages are read. Acknowledgement is not execution. State times "
+                    "are local receipt times; poll and push can arrive out of order. "
+                    "Correlate commands, native results, and automation traces; a "
+                    "ready or returning state alone cannot identify the stop cause."
+                ),
+            },
+        )
+
+
+def _activity_observation(item: dict[str, Any]) -> dict[str, Any]:
+    """Expose only bounded scalar metadata and raw integer state codes."""
+    result: dict[str, Any] = {
+        key: value[:256] if isinstance(value, str) else value
+        for key in _ACTIVITY_FIELDS
+        if key in item
+        and (
+            (value := item[key]) is None or isinstance(value, str | bool | int | float)
+        )
+    }
+    for key in ("state_codes", "error_codes"):
+        codes = item.get(key)
+        if isinstance(codes, list) and all(type(code) is int for code in codes):
+            result[key] = codes[:256]
+    return result
 
 
 @callback

--- a/custom_components/matic_robot/llm.py
+++ b/custom_components/matic_robot/llm.py
@@ -416,11 +416,7 @@ class MaticGetNativeHistoryTool(_MaticTool):
                         "room_evidence_truncated": len(room_evidence) < total_rooms,
                         "completed": record.session.completed,
                         "completion_scope": args.get("cleaning_mode")
-                        or (
-                            "vacuum_and_mop"
-                            if record.session.mode_results
-                            else "legacy"
-                        ),
+                        or ("unspecified" if record.session.mode_results else "legacy"),
                     },
                 )
             )
@@ -430,9 +426,11 @@ class MaticGetNativeHistoryTool(_MaticTool):
                 "read_only": True,
                 "robot": _entry_name(entry),
                 "completion_authority": (
-                    "Room completed and duration_seconds apply to completion_scope. "
-                    "Without cleaning_mode, per-mode records use vacuum_and_mop; "
-                    "false does not mean a vacuum-only or mop-only run failed. "
+                    "With cleaning_mode, room completed and duration_seconds apply "
+                    "to that completion_scope. Without it, native per-mode records "
+                    "have unspecified scope and completed is null; durations are "
+                    "totals across reported modes. Do not infer the requested mode "
+                    "from an omitted or unattempted mode. "
                     "Read each requested mode's status and positive duration. "
                     "Native results report work, not why cleaning ended; stopped "
                     "rooms can also be reported completed. Managed room_completed "
@@ -467,7 +465,8 @@ def _bounded_native_room_evidence(
         if cleaning_mode is not None
         else session.room_durations
     )
-    if cleaning_mode is None:
+    unscoped = cleaning_mode is None and bool(session.mode_results)
+    if cleaning_mode is None and not unscoped:
         completed = set(session.completed_rooms)
     for room, duration in room_durations:
         durations.setdefault(room, duration)
@@ -483,7 +482,7 @@ def _bounded_native_room_evidence(
             {
                 "room": room,
                 "visited": room in visited,
-                "completed": room in completed,
+                "completed": None if unscoped else room in completed,
                 "duration_seconds": durations.get(room),
             }
         )

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -1257,7 +1257,8 @@ async def _async_run_room(
                         continue
                     if outcome is RoomRunOutcome.STOPPED_IN_PLACE:
                         raise RoomStoppedInPlaceError(
-                            f"{room.name} ended in place without returning"
+                            f"{room.name} ended in place without returning; "
+                            "the stop cause is unconfirmed"
                         )
                     if outcome is RoomRunOutcome.INTERRUPTED:
                         raise RoomInterruptedError(
@@ -1731,7 +1732,8 @@ async def _async_run_leg(
                         break
                     if outcome is RoomRunOutcome.STOPPED_IN_PLACE:
                         raise RoomStoppedInPlaceError(
-                            f"{active_room.name} ended in place without returning"
+                            f"{active_room.name} ended in place without returning; "
+                            "the stop cause is unconfirmed"
                         )
                     # INTERRUPTED cannot occur here: the leg loop starts only
                     # after a confirmed in-room start, so the waiter is seeded
@@ -3022,13 +3024,12 @@ class RoomInterruptedError(HomeAssistantError):
 
 
 class RoomStoppedInPlaceError(RoomInterruptedError):
-    """The robot's task ended where it stood, so the room was not finished.
+    """The robot's task ended in place without a verified completion handoff.
 
-    Home Assistant saw the task end in place rather than return, which is
-    positive evidence that the room was stopped.  Late native reconciliation
-    is deliberately not scheduled for it: the robot reports a stopped room the
-    same way it reports a finished one, so a marker would credit exactly the
-    room this transition proves was interrupted.
+    This observation does not identify the stop source or prove a robot fault.
+    Late native reconciliation is deliberately not scheduled: the robot can
+    report a stopped room the same way it reports a finished one, so history
+    alone cannot resolve this terminal ambiguity safely.
     """
 
 

--- a/custom_components/matic_robot/strings.json
+++ b/custom_components/matic_robot/strings.json
@@ -1184,7 +1184,7 @@
       "message": "The robot could not complete the requested command."
     },
     "room_interrupted": {
-      "message": "{room} stopped without verified completion."
+      "message": "Cleaning in {room} ended without verified completion."
     },
     "room_taken_over": {
       "message": "The original cleaning task in {room} could no longer be verified. The plan was interrupted."

--- a/custom_components/matic_robot/translations/en.json
+++ b/custom_components/matic_robot/translations/en.json
@@ -1184,7 +1184,7 @@
       "message": "The robot could not complete the requested command."
     },
     "room_interrupted": {
-      "message": "{room} stopped without verified completion."
+      "message": "Cleaning in {room} ended without verified completion."
     },
     "room_taken_over": {
       "message": "The original cleaning task in {room} could no longer be verified. The plan was interrupted."

--- a/docs/activity-diagnostics.md
+++ b/docs/activity-diagnostics.md
@@ -6,8 +6,8 @@ When the robot briefly reports returning to dock or stops before finishing a
 plan, download the integration diagnostics soon afterward. `activity_observations`
 contains the last 512 command and state observations from the current integration
 load. Older observations are evicted; reloading or restarting clears this buffer.
-The administrator-only `MaticGetRecentEvents` tool also shows recent observations
-among its last 64 operational events.
+The administrator-only `MaticGetActivity` tool reads this journal directly;
+`MaticGetRecentEvents` mixes recent observations into its last 64 operational events.
 
 The integration emits `matic_robot_activity_observed` events locally. Home
 Assistant Recorder can retain these across restarts according to its event
@@ -34,6 +34,32 @@ integration did not request docking during that observed interval. It cannot
 distinguish an OEM-app command, a physical control, or an internal robot decision.
 Check for subscription gaps, missing sequences, and restarts before drawing that
 conclusion. These observations do not recover activity from before installation.
+
+## Inspecting a run through MCP
+
+Call `MaticGetActivity` with `kind: commands` to list integration command attempts
+and results. Use `kind: states`, `stream`, or `all` for state changes and stream
+boundaries. Every response identifies the integration load, earliest and latest
+available sequences and receipt times, and whether older observations were evicted.
+
+If `has_more` is true, pass `next_before_sequence` as `before_sequence`, together
+with the returned `observation_session` and the same `kind`. Pagination rejects a
+changed integration load. Compare available windows across pages: eviction during
+inspection can remove older evidence. An empty command page cannot explain events
+outside its available window. Use Recorder for older evidence when retained.
+
+Read `MaticGetNativeHistory` with the run's `cleaning_mode`: `vacuum`, `mop`, or
+`vacuum_and_mop`. Room completion and duration apply to the returned
+`completion_scope`. Without a mode, native per-mode records retain their combined
+scope; zero combined completions does not mean a vacuum-only run failed.
+
+Report three separate facts: what cleaning the native history reports, which
+integration commands were requested, and where the robot ended up. An intentional
+stop followed by verified docking is a successful stop outcome. It does not prove
+every room finished. An ended-in-place interruption records missing managed
+completion evidence; it does not identify who stopped the robot or prove a fault.
+Native firmware can also report a stopped room as completed, so history alone
+does not override that guard or retrospectively award managed completion credit.
 
 For a controlled reproduction, supervise one plan with presence automation
 temporarily disabled and avoid OEM-app or physical-control input. Note any

--- a/docs/activity-diagnostics.md
+++ b/docs/activity-diagnostics.md
@@ -50,8 +50,10 @@ outside its available window. Use Recorder for older evidence when retained.
 
 Read `MaticGetNativeHistory` with the run's `cleaning_mode`: `vacuum`, `mop`, or
 `vacuum_and_mop`. Room completion and duration apply to the returned
-`completion_scope`. Without a mode, native per-mode records retain their combined
-scope; zero combined completions does not mean a vacuum-only run failed.
+`completion_scope`. Without a mode, native per-mode records have unspecified scope
+and nullable completion flags; durations total the reported modes. Missing or
+unattempted modes do not identify which work the user requested. A zero count in
+the older native room summary does not mean a vacuum-only run failed.
 
 Report three separate facts: what cleaning the native history reports, which
 integration commands were requested, and where the robot ended up. An intentional

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -76,6 +76,6 @@ IDs where possible; subsequent user-assigned names are preserved.
 
 Administrator-only MCP tools provide live runner status, plan order/settings,
 recent native history, and recent events: `MaticGetOperations`, `MaticGetPlan`,
-`MaticGetNativeHistory`, and `MaticGetRecentEvents`.
+`MaticGetNativeHistory`, `MaticGetRecentEvents`, and `MaticGetActivity`.
 Recent events include the [command and raw-state observation trail](activity-diagnostics.md).
 Dust-bag observations are currently available through `MaticGetOperations` only.

--- a/docs/native-cleaning-results.md
+++ b/docs/native-cleaning-results.md
@@ -20,10 +20,11 @@ The `latest_mode_results` sensor attribute is available live but excluded from
 Recorder. Administrator-only MCP history includes the same per-mode detail.
 
 For MCP history, supply `cleaning_mode` so the completion flags and durations
-match the work requested. `completion_scope` labels the selected mode; without
-one, native results use the combined vacuum-and-mop scope. Finished events retain
-their existing combined room list and also provide separate positive-duration
-vacuum, mop, and combined completion counts.
+match the work requested. Without one, native per-mode results have unspecified
+scope and nullable completion flags. Finished events retain their existing native
+room summary, explicitly labeled as such, and provide separate positive-duration
+vacuum, mop, and combined completion counts. The native summary does not identify
+the mode requested by a plan.
 
 A native result does not identify why a mission ended. Firmware can report a
 stopped room as completed; managed plans also verify ownership and the terminal

--- a/docs/native-cleaning-results.md
+++ b/docs/native-cleaning-results.md
@@ -18,3 +18,14 @@ Partial or completed work affects rotation priority; unattempted work does not.
 For completion automations, use `matic_robot_room_completed` or **Last cleaned**.
 The `latest_mode_results` sensor attribute is available live but excluded from
 Recorder. Administrator-only MCP history includes the same per-mode detail.
+
+For MCP history, supply `cleaning_mode` so the completion flags and durations
+match the work requested. `completion_scope` labels the selected mode; without
+one, native results use the combined vacuum-and-mop scope. Finished events retain
+their existing combined room list and also provide separate positive-duration
+vacuum, mop, and combined completion counts.
+
+A native result does not identify why a mission ended. Firmware can report a
+stopped room as completed; managed plans also verify ownership and the terminal
+transition. A requested stop followed by docking can succeed while unfinished
+rooms remain due. See [activity diagnostics](activity-diagnostics.md).

--- a/docs/release-notes-0.4.3.md
+++ b/docs/release-notes-0.4.3.md
@@ -15,3 +15,12 @@ Assistant events follow Recorder retention settings.
 
 See [Activity diagnostics](activity-diagnostics.md) for interpretation and a
 controlled reproduction procedure.
+
+🧹 **Read results for the cleaning mode you requested.** MCP history now accepts
+vacuum, mop, or combined mode and labels its completion scope. Finished events
+include separate mode counts, so vacuum-only work is not mistaken for a failed
+combined clean.
+
+📋 **Inspect the retained command timeline directly.** `MaticGetActivity` supports
+command/state filters, pagination, and explicit retention boundaries. Reports
+distinguish a successful stop and return to dock from completing every room.

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -20,6 +20,7 @@ from custom_components.matic_robot.client.exceptions import (
 )
 from custom_components.matic_robot.client.mission import MissionClientState
 from custom_components.matic_robot.client.models import (
+    CleaningModeResult,
     CleaningSession,
     CuesGestureStatus,
     CuesIntent,
@@ -784,6 +785,53 @@ async def test_transient_sweep_failures_defer_then_record_degraded(hass) -> None
     assert coordinator._snapshot_attempts == {}
 
 
+async def test_cleaning_finished_reports_mode_counts_without_calling_vacuum_failed(
+    hass,
+) -> None:
+    from pytest_homeassistant_custom_component.common import async_capture_events
+
+    from custom_components.matic_robot.const import EVENT_CLEANING_FINISHED
+    from custom_components.matic_robot.llm import MaticOperationsAPI
+
+    client = _client()
+    with patch(
+        "custom_components.matic_robot.coordinator.dt_util.utcnow",
+        return_value=datetime(2026, 7, 20, 1, tzinfo=UTC),
+    ):
+        coordinator = _coordinator(hass, client)
+    events = async_capture_events(hass, EVENT_CLEANING_FINISHED)
+    client.async_get_telemetry.return_value = RobotTelemetry(
+        latest_session=CleaningSession(
+            "2026-07-20T01:10:00+00:00",
+            "2026-07-20T01:30:00+00:00",
+            1200,
+            ("Study", "Gallery", "Den"),
+            (("Study", 120), ("Gallery", 300)),
+            None,
+            vacuum_completed_rooms=("Study",),
+            mode_results=(
+                CleaningModeResult("Study", "vacuum", "completed", 120),
+                CleaningModeResult("Gallery", "vacuum", "partial", 300),
+                CleaningModeResult("Den", "vacuum", "unattempted", 0),
+            ),
+        )
+    )
+    await coordinator._async_update_data()
+    await hass.async_block_till_done()
+    assert len(events) == 1
+    event = events[0]
+    assert event.data["completed_rooms"] == []
+    assert event.data["completion_scope"] == "vacuum_and_mop"
+    assert event.data["vacuum_completed_room_count"] == 1
+    assert event.data["mop_completed_room_count"] == 0
+    assert event.data["combined_completed_room_count"] == 0
+    api = MaticOperationsAPI(hass)
+    api._async_capture_event(event)
+    assert api.recent_events[-1]["data"]["vacuum_completed_room_count"] == 1
+    assert api.recent_events[-1]["data"]["completion_scope"] == "vacuum_and_mop"
+    assert "Study" not in str(api.recent_events)
+
+
 async def test_cleaning_finished_event_fires_once_per_new_session(hass) -> None:
     from pytest_homeassistant_custom_component.common import async_capture_events
 
@@ -827,6 +875,7 @@ async def test_cleaning_finished_event_fires_once_per_new_session(hass) -> None:
     assert len(events) == 1
     assert events[0].data["duration_seconds"] == 1800
     assert events[0].data["completed_rooms"] == ["Study"]
+    assert events[0].data["completion_scope"] == "legacy"
     assert events[0].data["room_durations"] == {"Study": 1800}
     assert events[0].data["firmware_version"] == "v168.11"
     assert events[0].data["entry_id"] == "entry"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -20,7 +20,6 @@ from custom_components.matic_robot.client.exceptions import (
 )
 from custom_components.matic_robot.client.mission import MissionClientState
 from custom_components.matic_robot.client.models import (
-    CleaningModeResult,
     CleaningSession,
     CuesGestureStatus,
     CuesIntent,
@@ -790,8 +789,10 @@ async def test_cleaning_finished_reports_mode_counts_without_calling_vacuum_fail
 ) -> None:
     from pytest_homeassistant_custom_component.common import async_capture_events
 
+    from custom_components.matic_robot.client.api import _decode_cleaning_session
     from custom_components.matic_robot.const import EVENT_CLEANING_FINISHED
     from custom_components.matic_robot.llm import MaticOperationsAPI
+    from tests.wire_builders import _bfield, _vfield
 
     client = _client()
     with patch(
@@ -800,35 +801,37 @@ async def test_cleaning_finished_reports_mode_counts_without_calling_vacuum_fail
     ):
         coordinator = _coordinator(hass, client)
     events = async_capture_events(hass, EVENT_CLEANING_FINISHED)
-    client.async_get_telemetry.return_value = RobotTelemetry(
-        latest_session=CleaningSession(
-            "2026-07-20T01:10:00+00:00",
-            "2026-07-20T01:30:00+00:00",
-            1200,
-            ("Study", "Gallery", "Den"),
-            (("Study", 120), ("Gallery", 300)),
-            None,
-            vacuum_completed_rooms=("Study",),
-            mode_results=(
-                CleaningModeResult("Study", "vacuum", "completed", 120),
-                CleaningModeResult("Gallery", "vacuum", "partial", 300),
-                CleaningModeResult("Den", "vacuum", "unattempted", 0),
-            ),
-        )
+    summary = _bfield(3, _bfield(1, _vfield(1, 1784509800))) + _bfield(
+        4, _bfield(1, _vfield(1, 1784511000))
     )
+    for name, status, duration in (
+        ("Study", 2, 120),
+        ("Gallery", 1, 300),
+        ("Den", 0, 0),
+    ):
+        detail = (
+            _bfield(3, name.encode())
+            + _bfield(4, _vfield(1, duration))
+            + _vfield(5, status)
+        )
+        summary += _bfield(6, _bfield(1, _bfield(2, detail)))
+    session = _decode_cleaning_session(_bfield(5, summary))
+    assert session.completed_rooms == ("Study",)
+    assert session.combined_completed_rooms == ()
+    client.async_get_telemetry.return_value = RobotTelemetry(latest_session=session)
     await coordinator._async_update_data()
     await hass.async_block_till_done()
     assert len(events) == 1
     event = events[0]
-    assert event.data["completed_rooms"] == []
-    assert event.data["completion_scope"] == "vacuum_and_mop"
+    assert event.data["completed_rooms"] == ["Study"]
+    assert event.data["completion_scope"] == "native_room_summary"
     assert event.data["vacuum_completed_room_count"] == 1
     assert event.data["mop_completed_room_count"] == 0
     assert event.data["combined_completed_room_count"] == 0
     api = MaticOperationsAPI(hass)
     api._async_capture_event(event)
     assert api.recent_events[-1]["data"]["vacuum_completed_room_count"] == 1
-    assert api.recent_events[-1]["data"]["completion_scope"] == "vacuum_and_mop"
+    assert api.recent_events[-1]["data"]["completion_scope"] == "native_room_summary"
     assert "Study" not in str(api.recent_events)
 
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -641,7 +641,7 @@ async def test_native_history_scopes_completion_to_the_requested_mode() -> None:
     hass = _hass(entry)
     tool = MaticGetNativeHistoryTool(MaticOperationsAPI(hass))
     for mode, expected, durations in (
-        (None, [False, False], [120, 200]),
+        (None, [None, None], [120, 200]),
         ("vacuum", [True, True], [120, 200]),
         ("mop", [False, False], [None, 40]),
         ("vacuum_and_mop", [False, False], [120, 240]),
@@ -652,12 +652,12 @@ async def test_native_history_scopes_completion_to_the_requested_mode() -> None:
             _context(),
         )
         session = result["sessions"][0]
-        assert session["completion_scope"] == (mode or "vacuum_and_mop")
+        assert session["completion_scope"] == (mode or "unspecified")
         assert [room["completed"] for room in session["room_evidence"]] == expected
         assert [
             room["duration_seconds"] for room in session["room_evidence"]
         ] == durations
-        assert "false does not mean" in result["completion_authority"]
+        assert "Do not infer the requested mode" in result["completion_authority"]
         assert "not why cleaning ended" in result["completion_authority"]
     with pytest.raises(vol.Invalid):
         await tool.async_call(

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -13,6 +13,7 @@ from homeassistant.helpers import llm
 
 from custom_components.matic_robot.client.exceptions import CannotConnectError
 from custom_components.matic_robot.client.models import (
+    CleaningModeResult,
     CleaningSession,
     CleaningSessionRecord,
     FloorPlan,
@@ -22,11 +23,16 @@ from custom_components.matic_robot.client.models import (
     RobotTelemetry,
     Room,
 )
+from custom_components.matic_robot.client.observations import (
+    MAX_OBSERVATIONS,
+    ActivityJournal,
+)
 from custom_components.matic_robot.llm import (
     LLM_API_ID,
     MAX_NATIVE_HISTORY_ROOM_EVIDENCE,
     MAX_NATIVE_HISTORY_ROOM_EVIDENCE_BYTES,
     MAX_RECENT_EVENTS,
+    MaticGetActivityTool,
     MaticGetNativeHistoryTool,
     MaticGetOperationsTool,
     MaticGetPlanTool,
@@ -292,6 +298,7 @@ async def test_api_registration_event_capture_and_admin_gate() -> None:
         "MaticGetPlan",
         "MaticGetNativeHistory",
         "MaticGetRecentEvents",
+        "MaticGetActivity",
     ]
 
     with patch("custom_components.matic_robot.llm.llm.async_register_api") as register:
@@ -608,3 +615,143 @@ async def test_recent_events_returns_newest_first_and_honors_limit() -> None:
         f"Room {MAX_RECENT_EVENTS - 1}",
     ]
     assert "current Home Assistant process" in result["retention"]
+
+
+async def test_native_history_scopes_completion_to_the_requested_mode() -> None:
+    entry = _entry()
+    entry.runtime_data.client.async_get_cleaning_session_records.return_value = (
+        CleaningSessionRecord(
+            b"synthetic-key",
+            CleaningSession(
+                "2026-08-25T20:00:00+00:00",
+                "2026-08-25T20:10:00+00:00",
+                600,
+                ("Study", "Gallery"),
+                (("Study", 120), ("Gallery", 200)),
+                None,
+                vacuum_completed_rooms=("Study", "Gallery"),
+                mode_results=(
+                    CleaningModeResult("Study", "vacuum", "completed", 120),
+                    CleaningModeResult("Gallery", "vacuum", "completed", 200),
+                    CleaningModeResult("Gallery", "mop", "partial", 40),
+                ),
+            ),
+        ),
+    )
+    hass = _hass(entry)
+    tool = MaticGetNativeHistoryTool(MaticOperationsAPI(hass))
+    for mode, expected, durations in (
+        (None, [False, False], [120, 200]),
+        ("vacuum", [True, True], [120, 200]),
+        ("mop", [False, False], [None, 40]),
+        ("vacuum_and_mop", [False, False], [120, 240]),
+    ):
+        result = await tool.async_call(
+            hass,
+            llm.ToolInput(tool.name, {} if mode is None else {"cleaning_mode": mode}),
+            _context(),
+        )
+        session = result["sessions"][0]
+        assert session["completion_scope"] == (mode or "vacuum_and_mop")
+        assert [room["completed"] for room in session["room_evidence"]] == expected
+        assert [
+            room["duration_seconds"] for room in session["room_evidence"]
+        ] == durations
+        assert "false does not mean" in result["completion_authority"]
+        assert "not why cleaning ended" in result["completion_authority"]
+    with pytest.raises(vol.Invalid):
+        await tool.async_call(
+            hass, llm.ToolInput(tool.name, {"cleaning_mode": "unknown"}), _context()
+        )
+
+
+async def test_activity_journal_pagination_filtering_and_restart_guards() -> None:
+    entry = _entry()
+    journal = entry.runtime_data.client.activity_journal = ActivityJournal()
+    journal.record("command_requested", command="STOP", channel="user_command")
+    journal.record("command_sending", command_id=2, channel="user_command")
+    journal.record(
+        "command_result", command_id=2, command="STOP", outcome="acknowledged"
+    )
+    journal.record("state_stream_started", source="push")
+    journal.record(
+        "state", source="push", activity="ready", state_codes=[109], error_codes=[]
+    )
+    journal.record("state_stream_ended", source="push")
+    journal.record("command_requested", command="DOCK", channel="user_command")
+    journal.record("command_result", command_id=8, command="DOCK", outcome="failed")
+    hass = _hass(entry)
+    tool = MaticGetActivityTool(MaticOperationsAPI(hass))
+
+    async def read(**args):
+        return await tool.async_call(hass, llm.ToolInput(tool.name, args), _context())
+
+    result = await read(limit=2)
+    assert [item["sequence"] for item in result["observations"]] == [9, 8]
+    assert result["has_more"] is True
+    assert result["next_before_sequence"] == 8
+    assert result["first_available_sequence"] == 1
+    assert result["last_available_sequence"] == 9
+    assert result["older_observations_evicted"] is False
+    assert result["retained_observations"] == 9
+    older = await read(
+        before_sequence=8, observation_session=result["observation_session"]
+    )
+    assert [item["sequence"] for item in older["observations"]] == [4, 3, 2]
+    assert older["has_more"] is False
+    assert older["next_before_sequence"] is None
+    assert [
+        item["sequence"] for item in (await read(kind="states"))["observations"]
+    ] == [6]
+    assert [
+        item["sequence"] for item in (await read(kind="stream"))["observations"]
+    ] == [7, 5]
+    assert len((await read(kind="all"))["observations"]) == 9
+    assert not (
+        await read(before_sequence=1, observation_session=result["observation_session"])
+    )["observations"]
+    with pytest.raises(HomeAssistantError, match="requires observation_session"):
+        await read(before_sequence=8)
+    entry.runtime_data.client.activity_journal = ActivityJournal()
+    with pytest.raises(HomeAssistantError, match="restarted"):
+        await read(before_sequence=8, observation_session=result["observation_session"])
+    for invalid in (
+        {"limit": 129},
+        {"kind": "payload"},
+        {"observation_session": "bad"},
+        {"before_sequence": 0},
+    ):
+        with pytest.raises(vol.Invalid):
+            await read(**invalid)
+    entry.runtime_data.client.async_get_cleaning_session_records.assert_not_called()
+
+
+async def test_activity_journal_eviction_and_output_privacy() -> None:
+    entry = _entry()
+    journal = entry.runtime_data.client.activity_journal = ActivityJournal()
+    for _ in range(MAX_OBSERVATIONS):
+        journal.record("state", activity="ready", state_codes=[109], error_codes=[])
+    journal.record(
+        "command_result",
+        command="DOCK",
+        outcome="failed",
+        error_type="x" * 400,
+        channel={"private": "must-not-appear"},
+        payload="must-not-appear",
+        state_codes=[True],
+        error_codes="must-not-appear",
+    )
+    hass = _hass(entry)
+    result = await MaticGetActivityTool(MaticOperationsAPI(hass)).async_call(
+        hass, llm.ToolInput("MaticGetActivity", {"kind": "all", "limit": 2}), _context()
+    )
+    assert result["older_observations_evicted"] is True
+    assert result["first_available_sequence"] == 3
+    assert result["retained_observations"] == MAX_OBSERVATIONS
+    assert result["buffer_limit"] == MAX_OBSERVATIONS
+    assert "must-not-appear" not in str(result)
+    assert len(result["observations"][0]["error_type"]) == 256
+    assert "state_codes" not in result["observations"][0]
+    assert result["observations"][1]["state_codes"] == [109]
+    result["observations"][1]["state_codes"].append(1)
+    assert journal.snapshot[-2]["state_codes"] == [109]

--- a/tests/test_native_completion_modes.py
+++ b/tests/test_native_completion_modes.py
@@ -124,6 +124,34 @@ def test_coverage_setting_is_not_cleaning_status(setting):
     assert session.combined_completed_rooms == ()
 
 
+@pytest.mark.parametrize("mop_status", [None, 0, 1, 2])
+def test_unscoped_history_does_not_infer_requested_modes_from_native_summaries(
+    mop_status,
+):
+    from custom_components.matic_robot.llm import _bounded_native_room_evidence
+
+    session = _decode_cleaning_session(
+        _session_payload(
+            _vfield(5, 2),
+            mop_statuses=None if mop_status is None else _vfield(5, mop_status),
+        )
+    )
+    # A native single-mode room summary can be true while combined proof is
+    # absent. Neither the summary nor missing mop data identifies user intent.
+    assert session.completed_rooms == (("Study",) if mop_status in (None, 2) else ())
+    generic, _, _, _ = _bounded_native_room_evidence(session, 20, 5000)
+    assert generic[0]["completed"] is None
+    vacuum, _, _, _ = _bounded_native_room_evidence(
+        session, 20, 5000, cleaning_mode="vacuum"
+    )
+    combined, _, _, _ = _bounded_native_room_evidence(
+        session, 20, 5000, cleaning_mode="vacuum_and_mop"
+    )
+    assert vacuum[0]["completed"] is True
+    assert vacuum[0]["duration_seconds"] == 30
+    assert combined[0]["completed"] is (mop_status == 2)
+
+
 @pytest.mark.parametrize(
     "mode", ["vacuum", "mop", "vacuum_and_mop", None, "unknown", 5]
 )
@@ -253,7 +281,7 @@ async def test_seven_room_partial_session_credits_only_completed_requested_modes
     assert reported["Store"]["visited"] is False
     assert reported["Utility"]["visited"] is False
     assert reported["Pantry"]["visited"] is True
-    assert reported["Pantry"]["completed"] is False
+    assert reported["Pantry"]["completed"] is None
     assert reported["Pantry"]["modes"]["mop"]["status"] == "unattempted"
 
     from types import SimpleNamespace


### PR DESCRIPTION
Native room summaries could be mistaken for the outcome of a vacuum-only or combined plan. History now accepts the requested cleaning mode and labels its scope. Without a mode, per-mode records return nullable completion flags instead of guessing intent. Finished events retain their native room summary, label it explicitly, and add separate positive-duration mode counts.

Add a read-only activity tool with bounded command/state filtering, sequence windows, pagination, eviction reporting, and restart guards. Clarify that requested stops, reported cleaning results, and successful docking are separate outcomes, and that an ended-in-place transition alone does not establish a robot fault or stop source. Cleaning commands and completion-credit safeguards are unchanged.

Validation: 1,571 Python tests passed at 100% coverage; Ruff, formatting, strict mypy, and public-tree privacy checks passed. Added decoder-backed coverage for vacuum-only/combined results, event summary propagation, pagination, reloads, eviction, and output redaction.
