### PR TITLE
Fix live active plan elapsed time

### DIFF
--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -1243,6 +1243,11 @@ class CleaningPlanManager:
             }
             for plan_id, plan in robot["plans"].items()
         }
+        active_plan = deepcopy(robot.get("active_plan"))
+        if isinstance(active_plan, dict):
+            active_plan["active_elapsed_seconds"] = _active_elapsed_seconds(
+                active_plan, dt_util.utcnow()
+            )
         return {
             "completed_runs": completed_runs,
             "failed_runs": failed_runs,
@@ -1273,7 +1278,7 @@ class CleaningPlanManager:
             "selected_area_name": self._area_name(
                 serial_number, robot.get("selected_area")
             ),
-            "active_plan": deepcopy(robot.get("active_plan")),
+            "active_plan": active_plan,
             "last_interrupted_plan": deepcopy(robot.get("last_interrupted_plan")),
         }
 

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -1891,6 +1891,30 @@ async def test_stop_policy_learns_room_duration_and_applies_threshold(hass) -> N
         lock.release()
 
 
+async def test_snapshot_reports_running_active_elapsed(hass) -> None:
+    """Read-only snapshots include the currently open cleaning segment."""
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    await manager.async_save_plan(
+        "serial", "away", {"name": "Away", "enabled": True, "rooms": []}
+    )
+    room = _room("Kitchen", "room-kitchen")
+    base = dt_util.utcnow()
+
+    with patch("custom_components.matic_robot.plans.dt_util.utcnow", return_value=base):
+        await manager.async_mark_started("serial", "away", room)
+        await manager.async_mark_resumed("serial", "away", room)
+
+    with patch(
+        "custom_components.matic_robot.plans.dt_util.utcnow",
+        return_value=base + timedelta(seconds=45),
+    ):
+        active = manager.snapshot("serial")["active_plan"]
+
+    assert active["status"] == "running"
+    assert active["active_elapsed_seconds"] == 45
+
+
 async def test_active_duration_excludes_suspension_and_cancel_is_not_learned(
     hass,
 ) -> None:


### PR DESCRIPTION
The managed cleaning snapshot exposed `active_elapsed_seconds` from persisted state without adding the currently open cleaning segment. During a live run this made the read-only operations tool and active-plan sensor report `0` while the segment had been running for minutes, even though stop-threshold calculations already used the correct elapsed time.

This change computes the live segment duration in snapshots and adds a regression test. It does not guess vendor meanings for raw robot codes.

Validation:
- 1,572 tests passed with 100% coverage
- Ruff check and format check passed
- mypy passed
- public-tree privacy check passed
