### PR TITLE
Make managed cleaning runs explainable end to end

### DIFF
--- a/custom_components/matic_robot/client/observations.py
+++ b/custom_components/matic_robot/client/observations.py
@@ -29,6 +29,7 @@ class ActivityJournal:
         self._callback = callback
         self._session = uuid4().hex
         self._sequence = 0
+        self._run_id: str | None = None
         self._events: deque[dict[str, Any]] = deque(maxlen=MAX_OBSERVATIONS)
         self._states: dict[str, tuple[tuple[int, ...], tuple[int, ...]]] = {}
         self.record("started")
@@ -37,6 +38,10 @@ class ActivityJournal:
     def snapshot(self) -> list[dict[str, Any]]:
         """Return detached records, oldest first; older evidence is evicted."""
         return deepcopy(list(self._events))
+
+    def set_run_id(self, run_id: str | None) -> None:
+        """Associate subsequent integration observations with one managed run."""
+        self._run_id = run_id if isinstance(run_id, str) and run_id else None
 
     def record(self, kind: str, **fields: Any) -> int:
         """Record only fields constructed by the client's observation sites."""
@@ -48,6 +53,8 @@ class ActivityJournal:
             "kind": kind,
             **fields,
         }
+        if self._run_id is not None:
+            event["run_id"] = self._run_id
         self._events.append(event)
         if self._callback is not None:
             try:

--- a/custom_components/matic_robot/const.py
+++ b/custom_components/matic_robot/const.py
@@ -37,6 +37,7 @@ DATA_LLM_API: Final = "llm_api"
 EVENT_FIRMWARE_CHANGED: Final = f"{DOMAIN}_firmware_changed"
 EVENT_FIRMWARE_ANALYZED: Final = f"{DOMAIN}_firmware_analyzed"
 EVENT_CLEANING_FINISHED: Final = f"{DOMAIN}_cleaning_finished"
+EVENT_PLAN_FINISHED: Final = f"{DOMAIN}_plan_finished"
 EVENT_ACTIVITY_OBSERVED: Final = f"{DOMAIN}_activity_observed"
 EVENT_CUES: Final = f"{DOMAIN}_cues"
 

--- a/custom_components/matic_robot/llm.py
+++ b/custom_components/matic_robot/llm.py
@@ -24,6 +24,7 @@ from .const import (
     EVENT_CUES,
     EVENT_FIRMWARE_ANALYZED,
     EVENT_FIRMWARE_CHANGED,
+    EVENT_PLAN_FINISHED,
 )
 from .plans import CleaningPlanManager, leg_groups
 
@@ -41,6 +42,7 @@ _ACTIVITY_FIELDS = (
     "kind",
     "source",
     "command_id",
+    "run_id",
     "command",
     "channel",
     "outcome",
@@ -51,6 +53,7 @@ _ADMIN_ERROR = "Administrator access is required for Matic operational tools"
 _MATIC_EVENT_TYPES = (
     EVENT_ACTIVITY_OBSERVED,
     EVENT_CLEANING_FINISHED,
+    EVENT_PLAN_FINISHED,
     EVENT_CUES,
     EVENT_FIRMWARE_CHANGED,
     EVENT_FIRMWARE_ANALYZED,
@@ -69,6 +72,7 @@ _SAFE_EVENT_FIELDS = (
     "kind",
     "source",
     "command_id",
+    "run_id",
     "command",
     "channel",
     "outcome",
@@ -80,10 +84,14 @@ _SAFE_EVENT_FIELDS = (
     "event_type",
     "intent",
     "plan_id",
+    "trigger",
+    "service",
     "room_id",
     "room",
     "cleaning_mode",
     "coverage_setting",
+    "reason_code",
+    "cause",
     "error",
     "native_stop_reconciled",
     "firmware_version",
@@ -103,6 +111,9 @@ _SAFE_EVENT_FIELDS = (
     "duration_seconds",
     "completed",
     "completion_scope",
+    "room_count",
+    "completed_room_count",
+    "terminal_activity",
     "vacuum_completed_room_count",
     "mop_completed_room_count",
     "combined_completed_room_count",
@@ -114,7 +125,12 @@ class MaticOperationsAPI(llm.API):
 
     def __init__(self, hass: HomeAssistant) -> None:
         super().__init__(hass=hass, id=LLM_API_ID, name=LLM_API_NAME)
+        # Keep the compatibility trail for callers that inspect the API
+        # object directly, while retaining a second low-volume stream for the
+        # read-only tool.  Activity observations can arrive every poll and
+        # must not evict room or terminal events from operational evidence.
         self.recent_events: deque[JsonObjectType] = deque(maxlen=MAX_RECENT_EVENTS)
+        self.operational_events: deque[JsonObjectType] = deque(maxlen=MAX_RECENT_EVENTS)
         self._event_unsubscribers: list[Callable[[], None]] = []
 
     @callback
@@ -152,13 +168,14 @@ class MaticOperationsAPI(llm.API):
                 data["completed_room_count"] = len(completed_rooms)
             if isinstance(room_durations, dict):
                 data["room_duration_count"] = len(room_durations)
-        self.recent_events.append(
-            {
-                "event_type": str(event.event_type),
-                "time_fired": event.time_fired.isoformat(),
-                "data": data,
-            }
-        )
+        captured: JsonObjectType = {
+            "event_type": str(event.event_type),
+            "time_fired": event.time_fired.isoformat(),
+            "data": data,
+        }
+        self.recent_events.append(captured)
+        if event.event_type != EVENT_ACTIVITY_OBSERVED:
+            self.operational_events.append(captured)
 
     @override
     async def async_get_api_instance(
@@ -279,6 +296,24 @@ class MaticGetPlanTool(_MaticTool):
             if intelligent
             else rooms
         )
+        if intelligent:
+            rotation_value = runtime.cleaning_plans.rotation_details(
+                serial_number, plan["id"], rooms
+            )
+            rotation = rotation_value if isinstance(rotation_value, list) else []
+        else:
+            rotation = [
+                {
+                    "rank": rank,
+                    "room_id": room.room_id,
+                    "room": room.name,
+                    "last_result": None,
+                    "last_opportunity": None,
+                    "last_opportunity_source": None,
+                    "selection_reason": "saved_order",
+                }
+                for rank, room in enumerate(rooms, start=1)
+            ]
         groups = leg_groups(chosen)
         snapshot = runtime.cleaning_plans.snapshot(serial_number)
         active = snapshot.get("active_plan")
@@ -303,6 +338,7 @@ class MaticGetPlanTool(_MaticTool):
                     "run_behavior": plan.get("run_behavior", "intelligent"),
                     "return_to_base": bool(plan.get("return_to_base", True)),
                 },
+                "rotation": rotation,
                 "settings_boundary_count": max(0, len(groups) - 1),
                 "legs": [
                     {
@@ -506,15 +542,17 @@ class MaticGetRecentEventsTool(_MaticTool):
 
     name = "MaticGetRecentEvents"
     description = (
-        "Inspect recent allowlisted Matic command, raw-state, room, cleaning, Cues, "
-        "and firmware events "
-        "retained during the current Home Assistant process."
+        "Inspect recent allowlisted Matic room, cleaning, Cues, firmware, and command "
+        "events retained during the current Home Assistant process. Activity "
+        "observations are excluded by default so high-frequency polling cannot hide "
+        "operational events; use include_activity or MaticGetActivity for raw activity."
     )
     parameters = vol.Schema(
         {
             vol.Optional("limit", default=20): vol.All(
                 vol.Coerce(int), vol.Range(min=1, max=MAX_RECENT_EVENTS)
-            )
+            ),
+            vol.Optional("include_activity", default=False): cv.boolean,
         }
     )
 
@@ -527,15 +565,26 @@ class MaticGetRecentEventsTool(_MaticTool):
     ) -> JsonObjectType:
         """Return newest events first without querying recorder storage."""
         args = self.parameters(tool_input.tool_args)
-        events = list(self.api.recent_events)[-args["limit"] :]
+        source = (
+            self.api.recent_events
+            if args["include_activity"]
+            else self.api.operational_events
+        )
+        events = list(source)[-args["limit"] :]
         events.reverse()
         return cast(
             JsonObjectType,
             {
                 "read_only": True,
                 "retention": (
-                    f"current Home Assistant process, last {MAX_RECENT_EVENTS} events"
+                    f"current Home Assistant process, last {MAX_RECENT_EVENTS} "
+                    + (
+                        "events including activity"
+                        if args["include_activity"]
+                        else "operational events"
+                    )
                 ),
+                "activity_included": args["include_activity"],
                 "events": events,
             },
         )
@@ -759,6 +808,7 @@ def _robot_summary(entry: ConfigEntry[Any]) -> JsonObjectType:
                 "lock_held": manager.lock(serial_number).locked(),
                 "stop_settle_pending": manager.stop_pending(serial_number),
                 "active_plan": snapshot.get("active_plan"),
+                "last_run": snapshot.get("last_run"),
             },
             "selected_plan": {
                 "id": snapshot.get("selected_plan"),

--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -24,6 +24,7 @@ from typing import Any, Literal, cast, override
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.storage import Store
 from homeassistant.util import dt as dt_util
 
@@ -630,18 +631,43 @@ class CleaningPlanManager:
         floor_plan: FloorPlan | None,
         records: Iterable[CleaningSessionRecord],
     ) -> bool:
-        """Record robot-side cleaning activity without claiming completions."""
+        """Import native activity and reconcile only the matching pending room."""
         if floor_plan is None:
             return False
         robot = self._robot(serial_number)
         records = tuple(records)
         changed = _import_native_room_activity(robot, floor_plan, records)
+        reconciled: list[dict[str, str]] = []
         changed = (
-            _reconcile_pending_native_history(robot, floor_plan, records) or changed
+            _reconcile_pending_native_history(
+                robot, floor_plan, records, on_reconciled=reconciled.append
+            )
+            or changed
         )
         if not changed:
             return False
-        await self._async_save_and_notify(serial_number)
+        try:
+            await self._async_save_and_notify(serial_number)
+        finally:
+            for marker in reconciled:
+                entity_id = er.async_get(self.hass).async_get_entity_id(
+                    "vacuum", DOMAIN, f"{serial_number}_vacuum"
+                )
+                self.hass.bus.async_fire(
+                    f"{DOMAIN}_room_reconciled",
+                    {
+                        **({"entity_id": entity_id} if entity_id else {}),
+                        "plan_id": marker["plan_id"],
+                        "room_id": marker["room_id"],
+                        "room": marker["room"],
+                        **(
+                            {"run_id": marker["run_id"]} if marker.get("run_id") else {}
+                        ),
+                        "native_stop_reconciled": True,
+                        "reason_code": "native_reconciled_completion",
+                        "cause": "late_native_history",
+                    },
+                )
         return True
 
     def areas(self, serial_number: str) -> dict[str, dict[str, Any]]:
@@ -1752,6 +1778,8 @@ def _reconcile_pending_native_history(
     robot: dict[str, Any],
     floor_plan: FloorPlan,
     records: Iterable[CleaningSessionRecord],
+    *,
+    on_reconciled: Callable[[dict[str, str]], None] | None = None,
 ) -> bool:
     """Apply exactly one retained native completion to a pending plan room."""
     pending = _validated_native_reconciliation(
@@ -1832,6 +1860,8 @@ def _reconcile_pending_native_history(
         duration_seconds=matches[0][2],
     )
     robot.pop("pending_native_reconciliation", None)
+    if on_reconciled is not None:
+        on_reconciled(pending)
     return True
 
 

--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -1112,7 +1112,20 @@ class CleaningPlanManager:
         if duration is not None and duration > 0:
             global_room["last_duration_seconds"] = duration
         global_room["completed_runs"] = _stored_count(global_room, "completed_runs") + 1
-        self._robot(serial_number)["active_plan"] = None
+        robot = self._robot(serial_number)
+        last_run = robot.get("last_run")
+        if (
+            isinstance(last_run, dict)
+            and last_run.get("outcome") == "running"
+            and last_run.get("plan_id") == plan_id
+        ):
+            # Checkpoint verified credit with room history, so a crash before
+            # the plan finalizer cannot lose work already verified and saved.
+            last_run["completed_room_count"] = min(
+                _stored_count(last_run, "completed_room_count") + 1,
+                _stored_count(last_run, "room_count"),
+            )
+        robot["active_plan"] = None
         await self._async_save_and_notify(serial_number)
 
     async def async_mark_ended_unverified(
@@ -1691,6 +1704,7 @@ def _validated_native_reconciliation(
     if parsed_expiry is None or parsed_expiry.tzinfo is None:
         return None
     cleaning_mode = value.get("cleaning_mode")
+    run_id = value.get("run_id")
     return {
         "plan_id": plan_id,
         "room_id": room_id,
@@ -1701,6 +1715,11 @@ def _validated_native_reconciliation(
             {"cleaning_mode": cleaning_mode}
             if isinstance(cleaning_mode, str)
             and cleaning_mode in ("vacuum", "mop", "vacuum_and_mop")
+            else {}
+        ),
+        **(
+            {"run_id": run_id}
+            if isinstance(run_id, str) and 0 < len(run_id) <= 64
             else {}
         ),
     }

--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -38,7 +38,7 @@ from .client.models import CleaningSessionRecord, FloorPlan, Room
 from .const import DOMAIN
 
 STORAGE_VERSION = 1
-STORAGE_MINOR_VERSION = 4
+STORAGE_MINOR_VERSION = 5
 STORAGE_KEY = f"{DOMAIN}.plans"
 PLAN_MOTION_TOKEN = "_matic_plan_run"
 PLAN_FLOOR_TOKEN = "_matic_plan_floor"
@@ -67,6 +67,18 @@ class CleaningRoom:
     name: str
     cleaning_mode: str
     coverage_setting: str
+
+
+@dataclass(frozen=True, slots=True)
+class _RotationCandidate:
+    """One room's trusted rotation key and explainable selection metadata."""
+
+    index: int
+    room: CleaningRoom
+    effective_timestamp: float | None
+    effective_value: str | None
+    source: str | None
+    last_result: str | None
 
 
 def plan_floor_token(floor_plan: FloorPlan) -> str:
@@ -186,6 +198,8 @@ class _CleaningPlanStore(Store[dict[str, Any]]):
                     if isinstance(rooms, dict):
                         for record in rooms.values():
                             _migrate_room_opportunity(record)
+                if old_minor_version < 5:
+                    robot.setdefault("last_run", None)
         return old_data
 
 
@@ -807,6 +821,11 @@ class CleaningPlanManager:
                 "least_recent_opportunity" if intelligent else "saved_order"
             ),
             "rooms": [asdict(room) for room in chosen],
+            "rotation": (
+                self.rotation_details(serial_number, plan["id"], rooms)
+                if intelligent
+                else _saved_order_rotation_details(rooms)
+            ),
             "room_count": len(chosen),
             "return_to_base": bool(plan.get("return_to_base", True)),
             "finish_current_room": bool(plan.get("finish_current_room", False)),
@@ -817,6 +836,43 @@ class CleaningPlanManager:
             "completion_timeout": int(plan.get("completion_timeout", 21600)),
         }
 
+    def rotation_details(
+        self,
+        serial_number: str,
+        plan_id: str,
+        rooms: Sequence[CleaningRoom],
+    ) -> list[dict[str, Any]]:
+        """Explain the next intelligent order without changing rotation state."""
+        ordered = sorted(
+            self._rotation_candidates(serial_number, plan_id, rooms),
+            key=_rotation_sort_key,
+        )
+        details: list[dict[str, Any]] = []
+        previous_timestamp: float | None = None
+        for rank, candidate in enumerate(ordered, start=1):
+            if candidate.effective_timestamp is None:
+                reason = "no_prior_opportunity"
+            elif (
+                previous_timestamp is not None
+                and candidate.effective_timestamp == previous_timestamp
+            ):
+                reason = "saved_order_tiebreak"
+            else:
+                reason = "least_recent_opportunity"
+            details.append(
+                {
+                    "rank": rank,
+                    "room_id": candidate.room.room_id,
+                    "room": candidate.room.name,
+                    "last_result": candidate.last_result,
+                    "last_opportunity": candidate.effective_value,
+                    "last_opportunity_source": candidate.source,
+                    "selection_reason": reason,
+                }
+            )
+            previous_timestamp = candidate.effective_timestamp
+        return details
+
     def choose(
         self,
         serial_number: str,
@@ -824,6 +880,21 @@ class CleaningPlanManager:
         rooms: list[CleaningRoom],
     ) -> list[CleaningRoom]:
         """Order rooms by their oldest trusted cleaning opportunity."""
+        return [
+            candidate.room
+            for candidate in sorted(
+                self._rotation_candidates(serial_number, plan_id, rooms),
+                key=_rotation_sort_key,
+            )
+        ]
+
+    def _rotation_candidates(
+        self,
+        serial_number: str,
+        plan_id: str,
+        rooms: Sequence[CleaningRoom],
+    ) -> list[_RotationCandidate]:
+        """Build the shared trusted keys used by ordering and diagnostics."""
         robot = self._robot(serial_number)
         rotation = robot["rotations"].get(plan_id)
         records_value = rotation.get("rooms") if isinstance(rotation, Mapping) else None
@@ -835,19 +906,18 @@ class CleaningPlanManager:
             reset_values.get(plan_id) if isinstance(reset_values, Mapping) else None,
             now=now,
         )
-
-        def priority(item: tuple[int, CleaningRoom]) -> tuple[bool, float, int]:
-            index, room = item
+        candidates: list[_RotationCandidate] = []
+        for index, room in enumerate(rooms):
             record_value = records.get(room.room_id)
             global_value = global_records.get(room.room_id)
             record = record_value if isinstance(record_value, Mapping) else {}
             global_record = global_value if isinstance(global_value, Mapping) else {}
-            local_opportunity = _latest_timestamp(
+            local_opportunity = _latest_timestamp_value(
                 record.get("last_opportunity"),
                 record.get("last_completed"),
                 now=now,
             )
-            global_opportunity = _latest_timestamp(
+            global_opportunity = _latest_timestamp_value(
                 global_record.get("last_opportunity"),
                 global_record.get("last_completed"),
                 now=now,
@@ -855,31 +925,98 @@ class CleaningPlanManager:
             if (
                 reset_at is not None
                 and global_opportunity is not None
-                and global_opportunity <= reset_at
+                and global_opportunity[0] <= reset_at
             ):
                 global_opportunity = None
-            last_opportunity = max(
-                (
-                    timestamp
-                    for timestamp in (local_opportunity, global_opportunity)
-                    if timestamp is not None
-                ),
-                default=None,
+            if local_opportunity is None and global_opportunity is None:
+                effective = None
+                source = None
+            elif global_opportunity is None or (
+                local_opportunity is not None
+                and local_opportunity[0] >= global_opportunity[0]
+            ):
+                effective = local_opportunity
+                source = "plan"
+            else:
+                effective = global_opportunity
+                source = "global"
+            last_result = record.get("last_result")
+            candidates.append(
+                _RotationCandidate(
+                    index=index,
+                    room=room,
+                    effective_timestamp=effective[0] if effective else None,
+                    effective_value=effective[1] if effective else None,
+                    source=source,
+                    last_result=last_result if isinstance(last_result, str) else None,
+                )
             )
-            return (
-                last_opportunity is not None,
-                last_opportunity if last_opportunity is not None else 0.0,
-                index,
-            )
+        return candidates
 
-        ordered = sorted(
-            enumerate(rooms),
-            key=priority,
+    async def async_begin_run(
+        self,
+        serial_number: str,
+        plan_id: str,
+        run_id: str,
+        room_count: int,
+        *,
+        trigger: str,
+        service: str,
+    ) -> None:
+        """Persist the bounded identity and provenance of a managed run."""
+        robot = self._robot(serial_number)
+        robot["last_run"] = {
+            "run_id": run_id,
+            "plan_id": plan_id,
+            "plan_name": self._plan_name(serial_number, plan_id),
+            "started_at": dt_util.utcnow().isoformat(),
+            "ended_at": None,
+            "outcome": "running",
+            "reason_code": "run_started",
+            "trigger": trigger[:64],
+            "service": service[:128],
+            "room_count": max(0, room_count),
+            "completed_room_count": 0,
+        }
+        await self._async_save_and_notify(serial_number)
+
+    async def async_finish_run(
+        self,
+        serial_number: str,
+        run_id: str,
+        outcome: str,
+        reason_code: str,
+        completed_room_count: int,
+        *,
+        terminal_activity: str | None = None,
+    ) -> bool:
+        """Persist one terminal managed-run outcome when its ID still matches."""
+        robot = self._robot(serial_number)
+        last_run = robot.get("last_run")
+        if not isinstance(last_run, dict) or last_run.get("run_id") != run_id:
+            return False
+        room_count = last_run.get("room_count")
+        max_rooms = room_count if isinstance(room_count, int) and room_count >= 0 else 0
+        last_run.update(
+            {
+                "ended_at": dt_util.utcnow().isoformat(),
+                "outcome": outcome[:64],
+                "reason_code": reason_code[:64],
+                "completed_room_count": min(max(0, completed_room_count), max_rooms),
+            }
         )
-        return [room for _, room in ordered]
+        if terminal_activity is not None:
+            last_run["terminal_activity"] = terminal_activity[:64]
+        await self._async_save_and_notify(serial_number)
+        return True
 
     async def async_mark_started(
-        self, serial_number: str, plan_id: str, room: CleaningRoom
+        self,
+        serial_number: str,
+        plan_id: str,
+        room: CleaningRoom,
+        *,
+        run_id: str | None = None,
     ) -> None:
         """Record and publish the start of one room."""
         now = dt_util.utcnow().isoformat()
@@ -899,6 +1036,8 @@ class CleaningPlanManager:
             "active_elapsed_seconds": 0,
             "active_segment_started": None,
         }
+        if run_id is not None:
+            robot["active_plan"]["run_id"] = run_id
         await self._async_save_and_notify(serial_number)
 
     async def async_mark_completed(
@@ -1275,6 +1414,7 @@ class CleaningPlanManager:
             ),
             "active_plan": deepcopy(robot.get("active_plan")),
             "last_interrupted_plan": deepcopy(robot.get("last_interrupted_plan")),
+            "last_run": deepcopy(robot.get("last_run")),
         }
 
     def _robot(self, serial_number: str) -> dict[str, Any]:
@@ -1342,6 +1482,17 @@ class CleaningPlanManager:
             changed = True
         elif "active_plan" not in robot:
             robot["active_plan"] = None
+            changed = True
+        last_run = robot.get("last_run")
+        if last_run is not None and (
+            not isinstance(last_run, dict)
+            or not isinstance(last_run.get("run_id"), str)
+            or not isinstance(last_run.get("plan_id"), str)
+        ):
+            robot["last_run"] = None
+            changed = True
+        elif "last_run" not in robot:
+            robot["last_run"] = None
             changed = True
         pending = robot.get("pending_native_reconciliation")
         if pending is not None and _validated_native_reconciliation(pending) is None:
@@ -1742,11 +1893,42 @@ def _native_room_key(value: str) -> str:
     return " ".join(value.strip().casefold().split()).removeprefix("the ")
 
 
-def _latest_timestamp(*values: object, now: datetime | None = None) -> float | None:
-    """Return the latest trusted timezone-aware room-history timestamp."""
+def _rotation_sort_key(candidate: _RotationCandidate) -> tuple[bool, float, int]:
+    """Return the stable priority key used by intelligent rotation."""
+    return (
+        candidate.effective_timestamp is not None,
+        candidate.effective_timestamp
+        if candidate.effective_timestamp is not None
+        else 0.0,
+        candidate.index,
+    )
+
+
+def _saved_order_rotation_details(
+    rooms: Sequence[CleaningRoom],
+) -> list[dict[str, Any]]:
+    """Describe an ordered plan without implying intelligent history."""
+    return [
+        {
+            "rank": rank,
+            "room_id": room.room_id,
+            "room": room.name,
+            "last_result": None,
+            "last_opportunity": None,
+            "last_opportunity_source": None,
+            "selection_reason": "saved_order",
+        }
+        for rank, room in enumerate(rooms, start=1)
+    ]
+
+
+def _latest_timestamp_value(
+    *values: object, now: datetime | None = None
+) -> tuple[float, str] | None:
+    """Return the latest trusted timestamp and its original ISO value."""
     reference = now or dt_util.utcnow()
     future_limit = reference.timestamp() + ROTATION_FUTURE_TOLERANCE_SECONDS
-    timestamps: list[float] = []
+    timestamps: list[tuple[float, str]] = []
     for value in values:
         if not isinstance(value, str):
             continue
@@ -1758,8 +1940,14 @@ def _latest_timestamp(*values: object, now: datetime | None = None) -> float | N
         except OverflowError, OSError, ValueError:
             continue
         if math.isfinite(timestamp) and timestamp <= future_limit:
-            timestamps.append(timestamp)
-    return max(timestamps, default=None)
+            timestamps.append((timestamp, value))
+    return max(timestamps, key=lambda item: item[0], default=None)
+
+
+def _latest_timestamp(*values: object, now: datetime | None = None) -> float | None:
+    """Return the latest trusted timezone-aware room-history timestamp."""
+    latest = _latest_timestamp_value(*values, now=now)
+    return latest[0] if latest is not None else None
 
 
 def _active_elapsed_seconds(active: Mapping[str, Any], now: datetime) -> int:

--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -516,6 +516,8 @@ class CleaningPlanManager:
             await self._async_persist_reconciliation_removal(
                 serial_number, reconciliation_removed
             )
+            if not self.managed_motion_is_current(serial_number, token):
+                raise ManagedMotionReplacedError("managed motion was replaced")
             yield
 
     @asynccontextmanager
@@ -1662,6 +1664,9 @@ class CleaningPlanManager:
         if serial_number in self._reconciliation_removal_pending:
             for done in pending_saves:
                 await done.wait()
+            # A failed same-generation import can restore its marker while
+            # this command waits. Remove it again before persisting ownership.
+            self._robot(serial_number).pop("pending_native_reconciliation", None)
             await self._async_save_and_notify(serial_number)
             self._reconciliation_removal_pending.discard(serial_number)
 

--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -249,6 +249,18 @@ class CleaningPlanManager:
                 recovered = True
                 continue
             recovered = self._normalize_robot(robot) or recovered
+            last_run = robot.get("last_run")
+            if isinstance(last_run, dict) and last_run.get("outcome") == "running":
+                last_run.update(
+                    {
+                        "outcome": "interrupted",
+                        "reason_code": "home_assistant_restart",
+                        "cause": "home_assistant",
+                        "ended_at": None,
+                        "recovered_at": dt_util.utcnow().isoformat(),
+                    }
+                )
+                recovered = True
             fence_value = robot.get(STOP_FENCE_EXPIRES_AT)
             fence_remaining = _stop_fence_remaining_seconds(fence_value)
             if fence_value is not None:
@@ -390,7 +402,8 @@ class CleaningPlanManager:
     @callback
     def replace_managed_motion(self, serial_number: str) -> bool:
         """Cancel any managed plan before an independent motion command."""
-        self.cancel(serial_number)
+        if self.cancel(serial_number):
+            self._cancellation_reasons.setdefault(serial_number, "motion_replaced")
         self.cancel_reconciliation_tasks(serial_number)
         reconciliation_removed = (
             self._robot(serial_number).pop("pending_native_reconciliation", None)
@@ -989,6 +1002,7 @@ class CleaningPlanManager:
         completed_room_count: int,
         *,
         terminal_activity: str | None = None,
+        cause: str = "unknown",
     ) -> bool:
         """Persist one terminal managed-run outcome when its ID still matches."""
         robot = self._robot(serial_number)
@@ -1002,6 +1016,7 @@ class CleaningPlanManager:
                 "ended_at": dt_util.utcnow().isoformat(),
                 "outcome": outcome[:64],
                 "reason_code": reason_code[:64],
+                "cause": cause[:64],
                 "completed_room_count": min(max(0, completed_room_count), max_rooms),
             }
         )

--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -226,6 +226,8 @@ class CleaningPlanManager:
         self._managed_motion: dict[str, int] = {}
         self._run_tasks: dict[str, asyncio.Task[None]] = {}
         self._reconciliation_tasks: dict[str, set[asyncio.Task[None]]] = {}
+        self._native_history_saves: dict[str, set[asyncio.Event]] = {}
+        self._reconciliation_removal_pending: set[str] = set()
         self._cancellation_reasons: dict[str, str] = {}
         self._stop_fences: dict[str, float] = {}
 
@@ -409,7 +411,9 @@ class CleaningPlanManager:
         reconciliation_removed = (
             self._robot(serial_number).pop("pending_native_reconciliation", None)
             is not None
-        )
+        ) or bool(self._native_history_saves.get(serial_number))
+        if reconciliation_removed:
+            self._reconciliation_removal_pending.add(serial_number)
         self._motion_generations[serial_number] = (
             self._motion_generations.get(serial_number, 0) + 1
         )
@@ -636,7 +640,6 @@ class CleaningPlanManager:
             return False
         robot = self._robot(serial_number)
         before = deepcopy(robot)
-        generation = self.motion_generation(serial_number)
         records = tuple(records)
         changed = _import_native_room_activity(robot, floor_plan, records)
         reconciled: list[dict[str, str]] = []
@@ -648,16 +651,7 @@ class CleaningPlanManager:
         )
         if not changed:
             return False
-        applied = deepcopy(robot)
-        try:
-            await self._store.async_save(self._data)
-        except Exception, asyncio.CancelledError:
-            if self.motion_generation(serial_number) != generation:
-                # A replacement owns marker removal even when this save fails.
-                before.pop("pending_native_reconciliation", None)
-                applied.pop("pending_native_reconciliation", None)
-            _restore_unsaved_changes(robot, before, applied)
-            raise
+        await self._async_save_native_history(serial_number, before)
         for marker in reconciled:
             entity_id = er.async_get(self.hass).async_get_entity_id(
                 "vacuum", DOMAIN, f"{serial_number}_vacuum"
@@ -675,8 +669,7 @@ class CleaningPlanManager:
                     "cause": "late_native_history",
                 },
             )
-        for listener in tuple(self._listeners.get(serial_number, ())):
-            listener()
+        self._notify_listeners(serial_number)
         return True
 
     def areas(self, serial_number: str) -> dict[str, dict[str, Any]]:
@@ -1223,6 +1216,7 @@ class CleaningPlanManager:
         therefore safe against later or superseding native sessions.
         """
         robot = self._robot(serial_number)
+        before = deepcopy(robot)
         pending = _validated_native_reconciliation(
             robot.get("pending_native_reconciliation")
         )
@@ -1230,7 +1224,8 @@ class CleaningPlanManager:
             return False
         if _native_reconciliation_expired(pending):
             robot.pop("pending_native_reconciliation", None)
-            await self._async_save_and_notify(serial_number)
+            await self._async_save_native_history(serial_number, before)
+            self._notify_listeners(serial_number)
             return False
         if (
             pending["plan_id"] != plan_id
@@ -1241,7 +1236,8 @@ class CleaningPlanManager:
         record = self._room(serial_number, plan_id, room)
         if record.get("last_result") == "completed":
             robot.pop("pending_native_reconciliation", None)
-            await self._async_save_and_notify(serial_number)
+            await self._async_save_native_history(serial_number, before)
+            self._notify_listeners(serial_number)
             return False
         completed_value = (
             completed_at
@@ -1275,7 +1271,8 @@ class CleaningPlanManager:
             global_room["last_duration_seconds"] = duration
         global_room["completed_runs"] = _stored_count(global_room, "completed_runs") + 1
         robot.pop("pending_native_reconciliation", None)
-        await self._async_save_and_notify(serial_number)
+        await self._async_save_native_history(serial_number, before)
+        self._notify_listeners(serial_number)
         return True
 
     async def async_clear_native_reconciliation(
@@ -1622,15 +1619,51 @@ class CleaningPlanManager:
 
     async def _async_save_and_notify(self, serial_number: str) -> None:
         await self._store.async_save(self._data)
+        self._notify_listeners(serial_number)
+
+    def _notify_listeners(self, serial_number: str) -> None:
         for listener in tuple(self._listeners.get(serial_number, ())):
             listener()
+
+    async def _async_save_native_history(
+        self, serial_number: str, before: dict[str, Any]
+    ) -> None:
+        """Retain retryable evidence and fence replacement behind this save."""
+        robot = self._robot(serial_number)
+        applied = deepcopy(robot)
+        generation = self.motion_generation(serial_number)
+        done = asyncio.Event()
+        saves = self._native_history_saves.setdefault(serial_number, set())
+        saves.add(done)
+        try:
+            await self._store.async_save(self._data)
+        except Exception, asyncio.CancelledError:
+            if self.motion_generation(serial_number) != generation:
+                # Replacement must persist removal after this rollback finishes.
+                if before.get("pending_native_reconciliation") is not None:
+                    self._reconciliation_removal_pending.add(serial_number)
+                before.pop("pending_native_reconciliation", None)
+                applied.pop("pending_native_reconciliation", None)
+            _restore_unsaved_changes(robot, before, applied)
+            raise
+        finally:
+            saves.discard(done)
+            if not saves:
+                self._native_history_saves.pop(serial_number, None)
+            done.set()
 
     async def _async_persist_reconciliation_removal(
         self, serial_number: str, removed: bool
     ) -> None:
         """Save a durable-marker removal before replacement motion dispatches."""
-        if removed:
+        pending_saves = tuple(self._native_history_saves.get(serial_number, ()))
+        if removed or pending_saves:
+            self._reconciliation_removal_pending.add(serial_number)
+        if serial_number in self._reconciliation_removal_pending:
+            for done in pending_saves:
+                await done.wait()
             await self._async_save_and_notify(serial_number)
+            self._reconciliation_removal_pending.discard(serial_number)
 
 
 def _restore_unsaved_changes(

--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -635,6 +635,8 @@ class CleaningPlanManager:
         if floor_plan is None:
             return False
         robot = self._robot(serial_number)
+        before = deepcopy(robot)
+        generation = self.motion_generation(serial_number)
         records = tuple(records)
         changed = _import_native_room_activity(robot, floor_plan, records)
         reconciled: list[dict[str, str]] = []
@@ -646,28 +648,35 @@ class CleaningPlanManager:
         )
         if not changed:
             return False
+        applied = deepcopy(robot)
         try:
-            await self._async_save_and_notify(serial_number)
-        finally:
-            for marker in reconciled:
-                entity_id = er.async_get(self.hass).async_get_entity_id(
-                    "vacuum", DOMAIN, f"{serial_number}_vacuum"
-                )
-                self.hass.bus.async_fire(
-                    f"{DOMAIN}_room_reconciled",
-                    {
-                        **({"entity_id": entity_id} if entity_id else {}),
-                        "plan_id": marker["plan_id"],
-                        "room_id": marker["room_id"],
-                        "room": marker["room"],
-                        **(
-                            {"run_id": marker["run_id"]} if marker.get("run_id") else {}
-                        ),
-                        "native_stop_reconciled": True,
-                        "reason_code": "native_reconciled_completion",
-                        "cause": "late_native_history",
-                    },
-                )
+            await self._store.async_save(self._data)
+        except Exception, asyncio.CancelledError:
+            if self.motion_generation(serial_number) != generation:
+                # A replacement owns marker removal even when this save fails.
+                before.pop("pending_native_reconciliation", None)
+                applied.pop("pending_native_reconciliation", None)
+            _restore_unsaved_changes(robot, before, applied)
+            raise
+        for marker in reconciled:
+            entity_id = er.async_get(self.hass).async_get_entity_id(
+                "vacuum", DOMAIN, f"{serial_number}_vacuum"
+            )
+            self.hass.bus.async_fire(
+                f"{DOMAIN}_room_reconciled",
+                {
+                    **({"entity_id": entity_id} if entity_id else {}),
+                    "plan_id": marker["plan_id"],
+                    "room_id": marker["room_id"],
+                    "room": marker["room"],
+                    **({"run_id": marker["run_id"]} if marker.get("run_id") else {}),
+                    "native_stop_reconciled": True,
+                    "reason_code": "native_reconciled_completion",
+                    "cause": "late_native_history",
+                },
+            )
+        for listener in tuple(self._listeners.get(serial_number, ())):
+            listener()
         return True
 
     def areas(self, serial_number: str) -> dict[str, dict[str, Any]]:
@@ -1622,6 +1631,26 @@ class CleaningPlanManager:
         """Save a durable-marker removal before replacement motion dispatches."""
         if removed:
             await self._async_save_and_notify(serial_number)
+
+
+def _restore_unsaved_changes(
+    current: dict[str, Any], before: dict[str, Any], applied: dict[str, Any]
+) -> None:
+    """Undo a failed import without overwriting changes made during its save."""
+    missing = object()
+    for key, value in applied.items():
+        previous = before.get(key, missing)
+        present = current.get(key, missing)
+        if all(isinstance(item, dict) for item in (previous, value, present)):
+            _restore_unsaved_changes(present, previous, value)
+        elif present == value:
+            if previous is missing:
+                current.pop(key)
+            else:
+                current[key] = previous
+    for key in before.keys() - applied.keys():
+        if key not in current:
+            current[key] = before[key]
 
 
 def _elapsed_seconds(started: object, now: datetime) -> int | None:

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -13,6 +13,7 @@ from enum import StrEnum
 from functools import partial, wraps
 from time import monotonic
 from typing import Any
+from uuid import uuid4
 
 import voluptuous as vol
 from homeassistant.auth.permissions.const import POLICY_CONTROL
@@ -58,6 +59,7 @@ from .const import (
     DATA_FIRMWARE_TRACKER,
     DATA_PLAN_MANAGER,
     DOMAIN,
+    EVENT_PLAN_FINISHED,
 )
 from .firmware import (
     FirmwareTracker,
@@ -517,6 +519,11 @@ async def async_register_services(hass: HomeAssistant) -> None:
             mapped_room_names=tuple(room_map.values()),
             floor_is_current=floor_is_current,
             floor_token=execution_floor_token,
+            set_activity_run_id=getattr(
+                getattr(entry.runtime_data.client, "activity_journal", None),
+                "set_run_id",
+                None,
+            ),
         )
 
     async def async_clean_room_sequence(call: ServiceCall) -> None:
@@ -601,6 +608,11 @@ async def async_register_services(hass: HomeAssistant) -> None:
             mapped_room_names=tuple(room_map.values()),
             floor_is_current=floor_is_current,
             floor_token=execution_floor_token,
+            set_activity_run_id=getattr(
+                getattr(entry.runtime_data.client, "activity_journal", None),
+                "set_run_id",
+                None,
+            ),
         )
 
     hass.services.async_register(
@@ -1095,6 +1107,7 @@ async def _async_run_room(
     floor_token: str | None = None,
     session_identity: Callable[[], Awaitable[bytes | None]] | None = None,
     on_native_identity: Callable[[bytes | None], None] | None = None,
+    run_id: str | None = None,
 ) -> bool:
     """Run one room and report whether native history verified completion."""
     if not room_name_is_unique:
@@ -1110,8 +1123,11 @@ async def _async_run_room(
         "room": room.name,
         "cleaning_mode": room.cleaning_mode,
         "coverage_setting": room.coverage_setting,
+        "run_id": run_id,
     }
-    await manager.async_mark_started(serial_number, call.data["plan_id"], room)
+    await manager.async_mark_started(
+        serial_number, call.data["plan_id"], room, run_id=run_id
+    )
     hass.bus.async_fire(f"{DOMAIN}_room_started", event_data, context=call.context)
     completion_verified = False
     dispatch_attempted = False
@@ -1293,7 +1309,9 @@ async def _async_run_room(
     except ManagedMotionReplacedError as err:
         await manager.async_mark_cancelled(serial_number, call.data["plan_id"], room)
         hass.bus.async_fire(
-            f"{DOMAIN}_room_cancelled", event_data, context=call.context
+            f"{DOMAIN}_room_cancelled",
+            {**event_data, "reason_code": "managed_cancelled", "cause": "replacement"},
+            context=call.context,
         )
         raise PlanCancelledError from err
     except PlanCancelledError:
@@ -1319,14 +1337,26 @@ async def _async_run_room(
                     ),
                 )
             hass.bus.async_fire(
-                f"{DOMAIN}_room_interrupted", event_data, context=call.context
+                f"{DOMAIN}_room_interrupted",
+                {
+                    **event_data,
+                    "reason_code": "config_entry_unload",
+                    "cause": "home_assistant",
+                },
+                context=call.context,
             )
         else:
             await manager.async_mark_cancelled(
                 serial_number, call.data["plan_id"], room
             )
             hass.bus.async_fire(
-                f"{DOMAIN}_room_cancelled", event_data, context=call.context
+                f"{DOMAIN}_room_cancelled",
+                {
+                    **event_data,
+                    "reason_code": "managed_cancelled",
+                    "cause": "managed_cancellation",
+                },
+                context=call.context,
             )
         raise
     except RoomTakenOverError as err:
@@ -1335,7 +1365,12 @@ async def _async_run_room(
         )
         hass.bus.async_fire(
             f"{DOMAIN}_room_interrupted",
-            {**event_data, "error": str(err)},
+            {
+                **event_data,
+                "error": str(err),
+                "reason_code": "native_task_taken_over",
+                "cause": "unknown",
+            },
             context=call.context,
         )
         raise _validation_error(
@@ -1388,7 +1423,12 @@ async def _async_run_room(
             )
         hass.bus.async_fire(
             f"{DOMAIN}_room_interrupted",
-            {**event_data, "error": str(err)},
+            {
+                **event_data,
+                "error": str(err),
+                "reason_code": _interruption_reason_code(err),
+                "cause": "unknown",
+            },
             context=call.context,
         )
         raise _validation_error(
@@ -1443,7 +1483,12 @@ async def _async_run_room(
             )
         hass.bus.async_fire(
             f"{DOMAIN}_room_failed",
-            {**event_data, "error": failure_reason},
+            {
+                **event_data,
+                "error": failure_reason,
+                "reason_code": _failure_reason_code(err),
+                "cause": "unknown",
+            },
             context=call.context,
         )
         if isinstance(err, ServiceValidationError):
@@ -1474,14 +1519,22 @@ async def _async_run_room(
         if confirm_room_completed is not None:
             confirm_room_completed(room.name)
         hass.bus.async_fire(
-            f"{DOMAIN}_room_completed", event_data, context=call.context
+            f"{DOMAIN}_room_completed",
+            {**event_data, "reason_code": "verified_completion"},
+            context=call.context,
         )
     else:
         await manager.async_mark_ended_unverified(
             serial_number, call.data["plan_id"], room
         )
         hass.bus.async_fire(
-            f"{DOMAIN}_room_ended_unverified", event_data, context=call.context
+            f"{DOMAIN}_room_ended_unverified",
+            {
+                **event_data,
+                "reason_code": "unverified_completion",
+                "cause": "unknown",
+            },
+            context=call.context,
         )
     if completion_verified and prefetch_next is not None:
         await prefetch_next()
@@ -1511,6 +1564,7 @@ async def _async_run_leg(
     floor_token: str | None = None,
     session_identity: Callable[[], Awaitable[bytes | None]] | None = None,
     on_native_identity: Callable[[bytes | None], None] | None = None,
+    run_id: str | None = None,
 ) -> bool:
     """Run one mission leg and credit only natively verified rooms.
 
@@ -1542,6 +1596,7 @@ async def _async_run_leg(
             floor_token=floor_token,
             session_identity=session_identity,
             on_native_identity=on_native_identity,
+            run_id=run_id,
         )
     if not room_name_is_unique:
         raise _validation_error(
@@ -1558,11 +1613,14 @@ async def _async_run_leg(
             "room": room.name,
             "cleaning_mode": room.cleaning_mode,
             "coverage_setting": room.coverage_setting,
+            "run_id": run_id,
         }
 
     active_room = leg[0]
     observed_ids = {active_room.room_id}
-    await manager.async_mark_started(serial_number, call.data["plan_id"], active_room)
+    await manager.async_mark_started(
+        serial_number, call.data["plan_id"], active_room, run_id=run_id
+    )
     hass.bus.async_fire(
         f"{DOMAIN}_room_started", event_data(active_room), context=call.context
     )
@@ -1683,7 +1741,10 @@ async def _async_run_leg(
                         first_observation = active_room.room_id not in observed_ids
                         observed_ids.add(active_room.room_id)
                         await manager.async_mark_started(
-                            serial_number, call.data["plan_id"], active_room
+                            serial_number,
+                            call.data["plan_id"],
+                            active_room,
+                            run_id=run_id,
                         )
                         if first_observation:
                             hass.bus.async_fire(
@@ -1768,7 +1829,13 @@ async def _async_run_leg(
             serial_number, call.data["plan_id"], active_room
         )
         hass.bus.async_fire(
-            f"{DOMAIN}_room_cancelled", event_data(active_room), context=call.context
+            f"{DOMAIN}_room_cancelled",
+            {
+                **event_data(active_room),
+                "reason_code": "managed_cancelled",
+                "cause": "replacement",
+            },
+            context=call.context,
         )
         raise PlanCancelledError from err
     except PlanCancelledError:
@@ -1786,7 +1853,11 @@ async def _async_run_leg(
             )
             hass.bus.async_fire(
                 f"{DOMAIN}_room_interrupted",
-                event_data(active_room),
+                {
+                    **event_data(active_room),
+                    "reason_code": "config_entry_unload",
+                    "cause": "home_assistant",
+                },
                 context=call.context,
             )
         else:
@@ -1795,7 +1866,11 @@ async def _async_run_leg(
             )
             hass.bus.async_fire(
                 f"{DOMAIN}_room_cancelled",
-                event_data(active_room),
+                {
+                    **event_data(active_room),
+                    "reason_code": "managed_cancelled",
+                    "cause": "managed_cancellation",
+                },
                 context=call.context,
             )
         raise
@@ -1810,7 +1885,12 @@ async def _async_run_leg(
         )
         hass.bus.async_fire(
             f"{DOMAIN}_room_interrupted",
-            {**event_data(active_room), "error": str(err)},
+            {
+                **event_data(active_room),
+                "error": str(err),
+                "reason_code": _interruption_reason_code(err),
+                "cause": "unknown",
+            },
             context=call.context,
         )
         raise _validation_error(
@@ -1822,7 +1902,12 @@ async def _async_run_leg(
         )
         hass.bus.async_fire(
             f"{DOMAIN}_room_interrupted",
-            {**event_data(active_room), "error": str(err)},
+            {
+                **event_data(active_room),
+                "error": str(err),
+                "reason_code": "native_task_taken_over",
+                "cause": "unknown",
+            },
             context=call.context,
         )
         raise _validation_error(
@@ -1849,7 +1934,12 @@ async def _async_run_leg(
         )
         hass.bus.async_fire(
             f"{DOMAIN}_room_failed",
-            {**event_data(active_room), "error": failure_reason},
+            {
+                **event_data(active_room),
+                "error": failure_reason,
+                "reason_code": _failure_reason_code(err),
+                "cause": "unknown",
+            },
             context=call.context,
         )
         if isinstance(err, ServiceValidationError):
@@ -1889,14 +1979,22 @@ async def _async_run_leg(
             if confirm_room_completed is not None:
                 confirm_room_completed(room.name)
             hass.bus.async_fire(
-                f"{DOMAIN}_room_completed", event_data(room), context=call.context
+                f"{DOMAIN}_room_completed",
+                {**event_data(room), "reason_code": "verified_completion"},
+                context=call.context,
             )
         elif stop_sent and room.room_id not in observed_ids:
             await manager.async_mark_cancelled(
                 serial_number, call.data["plan_id"], room
             )
             hass.bus.async_fire(
-                f"{DOMAIN}_room_cancelled", event_data(room), context=call.context
+                f"{DOMAIN}_room_cancelled",
+                {
+                    **event_data(room),
+                    "reason_code": "managed_cancelled",
+                    "cause": "finish_current_room_or_stop",
+                },
+                context=call.context,
             )
         else:
             await manager.async_mark_ended_unverified(
@@ -1904,7 +2002,11 @@ async def _async_run_leg(
             )
             hass.bus.async_fire(
                 f"{DOMAIN}_room_ended_unverified",
-                event_data(room),
+                {
+                    **event_data(room),
+                    "reason_code": "unverified_completion",
+                    "cause": "unknown",
+                },
                 context=call.context,
             )
     all_verified = all(room.room_id in credited for room in leg)
@@ -2617,6 +2719,8 @@ async def _async_reconcile_native_stop(
                         "room_id": room.room_id,
                         "room": room.name,
                         "native_stop_reconciled": True,
+                        "reason_code": "native_reconciled_completion",
+                        "cause": "late_native_history",
                     },
                     context=context,
                 )
@@ -3033,6 +3137,24 @@ class RoomStoppedInPlaceError(RoomInterruptedError):
     """
 
 
+def _failure_reason_code(error: BaseException) -> str:
+    """Map an internal failure to a stable, non-sensitive event code."""
+    if isinstance(error, RoomStartTimeoutError):
+        return "start_timeout"
+    if isinstance(error, TimeoutError):
+        return "completion_timeout"
+    if isinstance(error, MaticError):
+        return "robot_error"
+    return "managed_failure"
+
+
+def _interruption_reason_code(error: RoomInterruptedError) -> str:
+    """Map an unverified room terminal state without guessing its cause."""
+    if isinstance(error, RoomStoppedInPlaceError):
+        return "stopped_in_place"
+    return "interrupted"
+
+
 class RoomTakenOverError(HomeAssistantError):
     """The native task ended, changed, or could no longer be identified."""
 
@@ -3056,6 +3178,7 @@ async def _async_execute_rooms(
     floor_is_current: Callable[[], bool] | None = None,
     floor_token: str | None = None,
     session_identity: Callable[[], Awaitable[bytes | None]] | None = None,
+    set_activity_run_id: Callable[[str | None], None] | None = None,
 ) -> None:
     """Execute every resolved room with safe cancellation semantics."""
     lock = manager.lock(serial_number)
@@ -3069,6 +3192,14 @@ async def _async_execute_rooms(
         motion_token = manager.begin_managed_motion(serial_number)
         cleanup_stop_sent = False
         native_identity: bytes | None = None
+        run_id = uuid4().hex
+        run_started_at = dt_util.utcnow().isoformat()
+        run_started = False
+        run_outcome = "failed"
+        run_reason_code = "run_not_finished"
+        run_cause = "unknown"
+        completed_room_names: set[str] = set()
+        chosen: list[CleaningRoom] = []
 
         def bind_native_identity(identity: bytes | None) -> None:
             nonlocal native_identity
@@ -3082,6 +3213,14 @@ async def _async_execute_rooms(
             lambda: native_identity,
             allow_ended_dock=True,
         )
+        if set_activity_run_id is not None:
+            set_activity_run_id(run_id)
+
+        def record_room_completion(room_name: str) -> None:
+            completed_room_names.add(room_name)
+            if confirm_room_completed is not None:
+                confirm_room_completed(room_name)
+
         try:
             # Publish ownership before the first suspending check. Otherwise
             # Stop can observe no run while this start waits for an old stop
@@ -3094,6 +3233,17 @@ async def _async_execute_rooms(
                 else rooms
             )
             legs = leg_groups(chosen)
+            begin_run = getattr(manager, "async_begin_run", None)
+            if isinstance(manager, CleaningPlanManager) and callable(begin_run):
+                await begin_run(
+                    serial_number,
+                    call.data["plan_id"],
+                    run_id,
+                    len(chosen),
+                    trigger="service_call",
+                    service=str(call.service),
+                )
+                run_started = True
             prepared_dispatches: dict[str, _PreparedRoomDispatch] = {}
             for index, leg in enumerate(legs):
                 if cancel_event.is_set() or not manager.managed_motion_is_current(
@@ -3153,7 +3303,7 @@ async def _async_execute_rooms(
                     motion_token,
                     active_session,
                     session_history,
-                    confirm_room_completed,
+                    record_room_completion,
                     managed_user_command,
                     room_name_is_unique=(
                         not mapped_room_names
@@ -3173,6 +3323,7 @@ async def _async_execute_rooms(
                     floor_token=floor_token,
                     session_identity=session_identity,
                     on_native_identity=bind_native_identity,
+                    run_id=run_id,
                 )
                 if not completion_verified:
                     break
@@ -3189,6 +3340,19 @@ async def _async_execute_rooms(
                         )
                         cleanup_stop_sent = _stop_is_pending(manager, serial_number)
                     break
+            completed_room_count = len(completed_room_names)
+            if finish_room_event.is_set() and completed_room_count < len(chosen):
+                run_outcome = "stopped"
+                run_reason_code = "managed_stop"
+                run_cause = "managed_cancellation"
+            elif completed_room_count == len(chosen):
+                run_outcome = "completed"
+                run_reason_code = "all_rooms_verified"
+                run_cause = "verified_completion"
+            else:
+                run_outcome = "partial"
+                run_reason_code = "partial_native_result"
+                run_cause = "native_result"
             if cancel_event.is_set() or not manager.managed_motion_is_current(
                 serial_number, motion_token
             ):
@@ -3211,8 +3375,25 @@ async def _async_execute_rooms(
                         "robot_command_failed",
                     ) from err
         except PlanCancelledError:
+            cancellation_reason_reader = getattr(manager, "cancellation_reason", None)
+            cancellation_reason = (
+                cancellation_reason_reader(serial_number)
+                if callable(cancellation_reason_reader)
+                else None
+            )
+            if cancellation_reason == "config_entry_unload":
+                run_outcome = "interrupted"
+                run_reason_code = "config_entry_unload"
+                run_cause = "home_assistant"
+            else:
+                run_outcome = "stopped"
+                run_reason_code = "managed_stop"
+                run_cause = "managed_cancellation"
             return
         except (Exception, asyncio.CancelledError) as err:
+            run_outcome = "failed"
+            run_reason_code = _failure_reason_code(err)
+            run_cause = "internal"
             # Leaf handlers retire expected failures. Unexpected failures must
             # also leave a terminal record before ownership is released.
             active = manager.snapshot(serial_number)["active_plan"]
@@ -3240,7 +3421,10 @@ async def _async_execute_rooms(
                             "room_id": room.room_id,
                             "cleaning_mode": room.cleaning_mode,
                             "coverage_setting": room.coverage_setting,
+                            "run_id": run_id,
                             "error": reason,
+                            "reason_code": "unexpected_exception",
+                            "cause": "internal",
                         },
                         context=call.context,
                     )
@@ -3269,6 +3453,52 @@ async def _async_execute_rooms(
         finally:
             manager.end_managed_motion(serial_number, motion_token)
             manager.unregister_run_task(serial_number)
+            if run_started:
+                finished_at = dt_util.utcnow().isoformat()
+                states = getattr(hass, "states", None)
+                state_getter = getattr(states, "get", None)
+                current_state = (
+                    state_getter(entity_id) if callable(state_getter) else None
+                )
+                terminal_activity = (
+                    str(getattr(current_state, "state", "unknown"))
+                    if current_state is not None
+                    else "unknown"
+                )
+                finish_run = getattr(manager, "async_finish_run", None)
+                if callable(finish_run):
+                    await finish_run(
+                        serial_number,
+                        run_id,
+                        run_outcome,
+                        run_reason_code,
+                        len(completed_room_names),
+                        terminal_activity=terminal_activity,
+                    )
+                bus = getattr(hass, "bus", None)
+                fire = getattr(bus, "async_fire", None)
+                if callable(fire):
+                    fire(
+                        EVENT_PLAN_FINISHED,
+                        {
+                            ATTR_ENTITY_ID: entity_id,
+                            "plan_id": call.data["plan_id"],
+                            "run_id": run_id,
+                            "trigger": "service_call",
+                            "service": str(call.service),
+                            "started_at": run_started_at,
+                            "ended_at": finished_at,
+                            "outcome": run_outcome,
+                            "reason_code": run_reason_code,
+                            "cause": run_cause,
+                            "terminal_activity": terminal_activity,
+                            "room_count": len(chosen),
+                            "completed_room_count": len(completed_room_names),
+                        },
+                        context=call.context,
+                    )
+            if set_activity_run_id is not None:
+                set_activity_run_id(None)
 
 
 async def _ensure_stop_settled(

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -1354,7 +1354,12 @@ async def _async_run_room(
                 {
                     **event_data,
                     "reason_code": "managed_cancelled",
-                    "cause": "managed_cancellation",
+                    "cause": (
+                        "replacement"
+                        if manager.cancellation_reason(serial_number)
+                        == "motion_replaced"
+                        else "managed_cancellation"
+                    ),
                 },
                 context=call.context,
             )
@@ -1869,7 +1874,12 @@ async def _async_run_leg(
                 {
                     **event_data(active_room),
                     "reason_code": "managed_cancelled",
-                    "cause": "managed_cancellation",
+                    "cause": (
+                        "replacement"
+                        if manager.cancellation_reason(serial_number)
+                        == "motion_replaced"
+                        else "managed_cancellation"
+                    ),
                 },
                 context=call.context,
             )
@@ -3139,6 +3149,8 @@ class RoomStoppedInPlaceError(RoomInterruptedError):
 
 def _failure_reason_code(error: BaseException) -> str:
     """Map an internal failure to a stable, non-sensitive event code."""
+    if isinstance(error, ServiceValidationError) and error.__cause__ is not None:
+        error = error.__cause__
     if isinstance(error, RoomStartTimeoutError):
         return "start_timeout"
     if isinstance(error, TimeoutError):
@@ -3374,7 +3386,7 @@ async def _async_execute_rooms(
                         "The robot could not return to its dock",
                         "robot_command_failed",
                     ) from err
-        except PlanCancelledError:
+        except PlanCancelledError as err:
             cancellation_reason_reader = getattr(manager, "cancellation_reason", None)
             cancellation_reason = (
                 cancellation_reason_reader(serial_number)
@@ -3385,6 +3397,12 @@ async def _async_execute_rooms(
                 run_outcome = "interrupted"
                 run_reason_code = "config_entry_unload"
                 run_cause = "home_assistant"
+            elif cancellation_reason == "motion_replaced" or isinstance(
+                err.__cause__, ManagedMotionReplacedError
+            ):
+                run_outcome = "stopped"
+                run_reason_code = "managed_replaced"
+                run_cause = "replacement"
             else:
                 run_outcome = "stopped"
                 run_reason_code = "managed_stop"
@@ -3407,7 +3425,11 @@ async def _async_execute_rooms(
                 return
             run_outcome = "failed"
             run_reason_code = _failure_reason_code(err)
-            run_cause = "internal"
+            run_cause = (
+                "unknown"
+                if isinstance(err, HomeAssistantError | MaticError | TimeoutError)
+                else "internal"
+            )
             # Leaf handlers retire expected failures. Unexpected failures must
             # also leave a terminal record before ownership is released.
             active = manager.snapshot(serial_number)["active_plan"]
@@ -3488,6 +3510,7 @@ async def _async_execute_rooms(
                         run_reason_code,
                         len(completed_room_names),
                         terminal_activity=terminal_activity,
+                        cause=run_cause,
                     )
                 bus = getattr(hass, "bus", None)
                 fire = getattr(bus, "async_fire", None)

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -150,6 +150,7 @@ class _NativeReconciliation:
     room: str
     dispatched_at: datetime
     cleaning_mode: str | None = None
+    run_id: str | None = None
 
 
 CLEAN_SERVICE_SCHEMA = cv.make_entity_service_schema(
@@ -1322,7 +1323,7 @@ async def _async_run_room(
                 dispatch_attempted,
             )
             reconciliation = _build_native_reconciliation(
-                call.data["plan_id"], room, dispatched_at, room_started
+                call.data["plan_id"], room, dispatched_at, room_started, run_id=run_id
             )
             async with _managed_reconciliation_guard(
                 manager, serial_number, motion_token
@@ -1393,7 +1394,7 @@ async def _async_run_room(
             None
             if isinstance(err, RoomStoppedInPlaceError)
             else _build_native_reconciliation(
-                call.data["plan_id"], room, dispatched_at, room_started
+                call.data["plan_id"], room, dispatched_at, room_started, run_id=run_id
             )
         )
         async with _managed_reconciliation_guard(
@@ -1454,7 +1455,7 @@ async def _async_run_room(
         else:
             failure_reason = str(err).strip() or "The managed room failed"
         reconciliation = _build_native_reconciliation(
-            call.data["plan_id"], room, dispatched_at, room_started
+            call.data["plan_id"], room, dispatched_at, room_started, run_id=run_id
         )
         async with _managed_reconciliation_guard(
             manager, serial_number, motion_token
@@ -2586,12 +2587,14 @@ def _build_native_reconciliation(
     room: CleaningRoom,
     dispatched_at: datetime | None,
     room_started: bool,
+    *,
+    run_id: str | None = None,
 ) -> _NativeReconciliation | None:
     """Build a late-native marker only after the robot visibly started the room."""
     if not room_started or dispatched_at is None:
         return None
     return _NativeReconciliation(
-        plan_id, room.room_id, room.name, dispatched_at, room.cleaning_mode
+        plan_id, room.room_id, room.name, dispatched_at, room.cleaning_mode, run_id
     )
 
 
@@ -2607,6 +2610,7 @@ def _native_reconciliation_data(
         "room": value.room,
         "dispatched_at": value.dispatched_at.isoformat(),
         **({"cleaning_mode": value.cleaning_mode} if value.cleaning_mode else {}),
+        **({"run_id": value.run_id} if value.run_id else {}),
     }
 
 
@@ -2731,6 +2735,11 @@ async def _async_reconcile_native_stop(
                         "native_stop_reconciled": True,
                         "reason_code": "native_reconciled_completion",
                         "cause": "late_native_history",
+                        **(
+                            {"run_id": reconciliation.run_id}
+                            if reconciliation.run_id
+                            else {}
+                        ),
                     },
                     context=context,
                 )
@@ -3426,6 +3435,20 @@ async def _async_execute_rooms(
                 run_reason_code = "stopped_in_place"
                 run_cause = "unknown"
                 return
+            leaf_error = (
+                err.__cause__
+                if isinstance(err, ServiceValidationError) and err.__cause__ is not None
+                else err
+            )
+            if isinstance(leaf_error, RoomInterruptedError | RoomTakenOverError):
+                run_outcome = "interrupted"
+                run_reason_code = (
+                    "native_task_taken_over"
+                    if isinstance(leaf_error, RoomTakenOverError)
+                    else _interruption_reason_code(leaf_error)
+                )
+                run_cause = "unknown"
+                raise
             run_outcome = "failed"
             run_reason_code = _failure_reason_code(err)
             run_cause = (
@@ -3490,55 +3513,59 @@ async def _async_execute_rooms(
                         )
             raise
         finally:
-            manager.end_managed_motion(serial_number, motion_token)
-            manager.unregister_run_task(serial_number)
-            if run_started:
-                finished_at = dt_util.utcnow().isoformat()
-                states = getattr(hass, "states", None)
-                state_getter = getattr(states, "get", None)
-                current_state = (
-                    state_getter(entity_id) if callable(state_getter) else None
-                )
-                terminal_activity = (
-                    str(getattr(current_state, "state", "unknown"))
-                    if current_state is not None
-                    else "unknown"
-                )
-                finish_run = getattr(manager, "async_finish_run", None)
-                if callable(finish_run):
-                    await finish_run(
-                        serial_number,
-                        run_id,
-                        run_outcome,
-                        run_reason_code,
-                        len(completed_room_names),
-                        terminal_activity=terminal_activity,
-                        cause=run_cause,
+            try:
+                if run_started:
+                    finished_at = dt_util.utcnow().isoformat()
+                    states = getattr(hass, "states", None)
+                    state_getter = getattr(states, "get", None)
+                    current_state = (
+                        state_getter(entity_id) if callable(state_getter) else None
                     )
-                bus = getattr(hass, "bus", None)
-                fire = getattr(bus, "async_fire", None)
-                if callable(fire):
-                    fire(
-                        EVENT_PLAN_FINISHED,
-                        {
-                            ATTR_ENTITY_ID: entity_id,
-                            "plan_id": call.data["plan_id"],
-                            "run_id": run_id,
-                            "trigger": "service_call",
-                            "service": str(call.service),
-                            "started_at": run_started_at,
-                            "ended_at": finished_at,
-                            "outcome": run_outcome,
-                            "reason_code": run_reason_code,
-                            "cause": run_cause,
-                            "terminal_activity": terminal_activity,
-                            "room_count": len(chosen),
-                            "completed_room_count": len(completed_room_names),
-                        },
-                        context=call.context,
+                    terminal_activity = (
+                        str(getattr(current_state, "state", "unknown"))
+                        if current_state is not None
+                        else "unknown"
                     )
-            if set_activity_run_id is not None:
-                set_activity_run_id(None)
+                    try:
+                        finish_run = getattr(manager, "async_finish_run", None)
+                        if callable(finish_run):
+                            await finish_run(
+                                serial_number,
+                                run_id,
+                                run_outcome,
+                                run_reason_code,
+                                len(completed_room_names),
+                                terminal_activity=terminal_activity,
+                                cause=run_cause,
+                            )
+                    finally:
+                        bus = getattr(hass, "bus", None)
+                        fire = getattr(bus, "async_fire", None)
+                        if callable(fire):
+                            fire(
+                                EVENT_PLAN_FINISHED,
+                                {
+                                    ATTR_ENTITY_ID: entity_id,
+                                    "plan_id": call.data["plan_id"],
+                                    "run_id": run_id,
+                                    "trigger": "service_call",
+                                    "service": str(call.service),
+                                    "started_at": run_started_at,
+                                    "ended_at": finished_at,
+                                    "outcome": run_outcome,
+                                    "reason_code": run_reason_code,
+                                    "cause": run_cause,
+                                    "terminal_activity": terminal_activity,
+                                    "room_count": len(chosen),
+                                    "completed_room_count": len(completed_room_names),
+                                },
+                                context=call.context,
+                            )
+            finally:
+                manager.end_managed_motion(serial_number, motion_token)
+                manager.unregister_run_task(serial_number)
+                if set_activity_run_id is not None:
+                    set_activity_run_id(None)
 
 
 async def _ensure_stop_settled(

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -3259,6 +3259,7 @@ async def _async_execute_rooms(
             legs = leg_groups(chosen)
             begin_run = getattr(manager, "async_begin_run", None)
             if isinstance(manager, CleaningPlanManager) and callable(begin_run):
+                run_started = True
                 await begin_run(
                     serial_number,
                     call.data["plan_id"],
@@ -3267,7 +3268,6 @@ async def _async_execute_rooms(
                     trigger="service_call",
                     service=str(call.service),
                 )
-                run_started = True
             prepared_dispatches: dict[str, _PreparedRoomDispatch] = {}
             for index, leg in enumerate(legs):
                 if cancel_event.is_set() or not manager.managed_motion_is_current(

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -3391,6 +3391,20 @@ async def _async_execute_rooms(
                 run_cause = "managed_cancellation"
             return
         except (Exception, asyncio.CancelledError) as err:
+            # A native task that ends in place is positive evidence that the
+            # room was stopped, but it does not identify who or what stopped
+            # it.  Keep the no-credit guard from the room handler while
+            # treating this expected partial plan outcome as a controlled
+            # result, so a presence automation does not turn a valid stop into
+            # a generic service error.
+            stopped_in_place = isinstance(err, RoomStoppedInPlaceError) or isinstance(
+                getattr(err, "__cause__", None), RoomStoppedInPlaceError
+            )
+            if stopped_in_place:
+                run_outcome = "partial"
+                run_reason_code = "stopped_in_place"
+                run_cause = "unknown"
+                return
             run_outcome = "failed"
             run_reason_code = _failure_reason_code(err)
             run_cause = "internal"

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -3155,7 +3155,10 @@ def _failure_reason_code(error: BaseException) -> str:
         return "start_timeout"
     if isinstance(error, TimeoutError):
         return "completion_timeout"
-    if isinstance(error, MaticError):
+    if isinstance(error, MaticError) or (
+        isinstance(error, ServiceValidationError)
+        and error.translation_key == "robot_error"
+    ):
         return "robot_error"
     return "managed_failure"
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@
 | Build an automation | [Actions, events, and examples](automation.md) |
 | Understand cleaning history | [Cleaning results](native-cleaning-results.md) |
 | Investigate unexpected docking or stopping | [Activity diagnostics](activity-diagnostics.md) |
+| Verify the managed cleaning contract | [End-to-end contract](e2e-contract.md) |
 | Check my setup | [Compatibility](acceptance-0.4.md) |
 | Understand stored data | [Privacy](privacy.md) |
 

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -28,7 +28,7 @@ For pause, resume, stop, and dock, use Home Assistant's standard vacuum actions.
 | Action | Fields and behavior |
 | --- | --- |
 | `list_plans` | Return saved plans. |
-| `preview_plan` | Return optional `plan`'s next room order and settings without running it. |
+| `preview_plan` | Return optional `plan`'s next room order, settings, and rotation rationale without running it. |
 | `save_plan` | Create or update a plan with `name` and `rooms`; pass `plan_id` to update. |
 | `select_plan` | Set required `plan` as the default. |
 | `delete_plan` | Delete required `plan`. |

--- a/docs/activity-diagnostics.md
+++ b/docs/activity-diagnostics.md
@@ -7,7 +7,10 @@ plan, download the integration diagnostics soon afterward. `activity_observation
 contains the last 512 command and state observations from the current integration
 load. Older observations are evicted; reloading or restarting clears this buffer.
 The administrator-only `MaticGetActivity` tool reads this journal directly;
-`MaticGetRecentEvents` mixes recent observations into its last 64 operational events.
+`MaticGetRecentEvents` returns the last 64 low-volume operational events by
+default, so polling observations cannot evict room and terminal evidence. Pass
+`include_activity: true` when a combined current-process trail is needed; use
+`MaticGetActivity` for the paginated raw journal.
 
 The integration emits `matic_robot_activity_observed` events locally. Home
 Assistant Recorder can retain these across restarts according to its event
@@ -17,6 +20,8 @@ exclusions and retention settings. No debug logging needs to be enabled.
 
 - `observation_session` identifies one integration load. `sequence` orders its
   observations, and `observed_at` is the Home Assistant receipt time in UTC.
+- `run_id` links integration commands and raw state observations to one managed
+  plan run. It is a random local token, not a user or account identifier.
 - `command_requested` identifies the integration's intended command, including
   internal cleanup. Later records refer to its sequence as `command_id`.
 - `command_sending` means transmission began. A subsequent failure or cancellation
@@ -62,6 +67,19 @@ every room finished. An ended-in-place interruption records missing managed
 completion evidence; it does not identify who stopped the robot or prove a fault.
 Native firmware can also report a stopped room as completed, so history alone
 does not override that guard or retrospectively award managed completion credit.
+
+Managed room events include a stable `reason_code` for machine handling. Codes
+such as `verified_completion`, `unverified_completion`, `stopped_in_place`,
+`native_task_taken_over`, `start_timeout`, `completion_timeout`, and
+`robot_error` describe the observed terminal path. A `cause` of `unknown` is
+intentional when the integration cannot prove whether an OEM app, physical
+control, or robot decision caused the transition; it must not be replaced with
+an inferred user or account identity.
+
+The `matic_robot_plan_finished` event is the managed-run boundary. Match its
+`run_id` to room events, `MaticGetActivity`, and the `last_run` plan snapshot.
+Its verified room count and outcome describe the plan runner; native history
+remains a separate robot-side evidence source.
 
 For a controlled reproduction, supervise one plan with presence automation
 temporarily disabled and avoid OEM-app or physical-control input. Note any

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -96,11 +96,12 @@ before automating the switch.
 | Event | Meaning |
 | --- | --- |
 | `matic_robot_room_started` | A managed room started; emitted once per room in a mission |
-| `matic_robot_room_completed` | Verified managed completion; updates last-cleaned and duration statistics |
-| `matic_robot_room_failed` | A managed room failed |
-| `matic_robot_room_cancelled` | A managed room was cancelled |
-| `matic_robot_room_interrupted` | A managed task was stopped or replaced |
-| `matic_robot_room_ended_unverified` | The task ended without sufficient completion evidence |
+| `matic_robot_room_completed` | Verified managed completion; updates last-cleaned and duration statistics (`reason_code: verified_completion`) |
+| `matic_robot_room_failed` | A managed room failed; `reason_code` distinguishes start timeout, completion timeout, robot error, or managed failure |
+| `matic_robot_room_cancelled` | A managed room was cancelled; the event includes a machine-readable `reason_code` and cause |
+| `matic_robot_room_interrupted` | A managed task was stopped or replaced; `reason_code` identifies the observed path while `cause: unknown` remains when the source is unproven |
+| `matic_robot_room_ended_unverified` | The task ended without sufficient completion evidence (`reason_code: unverified_completion`) |
+| `matic_robot_plan_finished` | One managed plan run ended; includes `run_id`, `outcome`, `reason_code`, `cause`, safe trigger/service labels, terminal activity, and verified room counts |
 | `matic_robot_cleaning_finished` | A newly ended native session, with times, duration, room results, and robot identifiers |
 | `matic_robot_firmware_changed` | A new firmware/protocol pair, with previous values and robot identifiers |
 | `matic_robot_firmware_analyzed` | Endpoint comparison counts and new wire paths |

--- a/docs/e2e-contract.md
+++ b/docs/e2e-contract.md
@@ -6,9 +6,9 @@ The managed runner keeps seven evidence boundaries explicit. A clean native
 history record is useful evidence, but it is not by itself proof that a saved
 plan completed or that a person caused a stop.
 
-1. **Managed outcomes.** Every managed run gets one local `run_id` and a
-   `matic_robot_plan_finished` event. Its `outcome` is `completed`, `partial`,
-   `stopped`, `failed`, or `interrupted`; `reason_code`, `cause`, and verified
+1. **Managed outcomes.** Every managed run gets one local `run_id` and emits a
+   `matic_robot_plan_finished` event when its runner exits. Its `outcome` is
+   `completed`, `partial`, `stopped`, `failed`, or `interrupted`; `reason_code`, `cause`, and verified
    room counts explain the result. `room_completed` is emitted only after the
    existing native completion guard passes.
 2. **Trigger provenance.** The run record carries the safe `trigger` label and
@@ -43,10 +43,16 @@ plan completed or that a person caused a stop.
 | All selected rooms verify | `plan_finished: completed`, matching `run_id`, all room events | Credit verified rooms only |
 | Native session ends early | `plan_finished: partial`, `partial_native_result`, `stopped_in_place`, or `unverified_completion` | Leave unverified rooms due; a known in-place stop is a controlled partial result, not a generic service fault |
 | Managed stop | `plan_finished: stopped`, `managed_stop`, stop command/activity when available | Do not credit the unfinished room |
+| Independent command replaces a plan | `plan_finished: stopped`, `managed_replaced`, `cause: replacement` | Do not credit the unfinished room or dispatch another plan command |
 | Home Assistant unload | `plan_finished: interrupted`, `config_entry_unload` | No completion credit |
 | Timeout or robot error | `plan_finished: failed`, stable failure code, room failure event | No completion credit |
-| Rotation preview and execution | Same room order and selection reasons | Update opportunity only for verified work |
+| Rotation preview and execution | Same room order and selection reasons | Advance opportunity on a confirmed cleaning start; credit completion only after verification |
 | Activity churn or restart | Operational events remain visible; journal session/sequence boundaries are explicit | Never infer a cause from missing activity |
 
 Keep release evidence separate from robot credentials, network identifiers,
 serials, maps, and personal account identifiers.
+
+After an abrupt Home Assistant restart, the persisted run becomes `interrupted`
+with `reason_code: home_assistant_restart`. `recovered_at` records when recovery
+observed it; `ended_at` remains unknown. Recovery does not reconstruct a missing
+terminal event or award room credit.

--- a/docs/e2e-contract.md
+++ b/docs/e2e-contract.md
@@ -41,7 +41,7 @@ plan completed or that a person caused a stop.
 | Scenario | Required evidence | Room-credit rule |
 | --- | --- | --- |
 | All selected rooms verify | `plan_finished: completed`, matching `run_id`, all room events | Credit verified rooms only |
-| Native session ends early | `plan_finished: partial`, `partial_native_result` or `unverified_completion` | Leave unverified rooms due |
+| Native session ends early | `plan_finished: partial`, `partial_native_result`, `stopped_in_place`, or `unverified_completion` | Leave unverified rooms due; a known in-place stop is a controlled partial result, not a generic service fault |
 | Managed stop | `plan_finished: stopped`, `managed_stop`, stop command/activity when available | Do not credit the unfinished room |
 | Home Assistant unload | `plan_finished: interrupted`, `config_entry_unload` | No completion credit |
 | Timeout or robot error | `plan_finished: failed`, stable failure code, room failure event | No completion credit |

--- a/docs/e2e-contract.md
+++ b/docs/e2e-contract.md
@@ -55,4 +55,9 @@ serials, maps, and personal account identifiers.
 After an abrupt Home Assistant restart, the persisted run becomes `interrupted`
 with `reason_code: home_assistant_restart`. `recovered_at` records when recovery
 observed it; `ended_at` remains unknown. Recovery does not reconstruct a missing
-terminal event or award room credit.
+terminal event or award room credit. Verified counts are saved with room history,
+so recovery retains work already verified before the interruption.
+
+Late native reconciliation carries the originating `run_id`. The terminal plan
+record continues to describe the evidence available when its runner exited;
+`room_reconciled` identifies any additional completion verified afterward.

--- a/docs/e2e-contract.md
+++ b/docs/e2e-contract.md
@@ -1,0 +1,52 @@
+# End-to-end cleaning contract
+
+[Documentation](README.md) · [Actions and events](automation.md) · [Activity diagnostics](activity-diagnostics.md)
+
+The managed runner keeps seven evidence boundaries explicit. A clean native
+history record is useful evidence, but it is not by itself proof that a saved
+plan completed or that a person caused a stop.
+
+1. **Managed outcomes.** Every managed run gets one local `run_id` and a
+   `matic_robot_plan_finished` event. Its `outcome` is `completed`, `partial`,
+   `stopped`, `failed`, or `interrupted`; `reason_code`, `cause`, and verified
+   room counts explain the result. `room_completed` is emitted only after the
+   existing native completion guard passes.
+2. **Trigger provenance.** The run record carries the safe `trigger` label and
+   Home Assistant service name. It never carries a context user ID, account
+   name, or email. An OEM-app, physical, or robot-originated action remains
+   `cause: unknown` unless the integration has direct evidence.
+3. **Correlation.** Room events, the active plan snapshot, terminal plan event,
+   and integration activity observations carry the same `run_id`. Activity also
+   has an `observation_session` and monotonic `sequence`; a restart starts a
+   new observation window.
+4. **Intelligent rotation.** `MaticGetPlan` and `preview_plan` expose the
+   exact selected order, last opportunity, source, result, and tie-break reason.
+   The preview and executor share the same deterministic rotation key.
+5. **Evidence retention.** Low-volume operational events have a separate
+   bounded 64-event trail. High-frequency state and command observations retain
+   their own bounded 512-record journal, so polling cannot hide a room or
+   terminal event. Both surfaces are read-only and payload-free.
+6. **Scenario coverage.** The automated matrix covers verified completion,
+   native partial/unverified results, managed stop and return, configuration
+   unload interruption, failure/timeout, rotation tie-breaking, activity
+   churn, and identifier redaction. Each scenario checks both persisted state
+   and its native Home Assistant event.
+7. **Runtime proof.** A release candidate is complete only after project CI
+   passes and that same candidate has install/restart readback and physical
+   acceptance. Local tests and UI checks complement live proof; they do not
+   replace it.
+
+## Acceptance matrix
+
+| Scenario | Required evidence | Room-credit rule |
+| --- | --- | --- |
+| All selected rooms verify | `plan_finished: completed`, matching `run_id`, all room events | Credit verified rooms only |
+| Native session ends early | `plan_finished: partial`, `partial_native_result` or `unverified_completion` | Leave unverified rooms due |
+| Managed stop | `plan_finished: stopped`, `managed_stop`, stop command/activity when available | Do not credit the unfinished room |
+| Home Assistant unload | `plan_finished: interrupted`, `config_entry_unload` | No completion credit |
+| Timeout or robot error | `plan_finished: failed`, stable failure code, room failure event | No completion credit |
+| Rotation preview and execution | Same room order and selection reasons | Update opportunity only for verified work |
+| Activity churn or restart | Operational events remain visible; journal session/sequence boundaries are explicit | Never infer a cause from missing activity |
+
+Keep release evidence separate from robot credentials, network identifiers,
+serials, maps, and personal account identifiers.

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -77,5 +77,7 @@ IDs where possible; subsequent user-assigned names are preserved.
 Administrator-only MCP tools provide live runner status, plan order/settings,
 recent native history, and recent events: `MaticGetOperations`, `MaticGetPlan`,
 `MaticGetNativeHistory`, `MaticGetRecentEvents`, and `MaticGetActivity`.
-Recent events include the [command and raw-state observation trail](activity-diagnostics.md).
+Recent events keep low-volume room and terminal evidence separate from the
+[command and raw-state observation trail](activity-diagnostics.md), which can be
+queried independently when needed.
 Dust-bag observations are currently available through `MaticGetOperations` only.

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -647,6 +647,8 @@ async def test_native_reconciliation_recovery_is_lifecycle_bound() -> None:
 
 
 async def test_restart_recovery_credits_late_native_completion(hass) -> None:
+    events = []
+    hass.bus.async_listen("matic_robot_room_reconciled", events.append)
     now = datetime(2026, 8, 13, 12, tzinfo=UTC)
     room = Room(
         "room-kitchen",
@@ -664,6 +666,7 @@ async def test_restart_recovery_credits_late_native_completion(hass) -> None:
         "room": room.name,
         "dispatched_at": (now - timedelta(seconds=5)).isoformat(),
         "expires_at": (now + timedelta(seconds=10)).isoformat(),
+        "run_id": "synthetic-restart-run",
     }
     pending = manager.pending_native_reconciliation("synthetic-serial")
     assert pending is not None
@@ -704,6 +707,10 @@ async def test_restart_recovery_credits_late_native_completion(hass) -> None:
     ][room.id]
     assert room_history["last_result"] == "completed"
     assert room_history["last_duration_seconds"] == 3
+    await hass.async_block_till_done()
+    assert len(events) == 1
+    assert events[0].data["run_id"] == "synthetic-restart-run"
+    assert events[0].data["reason_code"] == "native_reconciled_completion"
 
 
 async def test_restart_recovery_expires_marker_after_transport_error(hass) -> None:

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -157,7 +157,7 @@ async def test_api_registration_event_capture_and_admin_gate() -> None:
     hass = _hass(_entry())
     api = MaticOperationsAPI(hass)
     api.async_start()
-    assert hass.bus.async_listen.call_count == 12
+    assert hass.bus.async_listen.call_count == 13
 
     event_callback = hass.bus.async_listen.call_args_list[0].args[1]
     event_callback(
@@ -166,6 +166,8 @@ async def test_api_registration_event_capture_and_admin_gate() -> None:
             {
                 "entry_id": "x" * 300,
                 "native_stop_reconciled": True,
+                "reason_code": "robot_error",
+                "cause": "unknown",
                 "error": 7,
                 "coverage_setting": 1.5,
                 "device_id": None,
@@ -178,6 +180,8 @@ async def test_api_registration_event_capture_and_admin_gate() -> None:
     assert event["event_type"] == "matic_robot_room_failed"
     assert len(event["data"]["entry_id"]) == 256
     assert event["data"]["native_stop_reconciled"] is True
+    assert event["data"]["reason_code"] == "robot_error"
+    assert event["data"]["cause"] == "unknown"
     assert event["data"]["error"] == 7
     assert event["data"]["coverage_setting"] == 1.5
     assert event["data"]["device_id"] is None
@@ -304,7 +308,7 @@ async def test_api_registration_event_capture_and_admin_gate() -> None:
     with patch("custom_components.matic_robot.llm.llm.async_register_api") as register:
         registered = async_register_matic_llm_api(hass)
     register.assert_called_once_with(hass, registered)
-    assert hass.bus.async_listen.call_count == 24
+    assert hass.bus.async_listen.call_count == 26
 
 
 async def test_operations_and_robot_resolution() -> None:
@@ -617,6 +621,39 @@ async def test_recent_events_returns_newest_first_and_honors_limit() -> None:
     assert "current Home Assistant process" in result["retention"]
 
 
+async def test_recent_events_keep_operational_evidence_out_of_activity_churn() -> None:
+    api = MaticOperationsAPI(_hass(_entry()))
+    api._async_capture_event(
+        Event(
+            "matic_robot_room_started",
+            {"room": "Hallway"},
+            time_fired_timestamp=0,
+        )
+    )
+    for index in range(MAX_RECENT_EVENTS + 10):
+        api._async_capture_event(
+            Event(
+                "matic_robot_activity_observed",
+                {"sequence": index, "kind": "state"},
+                time_fired_timestamp=index + 1,
+            )
+        )
+
+    operational = await MaticGetRecentEventsTool(api).async_call(
+        api.hass, llm.ToolInput("MaticGetRecentEvents", {"limit": 1}), _context()
+    )
+    combined = await MaticGetRecentEventsTool(api).async_call(
+        api.hass,
+        llm.ToolInput("MaticGetRecentEvents", {"limit": 1, "include_activity": True}),
+        _context(),
+    )
+    assert len(api.operational_events) == 1
+    assert operational["activity_included"] is False
+    assert operational["events"][0]["event_type"] == "matic_robot_room_started"
+    assert combined["activity_included"] is True
+    assert combined["events"][0]["event_type"] == "matic_robot_activity_observed"
+
+
 async def test_native_history_scopes_completion_to_the_requested_mode() -> None:
     entry = _entry()
     entry.runtime_data.client.async_get_cleaning_session_records.return_value = (
@@ -724,6 +761,16 @@ async def test_activity_journal_pagination_filtering_and_restart_guards() -> Non
         with pytest.raises(vol.Invalid):
             await read(**invalid)
     entry.runtime_data.client.async_get_cleaning_session_records.assert_not_called()
+
+
+def test_activity_journal_run_id_is_bounded_and_clearable() -> None:
+    journal = ActivityJournal()
+    journal.set_run_id("a" * 32)
+    journal.record("command_requested", command="DOCK")
+    assert journal.snapshot[-1]["run_id"] == "a" * 32
+    journal.set_run_id(None)
+    journal.record("state", activity="ready")
+    assert "run_id" not in journal.snapshot[-1]
 
 
 async def test_activity_journal_eviction_and_output_privacy() -> None:

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -58,6 +58,7 @@ from custom_components.matic_robot.services import (
     PlanCancelledError,
     RoomInterruptedError,
     RoomRunOutcome,
+    RoomStoppedInPlaceError,
     RoomTakenOverError,
     _async_active_session_state,
     _async_dispatch_leg_command,
@@ -164,6 +165,39 @@ async def test_managed_run_identity_outcome_and_activity_scope(hass) -> None:
     assert (
         await manager.async_finish_run("serial", "wrong-run", "failed", "x", 9) is False
     )
+
+
+async def test_native_stop_in_place_is_a_controlled_partial_run(hass) -> None:
+    """A stopped native task never credits a room or fails the automation."""
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    events = []
+    hass.bus.async_listen(EVENT_PLAN_FINISHED, events.append)
+
+    async def stopped_leg(*_args, **_kwargs):
+        cause = RoomStoppedInPlaceError("Kitchen ended in place")
+        raise ServiceValidationError("room interrupted") from cause
+
+    with patch(
+        "custom_components.matic_robot.services._async_run_leg",
+        AsyncMock(side_effect=stopped_leg),
+    ):
+        await _async_execute_rooms(
+            hass,
+            _call(hass),
+            manager,
+            "vacuum.matic",
+            "serial",
+            [_room("Kitchen", "room-kitchen")],
+            intelligent=False,
+        )
+
+    last_run = manager.snapshot("serial")["last_run"]
+    assert last_run["outcome"] == "partial"
+    assert last_run["reason_code"] == "stopped_in_place"
+    assert last_run["completed_room_count"] == 0
+    assert events[0].data["cause"] == "unknown"
+    assert events[0].data["completed_room_count"] == 0
 
 
 def test_leg_groups_split_only_on_settings_changes() -> None:

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -208,6 +208,7 @@ async def test_native_stop_in_place_is_a_controlled_partial_run(hass) -> None:
         (RoomStartTimeoutError(), "start_timeout"),
         (TimeoutError(), "completion_timeout"),
         (MaticError("synthetic rejection"), "robot_error"),
+        ("entity_error", "robot_error"),
     ],
 )
 async def test_plan_failure_keeps_the_room_reason_after_translation(
@@ -221,6 +222,9 @@ async def test_plan_failure_keeps_the_room_reason_after_translation(
     hass.bus.async_listen(EVENT_PLAN_FINISHED, events.append)
 
     async def reject_dispatch(_call) -> None:
+        if error == "entity_error":
+            hass.states.async_set("vacuum.matic", "error")
+            return
         raise error
 
     hass.services.async_register("vacuum", "send_command", reject_dispatch)
@@ -234,6 +238,7 @@ async def test_plan_failure_keeps_the_room_reason_after_translation(
             [_room("Study", "room-study")],
             intelligent=False,
         )
+    await hass.async_block_till_done()
     last_run = manager.snapshot("serial")["last_run"]
     assert last_run["outcome"] == "failed"
     assert last_run["reason_code"] == reason

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -1,6 +1,7 @@
 """Durable intelligent cleaning behavior."""
 
 import asyncio
+from copy import deepcopy
 from dataclasses import replace
 from datetime import UTC, timedelta
 from types import SimpleNamespace
@@ -58,6 +59,7 @@ from custom_components.matic_robot.services import (
     PlanCancelledError,
     RoomInterruptedError,
     RoomRunOutcome,
+    RoomStartTimeoutError,
     RoomStoppedInPlaceError,
     RoomTakenOverError,
     _async_active_session_state,
@@ -198,6 +200,195 @@ async def test_native_stop_in_place_is_a_controlled_partial_run(hass) -> None:
     assert last_run["completed_room_count"] == 0
     assert events[0].data["cause"] == "unknown"
     assert events[0].data["completed_room_count"] == 0
+
+
+@pytest.mark.parametrize(
+    ("error", "reason"),
+    [
+        (RoomStartTimeoutError(), "start_timeout"),
+        (TimeoutError(), "completion_timeout"),
+        (MaticError("synthetic rejection"), "robot_error"),
+    ],
+)
+async def test_plan_failure_keeps_the_room_reason_after_translation(
+    hass, error, reason
+) -> None:
+    """The actual room boundary and terminal run agree on native failures."""
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    events = []
+    hass.bus.async_listen(f"{DOMAIN}_room_failed", events.append)
+    hass.bus.async_listen(EVENT_PLAN_FINISHED, events.append)
+
+    async def reject_dispatch(_call) -> None:
+        raise error
+
+    hass.services.async_register("vacuum", "send_command", reject_dispatch)
+    with pytest.raises(ServiceValidationError):
+        await _async_execute_rooms(
+            hass,
+            _call(hass),
+            manager,
+            "vacuum.matic",
+            "serial",
+            [_room("Study", "room-study")],
+            intelligent=False,
+        )
+    last_run = manager.snapshot("serial")["last_run"]
+    assert last_run["outcome"] == "failed"
+    assert last_run["reason_code"] == reason
+    assert last_run["cause"] == "unknown"
+    assert last_run["completed_room_count"] == 0
+    assert [event.data["reason_code"] for event in events] == [reason, reason]
+    assert {event.data["run_id"] for event in events} == {last_run["run_id"]}
+    assert manager.lock("serial").locked() is False
+
+
+@pytest.mark.parametrize("active_room", [False, True])
+async def test_restart_retires_persisted_running_outcome(hass, active_room) -> None:
+    """A crash between rooms must not leave a nonexistent run marked running."""
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    await manager.async_begin_run(
+        "serial",
+        "away",
+        "synthetic-run",
+        2,
+        trigger="service_call",
+        service="run_selected_plan",
+    )
+    if active_room:
+        await manager.async_mark_started(
+            "serial", "away", _room("Study", "room-study"), run_id="synthetic-run"
+        )
+    recovering = CleaningPlanManager(hass)
+    recovering._store = SimpleNamespace(
+        async_load=AsyncMock(return_value=deepcopy(manager._data)),
+        async_save=AsyncMock(),
+    )
+    await recovering.async_load()
+    last_run = recovering.snapshot("serial")["last_run"]
+    assert last_run["run_id"] == "synthetic-run"
+    assert last_run["outcome"] == "interrupted"
+    assert last_run["reason_code"] == "home_assistant_restart"
+    assert last_run["cause"] == "home_assistant"
+    assert last_run["ended_at"] is None
+    assert dt_util.parse_datetime(last_run["recovered_at"]) is not None
+    assert last_run["completed_room_count"] == 0
+    assert recovering.snapshot("serial")["active_plan"] is None
+    recovering._store.async_load.return_value = deepcopy(recovering._data)
+    await recovering.async_load()
+    assert recovering.snapshot("serial")["last_run"] == last_run
+
+
+@pytest.mark.parametrize(
+    ("scenario", "outcome", "reason", "room_event", "credit"),
+    [
+        ("complete", "completed", "all_rooms_verified", "room_completed", 1),
+        ("unverified", "partial", "partial_native_result", "room_ended_unverified", 0),
+        ("native_stop", "partial", "stopped_in_place", "room_interrupted", 0),
+        ("stop", "stopped", "managed_stop", "room_cancelled", 0),
+        ("replacement", "stopped", "managed_replaced", "room_cancelled", 0),
+        ("unload", "interrupted", "config_entry_unload", "room_interrupted", 0),
+    ],
+)
+async def test_managed_terminal_matrix_uses_real_room_history_and_events(
+    hass, scenario, outcome, reason, room_event, credit
+) -> None:
+    """Native observations flow through both room and plan outcome boundaries."""
+    manager = CleaningPlanManager(hass)
+    saved = []
+    manager._store = SimpleNamespace(
+        async_save=AsyncMock(side_effect=lambda data: saved.append(deepcopy(data)))
+    )
+    events = []
+    for event in ("room_started", room_event, "plan_finished"):
+        hass.bus.async_listen(f"{DOMAIN}_{event}", events.append)
+    hass.services.async_register("vacuum", "send_command", AsyncMock())
+    room = _room("Study", "room-study")
+    reads = 0
+
+    async def history():
+        nonlocal reads
+        reads += 1
+        if reads == 1 or scenario != "complete":
+            return ()
+        now = dt_util.utcnow()
+        return (
+            CleaningSessionRecord(
+                b"synthetic-session",
+                CleaningSession(
+                    (now - timedelta(seconds=5)).isoformat(),
+                    now.isoformat(),
+                    5,
+                    (room.name,),
+                    ((room.name, 5),),
+                    True,
+                ),
+            ),
+        )
+
+    async def native_outcome(*_args):
+        if scenario == "stop":
+            manager.cancel("serial")
+            raise PlanCancelledError
+        if scenario == "replacement":
+            manager.replace_managed_motion("serial")
+            raise PlanCancelledError
+        if scenario == "unload":
+            await manager.async_cancel_and_wait("serial")
+            raise PlanCancelledError
+        if scenario == "native_stop":
+            hass.states.async_set("vacuum.matic", "idle")
+            return RoomRunOutcome.STOPPED_IN_PLACE
+        hass.states.async_set("vacuum.matic", "returning")
+        return RoomRunOutcome.HANDOFF_CANDIDATE
+
+    with (
+        patch(
+            "custom_components.matic_robot.services._async_wait_for_owned_start",
+            AsyncMock(return_value="cleaning"),
+        ),
+        patch(
+            "custom_components.matic_robot.services._async_wait_for_room_outcome",
+            side_effect=native_outcome,
+        ),
+    ):
+        await _async_execute_rooms(
+            hass,
+            _call(hass),
+            manager,
+            "vacuum.matic",
+            "serial",
+            [room],
+            intelligent=True,
+            session_history=history,
+            active_session=AsyncMock(return_value=False),
+        )
+    await manager.async_cancel_and_wait("serial")
+    await hass.async_block_till_done()
+    snapshot = manager.snapshot("serial")
+    last_run = snapshot["last_run"]
+    assert last_run["outcome"] == outcome
+    assert last_run["reason_code"] == reason
+    assert last_run["completed_room_count"] == credit
+    assert snapshot["completed_runs"] == credit
+    assert snapshot["active_plan"] is None
+    assert [event.event_type for event in events] == [
+        f"{DOMAIN}_room_started",
+        f"{DOMAIN}_{room_event}",
+        EVENT_PLAN_FINISHED,
+    ]
+    assert {event.data["run_id"] for event in events} == {last_run["run_id"]}
+    assert events[-1].data["outcome"] == outcome
+    assert events[-1].data["reason_code"] == reason
+    assert events[-1].data["cause"] == last_run["cause"]
+    if scenario == "replacement":
+        assert events[1].data["cause"] == "replacement"
+        assert last_run["cause"] == "replacement"
+    assert events[-1].data["completed_room_count"] == credit
+    assert saved[-1]["robots"]["serial"]["last_run"] == last_run
+    assert manager.lock("serial").locked() is False
 
 
 def test_leg_groups_split_only_on_settings_changes() -> None:
@@ -3391,10 +3582,12 @@ async def test_leg_replaced_dispatch_cancels(hass) -> None:
     manager.async_mark_cancelled.assert_awaited_once()
 
 
-@pytest.mark.parametrize("reason", [None, "config_entry_unload"])
+@pytest.mark.parametrize("reason", [None, "motion_replaced", "config_entry_unload"])
 async def test_leg_cancellation_records_history(hass, reason: str | None) -> None:
     manager = _leg_manager(reason)
     cancel_event = asyncio.Event()
+    events = []
+    hass.bus.async_listen(f"{DOMAIN}_room_cancelled", events.append)
 
     async def send_command(_call) -> None:
         hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Kitchen"})
@@ -3418,8 +3611,12 @@ async def test_leg_cancellation_records_history(hass, reason: str | None) -> Non
             cancel_event=cancel_event,
         )
 
-    if reason is None:
+    if reason != "config_entry_unload":
         manager.async_mark_cancelled.assert_awaited_once()
+        await hass.async_block_till_done()
+        assert events[-1].data["cause"] == (
+            "replacement" if reason == "motion_replaced" else "managed_cancellation"
+        )
     else:
         manager.async_mark_interrupted.assert_awaited_once()
 

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -1672,6 +1672,138 @@ async def test_replacement_motion_persists_reconciliation_removal_before_yield(
         assert "pending_native_reconciliation" not in manager._robot("serial")
         manager._store.async_save.assert_awaited_once()
 
+    await add_marker()
+    manager._store.async_save.side_effect = OSError("synthetic removal save")
+    with pytest.raises(OSError, match="synthetic removal save"):
+        async with manager.external_motion("serial"):
+            pytest.fail("Replacement dispatched before marker removal was durable")
+    assert manager._reconciliation_removal_pending == {"serial"}
+    manager._store.async_save.side_effect = None
+    manager._store.async_save.reset_mock()
+    async with manager.external_motion("serial"):
+        manager._store.async_save.assert_awaited_once()
+        assert manager._reconciliation_removal_pending == set()
+
+
+@pytest.mark.parametrize("replacement", ["direct", "external", "managed"])
+@pytest.mark.parametrize("live_reconciliation", [False, True])
+@pytest.mark.parametrize("save_fails", [False, True])
+@pytest.mark.parametrize("hold_command_lock", [False, True])
+async def test_replacement_waits_for_reconciliation_persistence(
+    hass, replacement, live_reconciliation, save_fails, hold_command_lock
+) -> None:
+    """A restart cannot recover a marker already superseded by new motion."""
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    room = _room("Kitchen", "room-kitchen")
+    now = dt_util.utcnow()
+    dispatched_at = now - timedelta(seconds=5)
+    ended_at = (now - timedelta(seconds=1)).isoformat()
+    await manager.async_mark_started("serial", "away", room)
+    await manager.async_mark_failed(
+        "serial",
+        "away",
+        room,
+        "synthetic stop",
+        native_reconciliation={
+            "plan_id": "away",
+            "room_id": room.room_id,
+            "room": room.name,
+            "dispatched_at": dispatched_at.isoformat(),
+        },
+    )
+    persisted = deepcopy(manager._data)
+    entered = asyncio.Event()
+    finish = asyncio.Event()
+    dispatched = []
+    first_save = True
+
+    async def save(data):
+        nonlocal persisted, first_save
+        if first_save:
+            first_save = False
+            entered.set()
+            await finish.wait()
+            if save_fails:
+                raise OSError("synthetic save failure")
+        persisted = deepcopy(data)
+
+    manager._store.async_save.side_effect = save
+    floor_plan = FloorPlan(
+        1,
+        "partition",
+        b"partition",
+        (Room(room.room_id, room.name, "protocol-kitchen", b"kitchen", ()),),
+    )
+    records = [
+        CleaningSessionRecord(
+            b"synthetic-session",
+            CleaningSession(
+                (now - timedelta(seconds=10)).isoformat(),
+                ended_at,
+                9,
+                (room.name,),
+                ((room.name, 9),),
+                True,
+                (room.name,),
+            ),
+        )
+    ]
+    reconciliation = asyncio.create_task(
+        manager.async_mark_native_completed(
+            "serial",
+            "away",
+            room,
+            dispatched_at=dispatched_at,
+            completed_at=ended_at,
+            duration_seconds=9,
+        )
+        if live_reconciliation
+        else manager.async_import_native_history("serial", floor_plan, records)
+    )
+    await entered.wait()
+
+    async def replace():
+        if replacement == "direct":
+            await manager.async_replace_managed_motion("serial")
+            dispatched.append(True)
+        elif replacement == "external":
+            async with manager.external_motion("serial"):
+                dispatched.append(True)
+        else:
+            token = manager.begin_managed_motion("serial")
+            async with manager.managed_command("serial", token):
+                dispatched.append(True)
+
+    if hold_command_lock:
+        await manager.command_lock("serial").acquire()
+    next_motion = asyncio.create_task(replace())
+    await asyncio.sleep(0)
+    try:
+        assert not next_motion.done()
+        assert dispatched == []
+    finally:
+        finish.set()
+        if hold_command_lock:
+            await asyncio.gather(reconciliation, return_exceptions=True)
+            manager.command_lock("serial").release()
+        results = await asyncio.gather(
+            reconciliation, next_motion, return_exceptions=True
+        )
+    assert isinstance(results[0], OSError) if save_fails else results[0] is True
+    assert results[1] is None
+    assert dispatched == [True]
+    assert manager._native_history_saves == {}
+    assert manager._reconciliation_removal_pending == set()
+    recovered = CleaningPlanManager(hass)
+    recovered._store = SimpleNamespace(
+        async_load=AsyncMock(return_value=persisted), async_save=AsyncMock()
+    )
+    await recovered.async_load()
+    assert recovered.pending_native_reconciliation("serial") is None
+    await recovered.async_import_native_history("serial", floor_plan, records)
+    assert recovered.snapshot("serial")["completed_runs"] == int(not save_fails)
+
 
 @pytest.mark.parametrize(
     ("terminal_error", "translation_key", "last_result"),

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -1,6 +1,7 @@
 """Durable intelligent cleaning behavior."""
 
 import asyncio
+from contextlib import nullcontext
 from copy import deepcopy
 from dataclasses import replace
 from datetime import UTC, timedelta
@@ -250,7 +251,10 @@ async def test_plan_failure_keeps_the_room_reason_after_translation(
 
 
 @pytest.mark.parametrize("active_room", [False, True])
-async def test_restart_retires_persisted_running_outcome(hass, active_room) -> None:
+@pytest.mark.parametrize("verified_room", [False, True])
+async def test_restart_retires_persisted_running_outcome(
+    hass, active_room, verified_room
+) -> None:
     """A crash between rooms must not leave a nonexistent run marked running."""
     manager = CleaningPlanManager(hass)
     manager._store = SimpleNamespace(async_save=AsyncMock())
@@ -262,9 +266,16 @@ async def test_restart_retires_persisted_running_outcome(hass, active_room) -> N
         trigger="service_call",
         service="run_selected_plan",
     )
-    if active_room:
+    if verified_room:
         await manager.async_mark_started(
             "serial", "away", _room("Study", "room-study"), run_id="synthetic-run"
+        )
+        await manager.async_mark_completed(
+            "serial", "away", _room("Study", "room-study"), duration_seconds=30
+        )
+    if active_room:
+        await manager.async_mark_started(
+            "serial", "away", _room("Den", "room-den"), run_id="synthetic-run"
         )
     recovering = CleaningPlanManager(hass)
     recovering._store = SimpleNamespace(
@@ -279,11 +290,63 @@ async def test_restart_retires_persisted_running_outcome(hass, active_room) -> N
     assert last_run["cause"] == "home_assistant"
     assert last_run["ended_at"] is None
     assert dt_util.parse_datetime(last_run["recovered_at"]) is not None
-    assert last_run["completed_room_count"] == 0
+    assert last_run["completed_room_count"] == int(verified_room)
     assert recovering.snapshot("serial")["active_plan"] is None
     recovering._store.async_load.return_value = deepcopy(recovering._data)
     await recovering.async_load()
     assert recovering.snapshot("serial")["last_run"] == last_run
+
+
+@pytest.mark.parametrize("save_fails", [False, True])
+async def test_unload_waits_for_terminal_save_and_always_clears_run_scope(
+    hass, save_fails
+) -> None:
+    """Slow or failed terminal storage cannot outlive entry teardown silently."""
+    manager = CleaningPlanManager(hass)
+    saving = asyncio.Event()
+    release = asyncio.Event()
+    set_run_id = MagicMock()
+    events = []
+    hass.bus.async_listen(EVENT_PLAN_FINISHED, events.append)
+
+    async def save(data):
+        if data["robots"]["serial"]["last_run"]["outcome"] != "running":
+            saving.set()
+            await release.wait()
+            if save_fails:
+                raise OSError("synthetic storage failure")
+
+    manager._store = SimpleNamespace(async_save=AsyncMock(side_effect=save))
+    with patch(
+        "custom_components.matic_robot.services._async_run_leg",
+        AsyncMock(return_value=False),
+    ):
+        run = asyncio.create_task(
+            _async_execute_rooms(
+                hass,
+                _call(hass),
+                manager,
+                "vacuum.matic",
+                "serial",
+                [_room("Study", "room-study")],
+                intelligent=False,
+                set_activity_run_id=set_run_id,
+            )
+        )
+        await asyncio.wait_for(saving.wait(), 1)
+        unload = asyncio.create_task(manager.async_cancel_and_wait("serial"))
+        await asyncio.sleep(0)
+        waited_for_save = not unload.done()
+        release.set()
+        result, _ = await asyncio.gather(run, unload, return_exceptions=True)
+    await hass.async_block_till_done()
+    assert waited_for_save
+    assert isinstance(result, OSError) if save_fails else result is None
+    assert set_run_id.call_args.args == (None,)
+    assert manager.lock("serial").locked() is False
+    assert "serial" not in manager._run_tasks
+    assert len(events) == 1
+    assert events[0].data["run_id"] == set_run_id.call_args_list[0].args[0]
 
 
 @pytest.mark.parametrize(
@@ -295,6 +358,8 @@ async def test_restart_retires_persisted_running_outcome(hass, active_room) -> N
         ("stop", "stopped", "managed_stop", "room_cancelled", 0),
         ("replacement", "stopped", "managed_replaced", "room_cancelled", 0),
         ("unload", "interrupted", "config_entry_unload", "room_interrupted", 0),
+        ("interrupted", "interrupted", "interrupted", "room_interrupted", 0),
+        ("takeover", "interrupted", "native_task_taken_over", "room_interrupted", 0),
     ],
 )
 async def test_managed_terminal_matrix_uses_real_room_history_and_events(
@@ -346,10 +411,17 @@ async def test_managed_terminal_matrix_uses_real_room_history_and_events(
         if scenario == "native_stop":
             hass.states.async_set("vacuum.matic", "idle")
             return RoomRunOutcome.STOPPED_IN_PLACE
+        if scenario == "interrupted":
+            return RoomRunOutcome.INTERRUPTED
+        if scenario == "takeover":
+            raise RoomTakenOverError("synthetic native ownership change")
         hass.states.async_set("vacuum.matic", "returning")
         return RoomRunOutcome.HANDOFF_CANDIDATE
 
     with (
+        pytest.raises(ServiceValidationError)
+        if scenario in {"interrupted", "takeover"}
+        else nullcontext(),
         patch(
             "custom_components.matic_robot.services._async_wait_for_owned_start",
             AsyncMock(return_value="cleaning"),
@@ -394,6 +466,11 @@ async def test_managed_terminal_matrix_uses_real_room_history_and_events(
     assert events[-1].data["completed_room_count"] == credit
     assert saved[-1]["robots"]["serial"]["last_run"] == last_run
     assert manager.lock("serial").locked() is False
+    if scenario in {"interrupted", "unload"}:
+        assert (
+            manager.pending_native_reconciliation("serial")["run_id"]
+            == (last_run["run_id"])
+        )
 
 
 def test_leg_groups_split_only_on_settings_changes() -> None:

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -27,7 +27,7 @@ from custom_components.matic_robot.client.models import (
     FloorPlan,
     Room,
 )
-from custom_components.matic_robot.const import DOMAIN
+from custom_components.matic_robot.const import DOMAIN, EVENT_PLAN_FINISHED
 from custom_components.matic_robot.plans import (
     MAX_SAVED_PLANS_PER_ROBOT,
     OEM_STOP_RECONCILIATION_SECONDS,
@@ -112,6 +112,57 @@ def _call(hass, *, return_to_base: bool = False) -> ServiceCall:
             "completion_timeout": 21600,
             "return_to_base": return_to_base,
         },
+    )
+
+
+async def test_managed_run_identity_outcome_and_activity_scope(hass) -> None:
+    """A managed run emits one bounded terminal record without user identity."""
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    room = _room("Kitchen", "room-kitchen")
+    events = []
+    hass.bus.async_listen(EVENT_PLAN_FINISHED, events.append)
+    set_run_id = MagicMock()
+    confirmed = MagicMock()
+
+    async def fake_leg(*args, **kwargs):
+        args[11](args[5][0].name)
+        return True
+
+    with patch(
+        "custom_components.matic_robot.services._async_run_leg",
+        AsyncMock(side_effect=fake_leg),
+    ):
+        await _async_execute_rooms(
+            hass,
+            _call(hass),
+            manager,
+            "vacuum.matic",
+            "serial",
+            [room],
+            intelligent=False,
+            confirm_room_completed=confirmed,
+            set_activity_run_id=set_run_id,
+        )
+
+    last_run = manager.snapshot("serial")["last_run"]
+    assert last_run["outcome"] == "completed"
+    assert last_run["reason_code"] == "all_rooms_verified"
+    assert last_run["room_count"] == 1
+    assert last_run["completed_room_count"] == 1
+    confirmed.assert_called_once_with("Kitchen")
+    assert last_run["trigger"] == "service_call"
+    assert last_run["service"] == "intelligent_clean"
+    assert len(events) == 1
+    event = events[0].data
+    assert event["run_id"] == last_run["run_id"]
+    assert event["outcome"] == "completed"
+    assert event["terminal_activity"] == "unknown"
+    assert "@" not in str(event)
+    assert set_run_id.call_args_list[0].args[0] == last_run["run_id"]
+    assert set_run_id.call_args_list[-1].args[0] is None
+    assert (
+        await manager.async_finish_run("serial", "wrong-run", "failed", "x", 9) is False
     )
 
 
@@ -670,7 +721,7 @@ async def test_plan_store_migrates_legacy_areas_without_fabricating_map_binding(
 ) -> None:
     manager = CleaningPlanManager(hass)
     assert manager._store.version == 1
-    assert manager._store.minor_version == 4
+    assert manager._store.minor_version == 5
     assert manager._store._private is True
     stored = {
         "robots": {
@@ -739,7 +790,7 @@ async def test_plan_store_migrates_legacy_areas_without_fabricating_map_binding(
     with pytest.raises(ValueError, match="storage version"):
         await manager._store._async_migrate_func(2, 1, stored)
     with pytest.raises(ValueError, match="minor version"):
-        await manager._store._async_migrate_func(1, 5, stored)
+        await manager._store._async_migrate_func(1, 6, stored)
 
 
 async def test_intelligent_order_avoids_restarting_with_the_same_room(hass) -> None:
@@ -1079,6 +1130,7 @@ async def test_load_repairs_malformed_plan_storage_without_inventing_history(
                         "rotation_resets": {"away": 7},
                         "selected_plan": ["not", "hashable"],
                         "active_plan": {"plan_id": 7},
+                        "last_run": "not-a-run",
                     },
                 }
             }
@@ -1102,6 +1154,7 @@ async def test_load_repairs_malformed_plan_storage_without_inventing_history(
         "selected_plan": "valid",
         "selected_area": None,
         "active_plan": None,
+        "last_run": None,
     }
     manager._store.async_save.assert_awaited_once_with(manager._data)
 
@@ -2163,6 +2216,14 @@ async def test_room_native_plan_lifecycle_preview_selection_and_reset(hass) -> N
     preview = manager.preview("serial", room_map)
     assert [room["name"] for room in preview["rooms"]] == ["Kitchen", "Study"]
     assert preview["rotation_basis"] == "least_recent_opportunity"
+    assert [item["room"] for item in preview["rotation"]] == [
+        "Kitchen",
+        "Study",
+    ]
+    assert all(
+        item["selection_reason"] == "no_prior_opportunity"
+        for item in preview["rotation"]
+    )
 
     await manager.async_save_plan(
         "serial",
@@ -2186,6 +2247,43 @@ async def test_room_native_plan_lifecycle_preview_selection_and_reset(hass) -> N
         "serial", "whole_home", _room("Kitchen", "room-kitchen")
     )
     assert manager.preview("serial", room_map)["rooms"][0]["name"] == "Study"
+    rotation = manager.preview("serial", room_map)["rotation"]
+    assert rotation[0]["room"] == "Study"
+    assert rotation[0]["selection_reason"] == "no_prior_opportunity"
+    assert rotation[1]["room"] == "Kitchen"
+    assert rotation[1]["last_result"] == "completed"
+    assert rotation[1]["last_opportunity_source"] == "plan"
+
+    same_opportunity = (dt_util.utcnow() - timedelta(hours=1)).isoformat()
+    robot = manager._robot("serial")
+    robot["rotations"]["whole_home"]["rooms"]["room-kitchen"]["last_opportunity"] = (
+        same_opportunity
+    )
+    robot["rotations"]["whole_home"]["rooms"]["room-kitchen"]["last_completed"] = (
+        same_opportunity
+    )
+    robot["rotations"]["whole_home"]["rooms"]["room-study"] = {
+        "room_id": "room-study",
+        "name": "Study",
+        "cleaning_mode": "vacuum_and_mop",
+        "coverage_setting": "standard",
+        "last_opportunity": same_opportunity,
+    }
+    robot["rooms"]["room-kitchen"]["last_opportunity"] = same_opportunity
+    robot["rooms"]["room-kitchen"]["last_completed"] = same_opportunity
+    robot["rooms"]["room-study"] = {
+        "name": "Study",
+        "last_opportunity": same_opportunity,
+    }
+    tied_rotation = manager.rotation_details(
+        "serial",
+        "whole_home",
+        [
+            _room("Kitchen", "room-kitchen"),
+            _room("Study", "room-study"),
+        ],
+    )
+    assert tied_rotation[1]["selection_reason"] == "saved_order_tiebreak"
     manager._robot("serial")["plans"]["whole_home"]["run_behavior"] = "ordered"
     ordered_preview = manager.preview("serial", room_map)
     assert ordered_preview["rotation_basis"] == "saved_order"
@@ -4132,6 +4230,9 @@ async def test_unknown_active_session_interrupts_without_room_credit(
     assert interrupted.value.translation_key == "room_interrupted"
     sender.assert_awaited_once_with(10, UserCommand.STOP)
     manager.async_mark_completed.assert_not_awaited()
+    interrupted_event = bus.async_fire.call_args_list[-1].args[1]
+    assert interrupted_event["reason_code"] == "interrupted"
+    assert interrupted_event["cause"] == "unknown"
 
 
 async def test_room_starting_paused_is_suspended_until_resume() -> None:

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -349,6 +349,40 @@ async def test_unload_waits_for_terminal_save_and_always_clears_run_scope(
     assert events[0].data["run_id"] == set_run_id.call_args_list[0].args[0]
 
 
+@pytest.mark.parametrize("persistent_failure", [False, True])
+async def test_initial_save_failure_still_retires_the_run(
+    hass, persistent_failure
+) -> None:
+    manager = CleaningPlanManager(hass)
+    error = OSError("synthetic initial storage failure")
+    manager._store = SimpleNamespace(
+        async_save=AsyncMock(side_effect=error if persistent_failure else [error, None])
+    )
+    events = []
+    hass.bus.async_listen(EVENT_PLAN_FINISHED, events.append)
+    set_run_id = MagicMock()
+    with pytest.raises(OSError, match="synthetic initial storage failure"):
+        await _async_execute_rooms(
+            hass,
+            _call(hass),
+            manager,
+            "vacuum.matic",
+            "serial",
+            [_room("Study", "room-study")],
+            intelligent=False,
+            set_activity_run_id=set_run_id,
+        )
+    await hass.async_block_till_done()
+    last_run = manager.snapshot("serial")["last_run"]
+    assert last_run["outcome"] == "failed"
+    assert last_run["completed_room_count"] == 0
+    assert events[0].data["outcome"] == "failed"
+    assert events[0].data["run_id"] == last_run["run_id"]
+    assert set_run_id.call_args.args == (None,)
+    assert manager.lock("serial").locked() is False
+    assert "serial" not in manager._run_tasks
+
+
 @pytest.mark.parametrize(
     ("scenario", "outcome", "reason", "room_event", "credit"),
     [
@@ -1733,10 +1767,16 @@ async def test_suspended_and_interrupted_rooms_never_advance_history(hass) -> No
 
 async def test_pending_native_stop_completion_is_reconciled_on_history_import(
     hass,
+    entity_registry,
 ) -> None:
     """A native session that finishes after STOP still credits the managed room."""
     manager = CleaningPlanManager(hass)
     manager._store = SimpleNamespace(async_save=AsyncMock())
+    events = []
+    hass.bus.async_listen(f"{DOMAIN}_room_reconciled", events.append)
+    entity = entity_registry.async_get_or_create(
+        "vacuum", DOMAIN, "serial_vacuum", suggested_object_id="recovered_matic"
+    )
     room = _room("Kitchen", "room-kitchen")
     now = dt_util.utcnow()
     dispatched_at = (now - timedelta(seconds=5)).isoformat()
@@ -1751,6 +1791,7 @@ async def test_pending_native_stop_completion_is_reconciled_on_history_import(
             "room_id": room.room_id,
             "room": room.name,
             "dispatched_at": dispatched_at,
+            "run_id": "synthetic-recovered-run",
         },
     )
     floor_plan = FloorPlan(
@@ -1788,6 +1829,13 @@ async def test_pending_native_stop_completion_is_reconciled_on_history_import(
     assert room_record["completed_runs"] == 1
     assert room_record["last_duration_seconds"] == 9
     assert snapshot["native_reconciliation_pending"] is False
+    await manager.async_import_native_history("serial", floor_plan, [record])
+    await hass.async_block_till_done()
+    assert len(events) == 1
+    assert events[0].data["run_id"] == "synthetic-recovered-run"
+    assert events[0].data["entity_id"] == entity.entity_id
+    assert events[0].data["room_id"] == room.room_id
+    assert events[0].data["reason_code"] == "native_reconciled_completion"
 
 
 async def test_expired_native_reconciliation_is_cleared_without_plan_credit(

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -1685,7 +1685,35 @@ async def test_replacement_motion_persists_reconciliation_removal_before_yield(
         assert manager._reconciliation_removal_pending == set()
 
 
-@pytest.mark.parametrize("replacement", ["direct", "external", "managed"])
+async def test_managed_command_rechecks_ownership_after_storage(hass) -> None:
+    """A replacement arriving during storage prevents the older dispatch."""
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    room = _room("Kitchen", "room-kitchen")
+    await manager.async_mark_failed(
+        "serial",
+        "away",
+        room,
+        "synthetic stop",
+        native_reconciliation={
+            "plan_id": "away",
+            "room_id": room.room_id,
+            "room": room.name,
+            "dispatched_at": dt_util.utcnow().isoformat(),
+        },
+    )
+    token = manager.begin_managed_motion("serial")
+    manager._store.async_save.side_effect = lambda _: manager.replace_managed_motion(
+        "serial"
+    )
+    with pytest.raises(ManagedMotionReplacedError):
+        async with manager.managed_command("serial", token):
+            pytest.fail("A replacement revoked this command while storage was pending")
+
+
+@pytest.mark.parametrize(
+    "replacement", ["direct", "external", "managed", "managed_early"]
+)
 @pytest.mark.parametrize("live_reconciliation", [False, True])
 @pytest.mark.parametrize("save_fails", [False, True])
 @pytest.mark.parametrize("hold_command_lock", [False, True])
@@ -1749,6 +1777,11 @@ async def test_replacement_waits_for_reconciliation_persistence(
             ),
         )
     ]
+    early_token = (
+        manager.begin_managed_motion("serial")
+        if replacement == "managed_early"
+        else None
+    )
     reconciliation = asyncio.create_task(
         manager.async_mark_native_completed(
             "serial",
@@ -1771,7 +1804,7 @@ async def test_replacement_waits_for_reconciliation_persistence(
             async with manager.external_motion("serial"):
                 dispatched.append(True)
         else:
-            token = manager.begin_managed_motion("serial")
+            token = early_token or manager.begin_managed_motion("serial")
             async with manager.managed_command("serial", token):
                 dispatched.append(True)
 

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -1765,9 +1765,13 @@ async def test_suspended_and_interrupted_rooms_never_advance_history(hass) -> No
     assert snapshot["last_interrupted_plan"]["room"] == "Kitchen"
 
 
+@pytest.mark.parametrize(
+    "save_failure", [None, "io", "cancelled", "concurrent_edit", "replacement"]
+)
 async def test_pending_native_stop_completion_is_reconciled_on_history_import(
     hass,
     entity_registry,
+    save_failure,
 ) -> None:
     """A native session that finishes after STOP still credits the managed room."""
     manager = CleaningPlanManager(hass)
@@ -1822,6 +1826,34 @@ async def test_pending_native_stop_completion_is_reconciled_on_history_import(
         ),
     )
 
+    if save_failure is not None:
+        before = deepcopy(manager._data)
+        error_type = asyncio.CancelledError if save_failure == "cancelled" else OSError
+
+        async def fail_save(data):
+            if save_failure == "concurrent_edit":
+                manager._robot("serial")["selected_plan"] = "new-selection"
+            elif save_failure == "replacement":
+                manager.replace_managed_motion("serial")
+            raise error_type("synthetic reconciliation save")
+
+        manager._store.async_save.side_effect = fail_save
+        with pytest.raises(error_type, match="synthetic reconciliation save"):
+            await manager.async_import_native_history("serial", floor_plan, [record])
+        await hass.async_block_till_done()
+        assert events == []
+        if save_failure == "concurrent_edit":
+            before["robots"]["serial"]["selected_plan"] = "new-selection"
+        elif save_failure == "replacement":
+            before["robots"]["serial"].pop("pending_native_reconciliation")
+        assert manager._data == before
+        manager._store.async_save.side_effect = None
+    if save_failure == "replacement":
+        await manager.async_import_native_history("serial", floor_plan, [record])
+        await hass.async_block_till_done()
+        assert manager.snapshot("serial")["completed_runs"] == 0
+        assert events == []
+        return
     assert await manager.async_import_native_history("serial", floor_plan, [record])
     snapshot = manager.snapshot("serial")
     room_record = snapshot["plan_history"]["away"]["rooms"][room.room_id]

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -2203,12 +2203,17 @@ async def test_room_failures_translate_client_errors_at_boundary(
     assert event_data["cause"] == "unknown"
 
 
-async def test_oem_stop_reconciliation_credits_late_native_session(hass) -> None:
+@pytest.mark.parametrize("run_id", [None, "synthetic-run"])
+async def test_oem_stop_reconciliation_credits_late_native_session(
+    hass, run_id
+) -> None:
     """The ten-minute OEM stop can finish a room after the runner saw an error."""
     manager = CleaningPlanManager(hass)
     manager._store = SimpleNamespace(async_save=AsyncMock())
     room = CleaningRoom("room-study", "Study", "vacuum", "quick")
     now = dt_util.utcnow()
+    events = []
+    hass.bus.async_listen("matic_robot_room_reconciled", events.append)
     await manager.async_mark_started("serial", "away", room)
     await manager.async_mark_failed(
         "serial",
@@ -2220,8 +2225,10 @@ async def test_oem_stop_reconciliation_credits_late_native_session(hass) -> None
             "room_id": room.room_id,
             "room": room.name,
             "dispatched_at": (now - timedelta(seconds=5)).isoformat(),
+            "run_id": run_id,
         },
     )
+    assert manager.pending_native_reconciliation("serial").get("run_id") == run_id
     session = CleaningSession(
         (now - timedelta(seconds=10)).isoformat(),
         (now - timedelta(seconds=1)).isoformat(),
@@ -2235,7 +2242,7 @@ async def test_oem_stop_reconciliation_credits_late_native_session(hass) -> None
     hass.states.async_set("vacuum.test", "docked")
     confirmed = MagicMock()
     reconciliation = _NativeReconciliation(
-        "away", room.room_id, room.name, now - timedelta(seconds=5)
+        "away", room.room_id, room.name, now - timedelta(seconds=5), run_id=run_id
     )
     with patch(
         "custom_components.matic_robot.services.OEM_STOP_RECONCILIATION_POLL_SECONDS",
@@ -2260,6 +2267,8 @@ async def test_oem_stop_reconciliation_credits_late_native_session(hass) -> None
     assert record["last_duration_seconds"] == 9
     assert manager.snapshot("serial")["native_reconciliation_pending"] is False
     confirmed.assert_called_once_with(room.name)
+    await hass.async_block_till_done()
+    assert events[0].data.get("run_id") == run_id
 
 
 async def test_reconciliation_abandons_a_room_seen_ending_in_place(hass) -> None:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -2151,15 +2151,23 @@ async def test_app_stop_after_partial_room_never_credits_or_advances(hass) -> No
 
 
 @pytest.mark.parametrize(
-    ("error", "expected_type"),
+    ("error", "expected_type", "expected_reason_code"),
     [
-        (MaticError("robot rejected the command"), ServiceValidationError),
-        (ServiceValidationError("translated failure"), ServiceValidationError),
-        (HomeAssistantError("call failed"), HomeAssistantError),
+        (
+            MaticError("robot rejected the command"),
+            ServiceValidationError,
+            "robot_error",
+        ),
+        (
+            ServiceValidationError("translated failure"),
+            ServiceValidationError,
+            "managed_failure",
+        ),
+        (HomeAssistantError("call failed"), HomeAssistantError, "managed_failure"),
     ],
 )
 async def test_room_failures_translate_client_errors_at_boundary(
-    error, expected_type
+    error, expected_type, expected_reason_code
 ) -> None:
     services = SimpleNamespace(async_call=AsyncMock())
     bus = SimpleNamespace(async_fire=MagicMock())
@@ -2190,6 +2198,9 @@ async def test_room_failures_translate_client_errors_at_boundary(
     manager.async_mark_failed.assert_awaited_once()
     manager.async_mark_completed.assert_not_awaited()
     assert bus.async_fire.call_args_list[-1].args[0] == "matic_robot_room_failed"
+    event_data = bus.async_fire.call_args_list[-1].args[1]
+    assert event_data["reason_code"] == expected_reason_code
+    assert event_data["cause"] == "unknown"
 
 
 async def test_oem_stop_reconciliation_credits_late_native_session(hass) -> None:


### PR DESCRIPTION
Managed cleaning now retains one run identity and terminal outcome across saved state, room events, and the activity journal. Expected partial stops remain controlled outcomes without awarding unverified room credit. High-frequency observations no longer evict the separate operational event trail.

- Persist safe service provenance, verified room counts, terminal reason and cause; recover unfinished records as interrupted after a restart.
- Distinguish managed stops, replacement commands, native stops with unknown cause, and specific timeout or robot failures.
- Expose the deterministic intelligent-rotation order and rationale used by execution.
- Document the seven-part end-to-end contract and acceptance matrix.

Validation: 1,634 Python tests at 100% coverage, Ruff check/format, strict mypy, public-tree privacy, and clean diff. The unchanged frontend passed TypeScript and 603 browser tests; hosted CI runs them again on this head. Regressions cover real room-runner persistence and events for completion, unverified results, native stop, managed stop, replacement, unload, translated failures, native interruption and takeover, late reconciliation, restart recovery with verified counts, and slow or failed terminal storage, initial storage failure, and reconciliation events after restart. Failed reconciliation saves retain retryable evidence without emitting completion; cancellation and concurrent replacement/edit regressions protect retry and ownership behavior. Replacement motion waits for in-flight history saves and durable marker removal, including after a failed removal save; 32 restart/order cases exercise live and startup reconciliation through all three command paths, including ownership claimed before reconciliation begins. Managed commands re-check ownership after awaiting persistence.

Candidate installation, restart readback, and physical robot acceptance remain separate gates.
