### PR TITLE
Accept completed regular review summaries with fresh bot evidence

### DIFF
--- a/.github/scripts/review_summary.py
+++ b/.github/scripts/review_summary.py
@@ -1,0 +1,205 @@
+"""Read the connector's regular-review summary; never write GitHub state."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from datetime import datetime, timedelta
+from typing import Any
+
+BOT = "chatgpt-codex-connector[bot]"
+HEADER = "<!-- codex-pull-request-review-summary -->\n\n## Codex Review Summary\n"
+SHA = re.compile(r"[0-9a-f]{40}")
+COMMIT = re.compile(r"`([0-9a-f]{7,40})`")
+COMPLETED = re.compile(
+    r'✅ \*\*Completed\*\* <relative-time datetime="(?P<at>[^"<>]+)">'
+    r"(?P=at)</relative-time>"
+)
+
+
+def timestamp(value: Any) -> datetime | None:
+    """Accept only explicit UTC timestamps, including fractional seconds."""
+    if not isinstance(value, str) or not re.fullmatch(
+        r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z", value
+    ):
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def code_rows(body: str) -> tuple[tuple[str, ...], ...]:
+    """Recognize only the connector envelope and its regular Code Review rows."""
+    if not body.startswith(HEADER):
+        return ()
+    rows = []
+    for line in body.splitlines():
+        cells = tuple(cell.strip() for cell in line.split("|"))
+        if len(cells) >= 2 and cells[1] == "📝 **Code Review**":
+            rows.append(cells)
+    return tuple(rows)
+
+
+def matches_head(rows: tuple[tuple[str, ...], ...], head: str) -> bool:
+    """A prefix is sufficient to revoke a gate, but cannot grant approval."""
+    return any(
+        len(row) == 6
+        and (match := COMMIT.fullmatch(row[3])) is not None
+        and head.startswith(match[1])
+        for row in rows
+    )
+
+
+def changed_for_head(body: str, previous: str, action: str, head: str) -> bool:
+    """Ignore edits to independent Security Review rows in the same comment."""
+    current_rows, previous_rows = code_rows(body), code_rows(previous)
+    relevant = matches_head(current_rows, head) or matches_head(previous_rows, head)
+    return relevant and (action != "edited" or current_rows != previous_rows)
+
+
+def completed_for_head(body: str, action: str, head: str) -> bool:
+    """Only omit a persistent invalidation; the evaluator must still approve."""
+    rows = code_rows(body)
+    return (
+        action != "deleted"
+        and len(rows) == 1
+        and matches_head(rows, head)
+        and (completed := COMPLETED.fullmatch(rows[0][2])) is not None
+        and timestamp(completed["at"]) is not None
+    )
+
+
+def api(path: str, *, paginate: bool = False) -> Any:
+    """Use the existing workflow identity for bounded, read-only metadata calls."""
+    command = ["gh", "api", "--method", "GET", path]
+    if paginate:
+        command.extend(("--paginate", "--slurp"))
+    result = subprocess.run(command, check=True, capture_output=True, text=True)
+    value = json.loads(result.stdout)
+    return [item for page in value for item in page] if paginate else value
+
+
+def records(
+    comments: list[dict[str, Any]],
+    reactions: list[dict[str, Any]],
+    head: str,
+    resolved: dict[str, str],
+) -> list[dict[str, Any]]:
+    """Pair one current-head summary with a fresh, authenticated bot reaction."""
+    candidates = [
+        comment
+        for comment in comments
+        if comment.get("user", {}).get("login") == BOT
+        and isinstance(comment.get("body"), str)
+        and matches_head(code_rows(comment["body"]), head)
+    ]
+    result = []
+    for comment in candidates:
+        updated = timestamp(comment.get("updated_at"))
+        comment_id = comment.get("id")
+        if updated is None or type(comment_id) is not int or comment_id <= 0:
+            raise ValueError("Malformed trusted review summary metadata")
+        record = {
+            "at": updated.isoformat().replace("+00:00", "Z"),
+            "id": f"review-summary-{comment_id}-0",
+            "source": "review_summary",
+            "clean": False,
+        }
+        result.append(record)
+        rows = code_rows(comment["body"])
+        # Conflicting summaries/duplicate regular rows are not affirmative proof.
+        if len(candidates) != 1 or len(rows) != 1 or len(rows[0]) != 6:
+            continue
+        row = rows[0]
+        commit = COMMIT.fullmatch(row[3])
+        completed = COMPLETED.fullmatch(row[2])
+        if commit is None or completed is None or resolved.get(commit[1]) != head:
+            continue
+        completed_at = timestamp(completed["at"])
+        if completed_at is None or completed_at >= updated + timedelta(seconds=1):
+            continue
+        eligible = [
+            reaction
+            for reaction in reactions
+            if reaction.get("user", {}).get("login") == BOT
+            and reaction.get("content") == "+1"
+            and type(reaction.get("id")) is int
+            and reaction["id"] > 0
+            and (created := timestamp(reaction.get("created_at"))) is not None
+            and created > completed_at
+        ]
+        if not eligible:
+            continue
+        reaction = max(eligible, key=lambda value: value["created_at"])
+        record.update(
+            at=reaction["created_at"],
+            id=f"review-summary-{comment_id}-{reaction['id']}",
+            completed_at=completed["at"],
+            clean=True,
+        )
+    return result
+
+
+def collect(repo: str, number: str, head: str, bot: str) -> list[dict[str, Any]]:
+    """Resolve every abbreviated commit through GitHub before accepting it."""
+    if bot != BOT:
+        return []
+    comments = api(f"repos/{repo}/issues/{number}/comments?per_page=100", paginate=True)
+    prefixes = {
+        match[1]
+        for comment in comments
+        if comment.get("user", {}).get("login") == BOT
+        and isinstance(comment.get("body"), str)
+        for row in code_rows(comment["body"])
+        if len(row) == 6
+        and (match := COMMIT.fullmatch(row[3])) is not None
+        and head.startswith(match[1])
+    }
+    if not prefixes:
+        return []
+    resolved = {
+        prefix: api(f"repos/{repo}/commits/{prefix}").get("sha", "")
+        for prefix in prefixes
+    }
+    reactions = api(
+        f"repos/{repo}/issues/{number}/reactions?per_page=100", paginate=True
+    )
+    return records(comments, reactions, head, resolved)
+
+
+def main() -> None:
+    """Run the read-only workflow adapter or classify one comment delivery."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("operation", choices=("records", "classify"))
+    parser.add_argument("--head", required=True)
+    args = parser.parse_args()
+    if not SHA.fullmatch(args.head):
+        parser.error("A full current-head SHA is required")
+    if args.operation == "classify":
+        body = os.environ.get("EVENT_COMMENT_BODY", "")
+        action = os.environ.get("EVENT_ACTION", "")
+        value = {
+            "regular": changed_for_head(
+                body,
+                os.environ.get("EVENT_PREVIOUS_COMMENT_BODY", ""),
+                action,
+                args.head,
+            ),
+            "completed": completed_for_head(body, action, args.head),
+        }
+    else:
+        repo, number = os.environ["REPO"], os.environ["PR_NUMBER"]
+        if not re.fullmatch(
+            r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repo
+        ) or not re.fullmatch(r"[1-9][0-9]*", number):
+            parser.error("A repository and positive pull request number are required")
+        value = collect(repo, number, args.head, os.environ["REVIEW_BOT_EVENT_LOGIN"])
+    print(json.dumps(value))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/review-gate-audit.yml
+++ b/.github/workflows/review-gate-audit.yml
@@ -62,10 +62,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ matrix.pr_number }}
+          REVIEW_WORKFLOW_SHA: ${{ github.workflow_sha }}
           REPO: ${{ github.repository }}
           REVIEW_BOT_LOGIN: ${{ vars.REVIEW_PROVIDER == 'claude' && 'github-actions' || 'chatgpt-codex-connector' }}
           REVIEW_BOT_EVENT_LOGIN: ${{ vars.REVIEW_PROVIDER == 'claude' && 'github-actions[bot]' || 'chatgpt-codex-connector[bot]' }}
           REVIEW_GATE_CONTEXT: review-gate
+          REVIEW_COMMENT_CONTEXT: review-gate-regular-comment
           WORKFLOW_REF: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
@@ -195,16 +197,17 @@ jobs:
           active_regular_finding_count() {
             local pr_number="$1"
             local head_sha="$2"
+            local include_summaries="$3"
             local head_prefix="${head_sha:0:10}"
             review_owner="$(printf '%s' "$REPO" | cut -d/ -f1)"
             review_repo="$(printf '%s' "$REPO" | cut -d/ -f2)"
             # shellcheck disable=SC2016 # GraphQL expands these variables, not the shell.
             gh api graphql --paginate \
-              -f query='query($owner: String!, $name: String!, $number: Int!, $endCursor: String) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { reviewThreads(first: 100, after: $endCursor) { nodes { isResolved isOutdated comments(first: 100) { nodes { replyTo { databaseId } author { login } pullRequestReview { state body author { login } commit { oid } } } } pageInfo { hasNextPage endCursor } } } } } }' \
+              -f query='query($owner: String!, $name: String!, $number: Int!, $endCursor: String) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { reviewThreads(first: 100, after: $endCursor) { nodes { isResolved isOutdated comments(first: 100) { nodes { originalCommit { oid } replyTo { databaseId } author { login } pullRequestReview { state body author { login } commit { oid } } } } pageInfo { hasNextPage endCursor } } } } } }' \
               -F owner="$review_owner" \
               -F name="$review_repo" \
               -F number="$pr_number" \
-              | jq -rs --arg bot "$REVIEW_BOT_LOGIN" --arg head "$head_sha" --arg prefix "$head_prefix" '
+              | jq -rs --arg bot "$REVIEW_BOT_LOGIN" --arg head "$head_sha" --arg prefix "$head_prefix" --argjson include_summaries "$include_summaries" '
                   def regular_heading:
                     ascii_downcase
                     | test("(?mi)^[[:space:]]*(?:#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?)?codex review(?:[[:space:]]*:|[[:space:]]|$)|^[[:space:]]*(?:#{1,6}[[:space:]]+)?review result(?:[[:space:]]*:|[[:space:]]|$)");
@@ -230,13 +233,17 @@ jobs:
                    | select(.pullRequestReview != null)
                    | select((.pullRequestReview.author.login // "") == $bot)
                    | select((.pullRequestReview.state // "") != "DISMISSED")
-                   | select((.pullRequestReview.commit.oid // "") == $head)
+                   | select((.originalCommit.oid // .pullRequestReview.commit.oid // "") == $head)
                    | (.pullRequestReview.body // "") as $body
-                   | select($body | regular_heading)
-                   | select(($body | security_heading) | not)
-                   | select(($body | availability_notice) | not)
-                   | select($body | exact_head)
-                   | select($body | stock_clean_envelope)]
+                   | select(if $include_summaries then
+                       ($body | test("(?i)^[[:space:]]*#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?(?:Codex[[:space:]]+)?Security[[:space:]-]+Review") | not)
+                     else
+                       ($body | regular_heading)
+                       and ($body | security_heading | not)
+                       and ($body | availability_notice | not)
+                       and ($body | exact_head)
+                       and ($body | stock_clean_envelope)
+                     end)]
                   | length'
           }
 
@@ -245,20 +252,35 @@ jobs:
               | jq -er '.head.sha'
           )" || exit 0
           [[ "$head_sha" =~ ^[0-9a-f]{40}$ && -n "$WORKFLOW_REF" ]] || exit 0
+          [[ "$REVIEW_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]] || exit 1
+          review_summary_script="$(mktemp "$RUNNER_TEMP/review-summary.XXXXXX")"
+          trap 'rm -f "$review_summary_script"' EXIT
+          if ! gh api --method GET -H 'Accept: application/vnd.github.raw+json' \
+            "repos/$REPO/contents/.github/scripts/review_summary.py?ref=$REVIEW_WORKFLOW_SHA" \
+            > "$review_summary_script"; then
+            stamp_pending "$head_sha" "Trusted review summary reader is unavailable"
+            exit 1
+          fi
+
           gate_snapshot="$(current_gate_snapshot "$head_sha")"
           gate_state="$(jq -r '.state' <<< "$gate_snapshot")"
           gate_updated_at="$(jq -r '.updated_at // empty' <<< "$gate_snapshot")"
           gate_description="$(jq -r '.description // empty' <<< "$gate_snapshot")"
           comment_records="$(current_regular_comment_records "$head_sha")"
           review_records="$(current_regular_review_records "$head_sha")"
-          evidence_records="$(jq -cn --argjson comments "$comment_records" --argjson reviews "$review_records" '$comments + $reviews')"
+          if ! summary_records="$(python3 "$review_summary_script" records --head "$head_sha" | jq '[.[] | {id: (.id | capture("^review-summary-(?<comment>[0-9]+)-(?<reaction>[0-9]+)$") | "review-summary:\(.comment):\(.reaction)"), at}]')"; then
+            stamp_pending "$head_sha" "Current review summary evidence is unavailable"
+            exit 1
+          fi
+          include_summaries="$(jq 'length > 0' <<< "$summary_records")"
+          evidence_records="$(jq -cn --argjson comments "$comment_records" --argjson reviews "$review_records" --argjson summaries "$summary_records" '$comments + $reviews + $summaries')"
           latest_evidence_at="$(jq -r '[.[].at] | max // empty' <<< "$evidence_records")"
           evidence_ids="$(jq -c '[.[].id]' <<< "$evidence_records")"
           evidence_marker="$(
             jq -r '
               (.description // "") as $description
-              | if ($description | test("; evidence (review|issue-comment):[1-9][0-9]*$")) then
-                  ($description | capture("; evidence (?<id>(?:review|issue-comment):[1-9][0-9]*)$").id)
+              | if ($description | test("; evidence (?:(?:review|issue-comment):[1-9][0-9]*|review-summary:[1-9][0-9]*:[1-9][0-9]*)$")) then
+                  ($description | capture("; evidence (?<id>(?:(?:review|issue-comment):[1-9][0-9]*|review-summary:[1-9][0-9]*:[1-9][0-9]*))$").id)
                 else
                   ""
                 end' <<< "$gate_snapshot"
@@ -279,6 +301,12 @@ jobs:
           elif [[ "$gate_state" == "success" && -n "$evidence_marker" ]] && ! jq -e --arg evidence "$evidence_marker" 'index($evidence) != null' <<< "$evidence_ids" >/dev/null; then
             needs_reconciliation=true
             reconciliation_reason="clean normal evidence that is no longer current"
+            if [[ "$evidence_marker" == review-summary:* ]]; then
+              invalidated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+              gh api "repos/$REPO/statuses/$head_sha" --silent \
+                -f state=pending -f context="$REVIEW_COMMENT_CONTEXT" \
+                -f description="Regular issue-comment invalidated at $invalidated_at; summary evidence was withdrawn"
+            fi
           elif [[ "$gate_state" == "success" && -z "$evidence_marker" ]]; then
             needs_reconciliation=true
             reconciliation_reason="legacy clean normal evidence"
@@ -295,7 +323,7 @@ jobs:
           if [[ "$gate_state" != "success" ]]; then
             exit 0
           fi
-          findings="$(active_regular_finding_count "$PR_NUMBER" "$head_sha")"
+          findings="$(active_regular_finding_count "$PR_NUMBER" "$head_sha" "$include_summaries")"
           if [[ "$findings" -eq 0 ]]; then
             exit 0
           fi
@@ -305,7 +333,7 @@ jobs:
           if [[ "$(jq -r '.state' <<< "$gate_snapshot")" != "success" ]]; then
             exit 0
           fi
-          findings="$(active_regular_finding_count "$PR_NUMBER" "$head_sha")"
+          findings="$(active_regular_finding_count "$PR_NUMBER" "$head_sha" "$include_summaries")"
           if [[ "$findings" -eq 0 ]]; then
             exit 0
           fi

--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -43,6 +43,7 @@ jobs:
           EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           REPO: ${{ github.repository }}
+          REVIEW_WORKFLOW_SHA: ${{ github.workflow_sha }}
           REVIEW_BOT: ${{ vars.REVIEW_PROVIDER == 'claude' && 'github-actions[bot]' || 'chatgpt-codex-connector[bot]' }}
           REVIEW_BOT_LOGIN: ${{ vars.REVIEW_PROVIDER == 'claude' && 'github-actions' || 'chatgpt-codex-connector' }}
           REVIEW_BOT_EVENT_LOGIN: ${{ vars.REVIEW_PROVIDER == 'claude' && 'github-actions[bot]' || 'chatgpt-codex-connector[bot]' }}
@@ -220,7 +221,7 @@ jobs:
           # comments can qualify. Findings-bearing issue comments invalidate;
           # security review results and availability notices are ignored.
           regular_evidence() {
-            local review_records issue_comment_records
+            local review_records issue_comment_records summary_records
             review_records="$(
               # shellcheck disable=SC2016 # GraphQL expands these variables, not the shell.
               gh api graphql --paginate \
@@ -293,37 +294,44 @@ jobs:
                         source: "issue_comment",
                         clean: ($body | stock_clean_issue_comment_envelope)}]'
             )"
-            jq -cn --argjson reviews "$review_records" --argjson issue_comments "$issue_comment_records" '
-              {deliveries: ($reviews + $issue_comments),
+            summary_records="$(PR_NUMBER="$pr_number" python3 "$review_summary_script" records --head "$head_sha")"
+            jq -cn --argjson reviews "$review_records" --argjson issue_comments "$issue_comment_records" --argjson summaries "$summary_records" '
+              {deliveries: ($reviews + $issue_comments + $summaries),
                review_ids: [$reviews[].id]}'
           }
 
           regular_review_thread_summary() {
             local review_ids="$1"
+            local include_summaries="$2"
             # shellcheck disable=SC2016 # GraphQL expands these variables, not the shell.
             gh api graphql --paginate \
-              -f query='query($owner: String!, $name: String!, $number: Int!, $endCursor: String) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { reviewThreads(first: 100, after: $endCursor) { nodes { isResolved isOutdated comments(first: 100) { nodes { commit { oid } originalCommit { oid } replyTo { databaseId } pullRequestReview { databaseId } author { login } } } } pageInfo { hasNextPage endCursor } } } } }' \
+              -f query='query($owner: String!, $name: String!, $number: Int!, $endCursor: String) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { reviewThreads(first: 100, after: $endCursor) { nodes { isResolved isOutdated comments(first: 100) { nodes { updatedAt commit { oid } originalCommit { oid } replyTo { databaseId } pullRequestReview { databaseId body } author { login } } } } pageInfo { hasNextPage endCursor } } } } }' \
               -F owner="$review_owner" \
               -F name="$review_repo" \
               -F number="$pr_number" \
-              | jq -rs --argjson review_ids "$review_ids" --arg bot "$REVIEW_BOT_LOGIN" --arg head "$head_sha" '
+              | jq -rs --argjson review_ids "$review_ids" --argjson include_summaries "$include_summaries" --arg bot "$REVIEW_BOT_LOGIN" --arg head "$head_sha" '
                   [.[]
                    | .data.repository.pullRequest.reviewThreads.nodes[]? as $thread
                    | $thread.comments.nodes[]?
                    | select((.author.login // "") == $bot)
                    | select(.replyTo == null)
                    | select((((.pullRequestReview.databaseId // -1) | tostring) as $review_id
-                       | ($review_ids | index($review_id))) != null)
+                       | ($review_ids | index($review_id))) != null
+                       or ($include_summaries
+                           and ((.pullRequestReview.body // "")
+                                | test("(?i)^[[:space:]]*#{1,6}[[:space:]]+(?:[^[:alnum:]\\r\\n]+[[:space:]]+)?(?:Codex[[:space:]]+)?Security[[:space:]-]+Review") | not)))
                    # GitHub moves `commit` to the latest diff position after a
                    # later push. The original commit identifies the reviewed
                    # head that produced this finding, so it must win here.
                    | select((.originalCommit.oid // .commit.oid // "") == $head)
                    | {id: (.pullRequestReview.databaseId | tostring),
-                      active: (($thread.isResolved | not) and ($thread.isOutdated | not))}]
+                      active: (($thread.isResolved | not) and ($thread.isOutdated | not)),
+                      at: (.updatedAt // "")}]
                   | group_by(.id)
                   | map({id: .[0].id,
                          active_count: ([.[] | select(.active)] | length),
-                         total_count: length})'
+                         total_count: length,
+                         latest_at: ([.[].at] | max // "")})'
           }
 
           shared_open_head_count() {
@@ -346,12 +354,13 @@ jobs:
           }
 
           read_gate_snapshot() {
-            local evidence deliveries reviews review_ids thread_summary verdict_selection verdict finding_count latest_finding_at issue_comment_at review_invalidation_at
+            local evidence deliveries reviews review_ids thread_summary verdict_selection verdict finding_count latest_finding_at issue_comment_at review_invalidation_at include_summaries
             evidence="$(regular_evidence)"
             deliveries="$(jq -c '.deliveries' <<< "$evidence")"
             reviews="$(jq -c '[.deliveries[] | select(.source == "review")]' <<< "$evidence")"
             review_ids="$(jq -c '.review_ids' <<< "$evidence")"
-            thread_summary="$(regular_review_thread_summary "$review_ids")"
+            include_summaries="$(jq 'any(.deliveries[]; .source == "review_summary")' <<< "$evidence")"
+            thread_summary="$(regular_review_thread_summary "$review_ids" "$include_summaries")"
             verdict_selection="$(
               issue_comment_at="$(latest_regular_issue_comment_at)"
               review_invalidation_at="$(latest_regular_review_invalidation_at)"
@@ -361,14 +370,23 @@ jobs:
                     + [$reviews[]
                        | select(.id as $id | ($finding_ids | index($id)) != null)
                        | .at]
+                    + [$thread_summary[] | select(.total_count > 0) | .latest_at]
                     + (if $issue_comment_at == "" then [] else [$issue_comment_at] end)
                     + (if $review_invalidation_at == "" then [] else [$review_invalidation_at] end))
                    | max // "") as $latest_finding_at
                 | ($deliveries | sort_by(.at) | last) as $latest_delivery
                 | {verdict:
                      (if $latest_delivery != null
-                           and ($latest_delivery.source == "review" or $latest_delivery.source == "issue_comment")
+                           and ($latest_delivery.source == "review" or $latest_delivery.source == "issue_comment" or $latest_delivery.source == "review_summary")
                            and $latest_delivery.clean
+                           # A PR-level reaction cannot retire findings from
+                           # a regular review on the same head. Push a new head
+                           # or obtain an explicit newer regular verdict.
+                           and (if $latest_delivery.source == "review_summary" then
+                             ($finding_ids | length) == 0
+                             and ([$deliveries[] | select(.source != "review_summary" and (.clean | not))] | length) == 0
+                             and ($latest_finding_at == "" or $latest_delivery.completed_at > $latest_finding_at)
+                             else true end)
                            and (($finding_ids | index($latest_delivery.id)) == null)
                            and $latest_delivery.at > $latest_finding_at
                       then $latest_delivery
@@ -448,6 +466,12 @@ jobs:
           # The event head was revoked before its first API read. Revoke the
           # resolved head as well for manual dispatches and stale event payloads.
           stamp_review_gate pending "Evaluating the regular review on $head_prefix"
+          [[ "$REVIEW_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]] || exit 1
+          review_summary_script="$(mktemp "$RUNNER_TEMP/review-summary.XXXXXX")"
+          trap 'rm -f "$review_summary_script"' EXIT
+          gh api --method GET -H 'Accept: application/vnd.github.raw+json' \
+            "repos/$REPO/contents/.github/scripts/review_summary.py?ref=$REVIEW_WORKFLOW_SHA" \
+            > "$review_summary_script"
           gate_snapshot="$(read_gate_snapshot)"
           require_clean_regular_snapshot "$gate_snapshot"
 
@@ -515,6 +539,10 @@ jobs:
               evidence_comment_id="${evidence_id#issue-comment-}"
               [[ "$evidence_comment_id" =~ ^[1-9][0-9]*$ ]] || exit 1
               evidence_marker="issue-comment:$evidence_comment_id"
+              ;;
+            review_summary)
+              [[ "$evidence_id" =~ ^review-summary-([1-9][0-9]*)-([1-9][0-9]*)$ ]] || exit 1
+              evidence_marker="review-summary:${BASH_REMATCH[1]}:${BASH_REMATCH[2]}"
               ;;
             *)
               echo "Could not persist the current clean regular-review evidence." >&2

--- a/.github/workflows/review-regular-comment.yml
+++ b/.github/workflows/review-regular-comment.yml
@@ -28,12 +28,14 @@ jobs:
       - id: classify
         name: Classify regular Codex issue-comment verdicts
         env:
+          EVENT_ACTION: ${{ github.event.action }}
           EVENT_COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
           EVENT_COMMENT_BODY: ${{ github.event.comment.body }}
           EVENT_PREVIOUS_COMMENT_BODY: ${{ github.event.changes.body.from }}
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
+          REVIEW_WORKFLOW_SHA: ${{ github.workflow_sha }}
           REVIEW_BOT_EVENT_LOGIN: ${{ vars.REVIEW_PROVIDER == 'claude' && 'github-actions[bot]' || 'chatgpt-codex-connector[bot]' }}
           REVIEW_COMMENT_CONTEXT: review-gate-regular-comment
           REVIEW_GATE_CONTEXT: review-gate
@@ -93,6 +95,23 @@ jobs:
           fi
           head_prefix="${head_sha:0:10}"
 
+          [[ "$REVIEW_WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]] || exit 1
+          review_summary_script="$(mktemp "$RUNNER_TEMP/review-summary.XXXXXX")"
+          trap 'rm -f "$review_summary_script"' EXIT
+          if ! gh api --method GET -H 'Accept: application/vnd.github.raw+json' \
+            "repos/$REPO/contents/.github/scripts/review_summary.py?ref=$REVIEW_WORKFLOW_SHA" \
+            > "$review_summary_script" \
+            || ! summary_event="$(python3 "$review_summary_script" classify --head "$head_sha")"; then
+            # An unreadable classifier cannot leave a prior success armed.
+            # Let the existing invalidation job revoke it under the PR lock.
+            echo "regular=true" >> "$GITHUB_OUTPUT"
+            echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          summary_event_regular="$(jq -r '.regular' <<< "$summary_event")"
+          summary_event_completed="$(jq -r '.completed' <<< "$summary_event")"
+
           body_is_regular_comment() {
             local comment_body="$1"
             printf '%s' "$comment_body" \
@@ -142,7 +161,8 @@ jobs:
           }
 
           if ! body_is_regular_comment "$EVENT_COMMENT_BODY" \
-            && ! body_is_regular_comment "$EVENT_PREVIOUS_COMMENT_BODY"; then
+            && ! body_is_regular_comment "$EVENT_PREVIOUS_COMMENT_BODY" \
+            && [[ "$summary_event_regular" != "true" ]]; then
             echo "Ignoring a non-regular issue comment."
             exit 0
           fi
@@ -150,7 +170,9 @@ jobs:
             echo "regular=true"
             echo "head_sha=$head_sha"
           } >> "$GITHUB_OUTPUT"
-          if body_is_clean_comment "$EVENT_COMMENT_BODY"; then
+          # A completed summary still revokes the gate before evaluation. Its
+          # completion edit is not a new finding that requires another review.
+          if body_is_clean_comment "$EVENT_COMMENT_BODY" || [[ "$summary_event_completed" == "true" ]]; then
             echo "clean=true" >> "$GITHUB_OUTPUT"
           fi
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,15 @@ style. Keep runtime traffic local and use Home Assistant's asynchronous APIs.
 - Pairing changes must preserve the scoped BlueZ agent and cover success, malformed/rejected/expired codes, cancellation, and unavailable adapters.
 - Tests must retain 100% coverage. Required CI, privacy, HACS, Hassfest, and review must pass before a manual merge.
 
+The regular-review gate accepts an exact-commit verdict or the connector's
+completed Code Review summary paired with a later positive bot reaction on that
+PR. Abbreviated commits must resolve to the full current head, and active regular
+findings still block approval. A summary cannot retire findings on the same
+head; push the fix and get a new review. Security Review rows are independent. The quiet
+audit reconciles delayed or removed reactions; unavailable evidence leaves the
+gate pending. The summary reader comes from the trusted workflow's own commit,
+never from the proposed PR code. Regression checks run in `tests/test_review_summary.py`.
+
 ## Documentation
 
 Describe the feature or required action. Keep release notes focused on changes

--- a/tests/test_review_summary.py
+++ b/tests/test_review_summary.py
@@ -1,0 +1,575 @@
+"""Exercise summary evidence and the trusted workflow's actual decision code."""
+
+import importlib.util
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).parents[1]
+MODULE_PATH = ROOT / ".github/scripts/review_summary.py"
+SPEC = importlib.util.spec_from_file_location("review_summary", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+summary = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(summary)
+HEAD = "01234567" * 5
+PREFIX = HEAD[:7]
+COMPLETED = (
+    '✅ **Completed** <relative-time datetime="2026-01-01T00:00:01.250Z">'
+    "2026-01-01T00:00:01.250Z</relative-time>"
+)
+
+
+def body(status=COMPLETED, commit=PREFIX):
+    """Synthetic connector-generated envelope, without private PR content."""
+    return (
+        summary.HEADER
+        + "\nThis comment shows the latest Codex review activity.\n\n"
+        + "| Review | Status | Commit | Review trigger |\n"
+        + "| --- | --- | --- | --- |\n"
+        + f"| 📝 **Code Review** | {status} | `{commit}` | New commits |\n"
+    )
+
+
+@pytest.fixture
+def evidence():
+    """A completed current-head review followed by its positive bot reaction."""
+    return (
+        [
+            {
+                "id": 11,
+                "user": {"login": summary.BOT},
+                "body": body(),
+                "updated_at": "2026-01-01T00:00:02Z",
+            }
+        ],
+        [
+            {
+                "id": 22,
+                "user": {"login": summary.BOT},
+                "content": "+1",
+                "created_at": "2026-01-01T00:00:03Z",
+            }
+        ],
+        {PREFIX: HEAD},
+    )
+
+
+def evaluate(evidence):
+    comments, reactions, resolved = evidence
+    return summary.records(comments, reactions, HEAD, resolved)
+
+
+def test_current_review_needs_both_summary_and_fresh_reaction(evidence):
+    assert evaluate(evidence) == [
+        {
+            "at": "2026-01-01T00:00:03Z",
+            "id": "review-summary-11-22",
+            "source": "review_summary",
+            "completed_at": "2026-01-01T00:00:01.250Z",
+            "clean": True,
+        }
+    ]
+    evidence[1].clear()
+    assert evaluate(evidence)[0]["clean"] is False
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "other_author",
+        "old_head",
+        "security_only",
+        "no_envelope",
+        "no_review_row",
+    ],
+)
+def test_unrelated_metadata_does_not_supply_regular_evidence(evidence, mutation):
+    comment = evidence[0][0]
+    if mutation == "other_author":
+        comment["user"]["login"] = "someone-else"
+    elif mutation == "old_head":
+        comment["body"] = body(commit="b" * 40)
+    elif mutation == "security_only":
+        comment["body"] = body().replace("Code Review", "Security Review")
+    elif mutation == "no_envelope":
+        comment["body"] = "Quoted:\n" + body()
+    else:
+        comment["body"] = summary.HEADER
+    assert evaluate(evidence) == []
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "running",
+        "failed",
+        "unknown_status",
+        "duplicate_row",
+        "duplicate_comment",
+        "unresolved_prefix",
+        "wrong_resolved_commit",
+        "other_reaction_author",
+        "old_reaction",
+        "ambiguous_same_second",
+        "negative_reaction",
+        "bad_reaction_id",
+        "invalid_reaction_time",
+        "future_completion",
+        "mismatched_display_time",
+    ],
+)
+def test_incomplete_or_ambiguous_evidence_fails_closed(evidence, mutation):
+    comment, reaction = evidence[0][0], evidence[1][0]
+    if mutation in {"running", "failed", "unknown_status"}:
+        comment["body"] = body(status=mutation)
+    elif mutation == "duplicate_row":
+        comment["body"] += body().splitlines()[-1]
+    elif mutation == "duplicate_comment":
+        evidence[0].append({**comment, "id": 12})
+    elif mutation == "unresolved_prefix":
+        evidence[2].clear()
+    elif mutation == "wrong_resolved_commit":
+        evidence[2][PREFIX] = "b" * 40
+    elif mutation == "other_reaction_author":
+        reaction["user"]["login"] = "someone-else"
+    elif mutation == "old_reaction":
+        reaction["created_at"] = "2025-12-31T23:59:59Z"
+    elif mutation == "ambiguous_same_second":
+        reaction["created_at"] = "2026-01-01T00:00:01Z"
+    elif mutation == "negative_reaction":
+        reaction["content"] = "-1"
+    elif mutation == "bad_reaction_id":
+        reaction["id"] = True
+    elif mutation == "invalid_reaction_time":
+        reaction["created_at"] = "tomorrow"
+    elif mutation == "future_completion":
+        comment["body"] = body().replace("00:00:01.250Z", "00:00:09Z")
+    else:
+        comment["body"] = body().replace(
+            ">2026-01-01T00:00:01.250Z", ">2026-01-01T00:00:02Z"
+        )
+    assert all(record["clean"] is False for record in evaluate(evidence))
+
+
+def test_security_changes_do_not_invalidate_completed_code_review(evidence):
+    security = "| 🔒 **Security Review** | Running | `b123456` | Comment |\n"
+    previous, current = body(), body() + security
+    assert not summary.changed_for_head(current, previous, "edited", HEAD)
+    evidence[0][0].update(body=current, updated_at="2026-01-01T00:00:10Z")
+    assert evaluate(evidence)[0]["clean"] is True
+
+
+@pytest.mark.parametrize(
+    "current,previous,action",
+    [
+        (body(), "", "created"),
+        (body(), body(status="Running"), "edited"),
+        (body(status="Running"), body(), "edited"),
+        ("removed", body(), "edited"),
+        (body(), "", "deleted"),
+        (body(commit="b" * 40), body(), "edited"),
+    ],
+)
+def test_changes_to_regular_review_revoke_current_head(current, previous, action):
+    assert summary.changed_for_head(current, previous, action, HEAD)
+
+
+@pytest.mark.parametrize("value", [None, 2, "yesterday", "2026-99-99T00:00:00Z"])
+def test_invalid_timestamps_are_not_ordered_as_evidence(value):
+    assert summary.timestamp(value) is None
+
+
+def test_malformed_trusted_metadata_raises(evidence):
+    evidence[0][0]["updated_at"] = "invalid"
+    with pytest.raises(ValueError, match="Malformed trusted"):
+        evaluate(evidence)
+
+
+def test_collect_resolves_full_commit_and_scopes_reactions_to_pr(evidence, monkeypatch):
+    calls = []
+
+    def api(path, *, paginate=False):
+        calls.append((path, paginate))
+        if "/comments?" in path:
+            return evidence[0]
+        if "/reactions?" in path:
+            return evidence[1]
+        if path == f"repos/example/project/commits/{PREFIX}":
+            return {"sha": HEAD}
+        pytest.fail(f"Unexpected endpoint: {path}")
+
+    monkeypatch.setattr(summary, "api", api)
+    assert summary.collect("example/project", "42", HEAD, summary.BOT)[0]["clean"]
+    assert calls == [
+        ("repos/example/project/issues/42/comments?per_page=100", True),
+        (f"repos/example/project/commits/{PREFIX}", False),
+        ("repos/example/project/issues/42/reactions?per_page=100", True),
+    ]
+    calls.clear()
+    assert summary.collect("example/project", "42", HEAD, "github-actions[bot]") == []
+    assert not calls
+
+
+def workflow_run(name, job, step=0):
+    config = yaml.safe_load((ROOT / ".github/workflows" / name).read_text())
+    return config["jobs"][job]["steps"][step]["run"]
+
+
+def shell_function(script, name):
+    match = re.search(rf"(?ms)^{name}\(\) \{{\n.*?^\}}", script)
+    assert match is not None
+    return match[0]
+
+
+@pytest.mark.parametrize(
+    "change,expected",
+    [
+        ("completed", "true"),
+        ("running", "true"),
+        ("security_edit", "false"),
+        ("reader_unavailable", "true"),
+    ],
+)
+def test_actual_comment_router_recognizes_current_summary(tmp_path, change, expected):
+    fixture = tmp_path / "gh"
+    fixture.write_text(
+        "#!/usr/bin/env python3\nimport json,os,sys\n"
+        "from pathlib import Path\n"
+        "if any('/contents/' in a for a in sys.argv):\n"
+        " if os.environ.get('FAIL_READER') == 'true': raise SystemExit(1)\n"
+        " print(Path(os.environ['SUMMARY_MODULE']).read_text())\n"
+        "elif any('/pulls/42' in a for a in sys.argv):\n"
+        " print(json.dumps({'head':{'sha':os.environ['TEST_HEAD']}}))\n"
+        "else: raise SystemExit('Unexpected GitHub call')\n"
+    )
+    fixture.chmod(0o700)
+    current = body(status="Running") if change == "running" else body()
+    previous = (
+        body() if change in {"security_edit", "running"} else body(status="Running")
+    )
+    if change == "security_edit":
+        current += "| 🔒 **Security Review** | Running | `b123456` | Comment |\n"
+    output = tmp_path / "output"
+    env = dict(
+        os.environ,
+        PATH=f"{tmp_path}:{os.environ['PATH']}",
+        EVENT_COMMENT_AUTHOR=summary.BOT,
+        REVIEW_BOT_EVENT_LOGIN=summary.BOT,
+        EVENT_COMMENT_BODY=current,
+        EVENT_PREVIOUS_COMMENT_BODY=previous,
+        EVENT_ACTION="edited",
+        PR_NUMBER="42",
+        REPO="example/project",
+        REVIEW_WORKFLOW_SHA="c" * 40,
+        RUNNER_TEMP=str(tmp_path),
+        GITHUB_OUTPUT=str(output),
+        TEST_HEAD=HEAD,
+        SUMMARY_MODULE=str(MODULE_PATH),
+        FAIL_READER=str(change == "reader_unavailable").lower(),
+    )
+    script = workflow_run("review-regular-comment.yml", "classify")
+    # The repository's fixed PATH prefixes still precede our isolated fake gh.
+    script = script.replace('export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"', ":")
+    subprocess.run(["bash", "-c", script], env=env, check=True, capture_output=True)
+    values = dict(line.split("=", 1) for line in output.read_text().splitlines())
+    assert values["regular"] == expected
+    # Both paths revoke the gate; a completion edit need not require a new run.
+    assert values["clean"] == ("true" if change == "completed" else "false")
+    if expected == "true":
+        assert values["head_sha"] == HEAD
+
+
+@pytest.mark.parametrize(
+    "active,updated,security,expected",
+    [
+        (True, "2026-01-01T00:00:01Z", False, 1),
+        (False, "2026-01-01T00:00:01Z", False, 0),
+        (True, "2026-01-01T00:00:01Z", True, 0),
+    ],
+)
+def test_summary_cannot_skip_unresolved_bot_findings(
+    tmp_path, active, updated, security, expected
+):
+    review_body = "### Security Review" if security else "Review on the short head"
+    event = {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "nodes": [
+                            {
+                                "isResolved": not active,
+                                "isOutdated": False,
+                                "comments": {
+                                    "nodes": [
+                                        {
+                                            "author": {
+                                                "login": summary.BOT.removesuffix(
+                                                    "[bot]"
+                                                )
+                                            },
+                                            "replyTo": None,
+                                            "originalCommit": {"oid": HEAD},
+                                            "commit": {"oid": HEAD},
+                                            "updatedAt": updated,
+                                            "pullRequestReview": {
+                                                "databaseId": 7,
+                                                "body": review_body,
+                                            },
+                                        }
+                                    ]
+                                },
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+    data = tmp_path / "graphql.json"
+    data.write_text(json.dumps(event))
+    script = shell_function(
+        workflow_run("review-gate.yml", "evaluate"), "regular_review_thread_summary"
+    )
+    env = dict(
+        os.environ,
+        FIXTURE=str(data),
+        head_sha=HEAD,
+        REVIEW_BOT_LOGIN=summary.BOT.removesuffix("[bot]"),
+        review_owner="example",
+        review_repo="project",
+        pr_number="42",
+    )
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            'gh() { cat "$FIXTURE"; }\n'
+            + script
+            + '\nregular_review_thread_summary "[]" true',
+        ],
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    groups = json.loads(result.stdout)
+    assert sum(group["active_count"] for group in groups) == expected
+
+
+@pytest.mark.parametrize(
+    "finding_at,active,invalidation,accepted",
+    [
+        ("", 0, "", True),
+        ("2026-01-01T00:00:01Z", 0, "", False),
+        ("2026-01-01T00:00:01Z", 1, "", False),
+        ("2026-01-01T00:00:04Z", 0, "", False),
+        ("", 0, "2026-01-01T00:00:04Z", False),
+    ],
+)
+def test_actual_gate_decision_preserves_finding_and_invalidation_fences(
+    tmp_path, evidence, finding_at, active, invalidation, accepted
+):
+    (tmp_path / "evidence").write_text(
+        json.dumps(
+            {
+                "deliveries": evaluate(evidence),
+                "review_ids": [],
+            }
+        )
+    )
+    groups = (
+        []
+        if not finding_at
+        else [
+            {
+                "id": "7",
+                "total_count": 1,
+                "active_count": active,
+                "latest_at": finding_at,
+            }
+        ]
+    )
+    (tmp_path / "threads").write_text(json.dumps(groups))
+    run = workflow_run("review-gate.yml", "evaluate")
+    script = "\n".join(
+        shell_function(run, name)
+        for name in ("read_gate_snapshot", "require_clean_regular_snapshot")
+    )
+    script += """
+regular_evidence() { cat "$FIXTURES/evidence"; }
+regular_review_thread_summary() { cat "$FIXTURES/threads"; }
+latest_regular_issue_comment_at() { printf '%s' "$INVALIDATION"; }
+latest_regular_review_invalidation_at() { :; }
+base_change_marker_exists() { return 1; }
+stamp_status() { :; }
+stamp_review_gate() { echo "$1"; }
+snapshot="$(read_gate_snapshot)"
+require_clean_regular_snapshot "$snapshot"
+echo accepted
+"""
+    result = subprocess.run(
+        ["bash", "-c", script],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=dict(
+            os.environ,
+            FIXTURES=str(tmp_path),
+            INVALIDATION=invalidation,
+            head_prefix=HEAD[:10],
+            REVIEW_REVIEW_CONTEXT="review-gate-regular-review",
+        ),
+    )
+    assert ("accepted" in result.stdout.splitlines()) is accepted
+
+
+def test_workflows_fetch_only_their_trusted_definition_commit():
+    for name, job in (
+        ("review-gate.yml", "evaluate"),
+        ("review-regular-comment.yml", "classify"),
+        ("review-gate-audit.yml", "audit"),
+    ):
+        config = yaml.safe_load((ROOT / ".github/workflows" / name).read_text())
+        step = config["jobs"][job]["steps"][0]
+        assert step["env"]["REVIEW_WORKFLOW_SHA"] == "${{ github.workflow_sha }}"
+        assert "review_summary.py?ref=$REVIEW_WORKFLOW_SHA" in step["run"]
+        assert "review_summary.py?ref=$head_sha" not in step["run"]
+
+
+@pytest.mark.parametrize(
+    "scenario,withdraws",
+    [
+        ("late_reaction", True),
+        ("unchanged", False),
+        ("reaction_removed", True),
+        ("security_edit", False),
+        ("reader_unavailable", True),
+        ("reopened_finding", True),
+    ],
+)
+def test_actual_audit_reconciles_summary_lifecycle(
+    tmp_path, evidence, scenario, withdraws
+):
+    comments, reactions, _ = evidence
+    if scenario == "reaction_removed":
+        reactions.clear()
+    if scenario == "security_edit":
+        comments[0]["body"] += (
+            "| 🔒 **Security Review** | Running | `b123456` | Comment |\n"
+        )
+        comments[0]["updated_at"] = "2026-01-01T00:00:09Z"
+    status = {
+        "context": "review-gate",
+        "state": "success",
+        "updated_at": "2026-01-01T00:00:04Z",
+        "description": "Clean regular review; evidence review-summary:11:22",
+    }
+    if scenario == "late_reaction":
+        status.update(
+            state="pending",
+            updated_at="2026-01-01T00:00:00Z",
+            description="Waiting for the regular review",
+        )
+    threads = []
+    if scenario == "reopened_finding":
+        threads = [
+            {
+                "isResolved": False,
+                "isOutdated": False,
+                "comments": {
+                    "nodes": [
+                        {
+                            "originalCommit": {"oid": HEAD},
+                            "replyTo": None,
+                            "author": {"login": summary.BOT.removesuffix("[bot]")},
+                            "pullRequestReview": {
+                                "state": "COMMENTED",
+                                "body": "Review using a newer envelope",
+                                "author": {"login": summary.BOT.removesuffix("[bot]")},
+                                "commit": {"oid": HEAD},
+                            },
+                        }
+                    ]
+                },
+            }
+        ]
+    payloads = {
+        "comments": comments,
+        "reactions": reactions,
+        "statuses": [status],
+        "threads": threads,
+        "head": HEAD,
+    }
+    (tmp_path / "payloads.json").write_text(json.dumps(payloads))
+    fake_gh = tmp_path / "gh"
+    fake_gh.write_text("""#!/usr/bin/env python3
+import json,os,sys
+from pathlib import Path
+base=Path(os.environ['FIXTURES'])
+d=json.loads((base/'payloads.json').read_text())
+a=sys.argv[1:]
+if a[:2] == ['workflow','run']:
+    with (base/'writes').open('a') as f: f.write('dispatch\\n')
+    raise SystemExit(0)
+if a[0] != 'api': raise SystemExit('Unexpected command')
+path=next((x for x in a if x.startswith('repos/') or x=='graphql'),'')
+if '/statuses/' in path:
+    with (base/'writes').open('a') as f: f.write('pending\\n')
+    raise SystemExit(0)
+if '/contents/.github/scripts/' in path:
+    if os.environ.get('FAIL_READER') == 'true': raise SystemExit(1)
+    print(Path(os.environ['SUMMARY_MODULE']).read_text())
+    raise SystemExit(0)
+if '/contents/.github/workflows/' in path: value={}
+elif '/pulls/42' in path: value={'head':{'sha':d['head']}}
+elif '/commits/' in path and '/statuses?' not in path: value={'sha':d['head']}
+elif '/comments?' in path: value=d['comments']
+elif '/reactions?' in path: value=d['reactions']
+elif '/statuses?' in path: value=d['statuses']
+elif path=='graphql':
+    if any('reviewThreads(' in x for x in a):
+        value={'data':{'repository':{'pullRequest':{'reviewThreads':{'nodes':d['threads']}}}}}
+    else: value={'data':{'repository':{'pullRequest':{'reviews':{'nodes':[]}}}}}
+else: raise SystemExit('Unexpected API path '+path)
+if '--slurp' in a: value=[value]
+print(json.dumps(value))
+""")
+    fake_gh.chmod(0o700)
+    script = workflow_run("review-gate-audit.yml", "audit").replace(
+        'export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"', ":"
+    )
+    env = dict(
+        os.environ,
+        PATH=f"{tmp_path}:{os.environ['PATH']}",
+        REPO="example/project",
+        PR_NUMBER="42",
+        REVIEW_GATE_CONTEXT="review-gate",
+        REVIEW_COMMENT_CONTEXT="review-gate-regular-comment",
+        REVIEW_BOT_EVENT_LOGIN=summary.BOT,
+        REVIEW_BOT_LOGIN=summary.BOT.removesuffix("[bot]"),
+        REVIEW_WORKFLOW_SHA="c" * 40,
+        WORKFLOW_REF="main",
+        RUNNER_TEMP=str(tmp_path),
+        FIXTURES=str(tmp_path),
+        SUMMARY_MODULE=str(MODULE_PATH),
+        FAIL_READER=str(scenario == "reader_unavailable").lower(),
+    )
+    process = subprocess.run(
+        ["bash", "-c", script], env=env, capture_output=True, text=True
+    )
+    assert process.returncode == (1 if scenario == "reader_unavailable" else 0), (
+        process.stderr
+    )
+    writes = (
+        (tmp_path / "writes").read_text().splitlines()
+        if (tmp_path / "writes").exists()
+        else []
+    )
+    assert ("pending" in writes) is withdraws
+    assert ("dispatch" in writes) is (withdraws and scenario != "reader_unavailable")


### PR DESCRIPTION
Completed Codex reviews can arrive as a Code Review summary and a positive bot reaction. The current comment router ignores that format, leaving the required review gate pending indefinitely.

Recognize the connector-owned summary, resolve its abbreviated commit through GitHub to the full current head, and require a positive bot reaction after review completion. A summary cannot retire regular findings on the same head. The existing head/base rechecks and manual merge policy remain intact. The comment router withdraws approval when review state changes; the quiet audit recovers delayed reactions and withdraws deleted evidence. Security-only summary edits are independent. The read-only parser is loaded from the trusted workflow definition commit, never the proposed PR code.

Validation: 1,616 Python tests passed at 100% integration coverage, including 53 new cases exercising the actual router, evaluator, and audit shell code. Cases cover stale or missing reactions, wrong authors/commits, duplicate summaries, unresolved/reopened findings, lost evidence, unavailable readers, and Security-only updates. Ruff, format, strict mypy, privacy, and actionlint passed.

This change takes effect only after installation on the default branch; the existing trusted gate still evaluates this PR under its prior format contract.
