### PR TITLE
Close stale room history after managed runs end

### DIFF
--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -1733,6 +1733,11 @@ def _close_unfinished_room_records(
                     "plan_id": record_plan_id,
                     "room_id": room_id,
                     "room": str(record.get("name", room_id)),
+                    **{
+                        key: record[key]
+                        for key in ("cleaning_mode", "coverage_setting")
+                        if isinstance(record.get(key), str)
+                    },
                 }
             )
     return closed

--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -22,7 +22,7 @@ from statistics import median
 from time import monotonic
 from typing import Any, Literal, cast, override
 
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import Context, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.storage import Store
@@ -304,6 +304,10 @@ class CleaningPlanManager:
                 )
                 robot["last_interrupted_plan"] = deepcopy(active)
                 robot["active_plan"] = None
+                recovered = True
+            if _close_unfinished_room_records(
+                robot, recovered_at=dt_util.utcnow().isoformat()
+            ):
                 recovered = True
         if recovered:
             await self._store.async_save(self._data)
@@ -1033,6 +1037,8 @@ class CleaningPlanManager:
         *,
         terminal_activity: str | None = None,
         cause: str = "unknown",
+        entity_id: str | None = None,
+        context: Context | None = None,
     ) -> bool:
         """Persist one terminal managed-run outcome when its ID still matches."""
         robot = self._robot(serial_number)
@@ -1041,9 +1047,16 @@ class CleaningPlanManager:
             return False
         room_count = last_run.get("room_count")
         max_rooms = room_count if isinstance(room_count, int) and room_count >= 0 else 0
+        ended_at = dt_util.utcnow().isoformat()
+        unfinished = _close_unfinished_room_records(
+            robot,
+            plan_id=last_run["plan_id"],
+            run_id=run_id,
+            ended_at=ended_at,
+        )
         last_run.update(
             {
-                "ended_at": dt_util.utcnow().isoformat(),
+                "ended_at": ended_at,
                 "outcome": outcome[:64],
                 "reason_code": reason_code[:64],
                 "cause": cause[:64],
@@ -1053,6 +1066,18 @@ class CleaningPlanManager:
         if terminal_activity is not None:
             last_run["terminal_activity"] = terminal_activity[:64]
         await self._async_save_and_notify(serial_number)
+        for room in unfinished:
+            self.hass.bus.async_fire(
+                f"{DOMAIN}_room_ended_unverified",
+                {
+                    **({"entity_id": entity_id} if entity_id else {}),
+                    **room,
+                    "run_id": run_id,
+                    "reason_code": "run_ended_without_room_evidence",
+                    "cause": "run_ended",
+                },
+                context=context,
+            )
         return True
 
     async def async_mark_started(
@@ -1068,6 +1093,10 @@ class CleaningPlanManager:
         record = self._room(serial_number, plan_id, room)
         record["last_started"] = now
         record["last_result"] = "running"
+        if run_id is not None:
+            record["run_id"] = run_id
+        else:
+            record.pop("run_id", None)
         robot = self._robot(serial_number)
         robot.pop("pending_native_reconciliation", None)
         robot["active_plan"] = {
@@ -1669,6 +1698,44 @@ class CleaningPlanManager:
             self._robot(serial_number).pop("pending_native_reconciliation", None)
             await self._async_save_and_notify(serial_number)
             self._reconciliation_removal_pending.discard(serial_number)
+
+
+def _close_unfinished_room_records(
+    robot: dict[str, Any],
+    *,
+    plan_id: str | None = None,
+    run_id: str | None = None,
+    ended_at: str | None = None,
+    recovered_at: str | None = None,
+) -> list[dict[str, str]]:
+    """Close attempts lacking terminal evidence without inventing completion."""
+    closed = []
+    for record_plan_id, rotation in robot["rotations"].items():
+        if plan_id is not None and record_plan_id != plan_id:
+            continue
+        for room_id, record in rotation["rooms"].items():
+            previous = record.get("last_result")
+            if (
+                not isinstance(previous, str)
+                or previous not in {"running", "suspended", "verifying"}
+                or (run_id is not None and record.get("run_id") != run_id)
+            ):
+                continue
+            record["last_result"] = "ended_unverified"
+            record["unverified_runs"] = _stored_count(record, "unverified_runs") + 1
+            if ended_at is not None:
+                record["last_ended_unverified"] = ended_at
+            if recovered_at is not None:
+                record["recovered_at"] = recovered_at
+                record["last_result_before_recovery"] = previous
+            closed.append(
+                {
+                    "plan_id": record_plan_id,
+                    "room_id": room_id,
+                    "room": str(record.get("name", room_id)),
+                }
+            )
+    return closed
 
 
 def _restore_unsaved_changes(

--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -1073,8 +1073,8 @@ class CleaningPlanManager:
                     **({"entity_id": entity_id} if entity_id else {}),
                     **room,
                     "run_id": run_id,
-                    "reason_code": "run_ended_without_room_evidence",
-                    "cause": "run_ended",
+                    "reason_code": "unverified_completion",
+                    "cause": "unknown",
                 },
                 context=context,
             )

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -3537,6 +3537,8 @@ async def _async_execute_rooms(
                                 len(completed_room_names),
                                 terminal_activity=terminal_activity,
                                 cause=run_cause,
+                                entity_id=entity_id,
+                                context=call.context,
                             )
                     finally:
                         bus = getattr(hass, "bus", None)

--- a/docs/e2e-contract.md
+++ b/docs/e2e-contract.md
@@ -61,3 +61,10 @@ so recovery retains work already verified before the interruption.
 Late native reconciliation carries the originating `run_id`. The terminal plan
 record continues to describe the evidence available when its runner exited;
 `room_reconciled` identifies any additional completion verified afterward.
+
+When a multi-room run exits, earlier rooms from that run that still lack a
+terminal result become `ended_unverified` and emit a matching room event.
+Their rotation opportunity remains recorded; completion credit still requires
+native evidence. Startup also closes stored nonterminal room records, preserving
+the previous result and recording the recovery time. It does not reconstruct
+missing room events or invent a physical room-end timestamp.

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -507,6 +507,133 @@ async def test_managed_terminal_matrix_uses_real_room_history_and_events(
         )
 
 
+@pytest.mark.parametrize("terminal", ["stop", "interrupted", "failed"])
+async def test_multi_room_exit_closes_earlier_room_history(hass, terminal) -> None:
+    """An ended leg cannot leave its previously visited rooms marked running."""
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    hass.services.async_register("vacuum", "send_command", AsyncMock())
+    rooms = [_room("Kitchen", "room-kitchen"), _room("Study", "room-study")]
+    older_room = _room("Storage", "room-storage")
+    for plan_id in ("away", "earlier-plan"):
+        await manager.async_mark_started(
+            "serial", plan_id, older_room, run_id="earlier-run"
+        )
+    manager._robot("serial")["active_plan"] = None
+    events = []
+    for event in ("room_started", "room_ended_unverified", "plan_finished"):
+        hass.bus.async_listen(f"{DOMAIN}_{event}", events.append)
+    observations = 0
+
+    async def native_outcome(*args, **kwargs):
+        nonlocal observations
+        observations += 1
+        if observations == 1:
+            return RoomRunOutcome.ROOM_CHANGED, rooms[1]
+        if terminal == "stop":
+            manager.cancel("serial")
+            raise PlanCancelledError
+        if terminal == "interrupted":
+            raise RoomInterruptedError("synthetic interruption")
+        raise MaticError("synthetic failure")
+
+    with (
+        nullcontext() if terminal == "stop" else pytest.raises(ServiceValidationError),
+        patch(
+            "custom_components.matic_robot.services._async_wait_for_owned_start",
+            AsyncMock(return_value="cleaning"),
+        ),
+        patch(
+            "custom_components.matic_robot.services._async_wait_for_leg_outcome",
+            side_effect=native_outcome,
+        ),
+    ):
+        await _async_execute_rooms(
+            hass,
+            _call(hass),
+            manager,
+            "vacuum.matic",
+            "serial",
+            rooms,
+            intelligent=False,
+            session_history=AsyncMock(return_value=()),
+        )
+    await hass.async_block_till_done()
+    snapshot = manager.snapshot("serial")
+    records = snapshot["plan_history"]["away"]["rooms"]
+    assert records[rooms[0].room_id]["last_result"] == "ended_unverified"
+    assert records[rooms[0].room_id]["unverified_runs"] == 1
+    assert records[older_room.room_id]["last_result"] == "running"
+    assert (
+        snapshot["plan_history"]["earlier-plan"]["rooms"][older_room.room_id][
+            "last_result"
+        ]
+        == "running"
+    )
+    assert (
+        records[rooms[1].room_id]["last_result"]
+        == {"stop": "cancelled", "interrupted": "interrupted", "failed": "failed"}[
+            terminal
+        ]
+    )
+    assert snapshot["completed_runs"] == 0
+    assert snapshot["active_plan"] is None
+    assert snapshot["last_run"]["completed_room_count"] == 0
+    unverified = [
+        e for e in events if e.event_type == f"{DOMAIN}_room_ended_unverified"
+    ]
+    assert len(unverified) == 1
+    assert unverified[0].data["room_id"] == rooms[0].room_id
+    assert unverified[0].data["run_id"] == snapshot["last_run"]["run_id"]
+
+
+@pytest.mark.parametrize("old_result", ["running", "suspended", "verifying"])
+async def test_restart_closes_orphaned_room_status_without_new_credit(
+    hass, old_result
+) -> None:
+    """Legacy room status can recover without guessing its physical end time."""
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    room = _room("Kitchen", "room-kitchen")
+    completed_at = (dt_util.utcnow() - timedelta(hours=2)).isoformat()
+    await manager.async_mark_completed(
+        "serial", "away", room, completed_at=completed_at, duration_seconds=31
+    )
+    await manager.async_mark_started("serial", "away", room)
+    await manager.async_mark_resumed("serial", "away", room)
+    robot = manager._robot("serial")
+    robot["active_plan"] = None
+    robot["rotations"]["away"]["rooms"][room.room_id]["last_result"] = old_result
+    robot["rotations"]["away"]["rooms"]["malformed"] = {"last_result": []}
+    global_before = deepcopy(robot["rooms"])
+    events = []
+    hass.bus.async_listen(f"{DOMAIN}_room_ended_unverified", events.append)
+    recovered = CleaningPlanManager(hass)
+    recovered._store = SimpleNamespace(
+        async_load=AsyncMock(return_value=deepcopy(manager._data)),
+        async_save=AsyncMock(),
+    )
+
+    await recovered.async_load()
+    record = recovered.snapshot("serial")["plan_history"]["away"]["rooms"][room.room_id]
+    assert record["last_result"] == "ended_unverified"
+    assert record["last_result_before_recovery"] == old_result
+    assert dt_util.parse_datetime(record["recovered_at"]) is not None
+    assert "last_ended_unverified" not in record
+    assert record["unverified_runs"] == 1
+    assert record["completed_runs"] == 1
+    assert record["last_completed"] == completed_at
+    assert record["last_duration_seconds"] == 31
+    assert recovered._robot("serial")["rooms"] == global_before
+    await hass.async_block_till_done()
+    assert events == []
+    after_recovery = deepcopy(recovered._data)
+    recovered._store.async_load.return_value = deepcopy(after_recovery)
+    recovered._store.async_save.reset_mock()
+    await recovered.async_load()
+    assert recovered._data == after_recovery
+
+
 def test_leg_groups_split_only_on_settings_changes() -> None:
     quick_a = _room("Living Room", "room-a")
     quick_b = _room("Dining Room", "room-b")

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -583,8 +583,11 @@ async def test_multi_room_exit_closes_earlier_room_history(hass, terminal) -> No
         e for e in events if e.event_type == f"{DOMAIN}_room_ended_unverified"
     ]
     assert len(unverified) == 1
+    assert unverified[0].data["entity_id"] == "vacuum.matic"
     assert unverified[0].data["room_id"] == rooms[0].room_id
     assert unverified[0].data["run_id"] == snapshot["last_run"]["run_id"]
+    assert unverified[0].data["cleaning_mode"] == rooms[0].cleaning_mode
+    assert unverified[0].data["coverage_setting"] == rooms[0].coverage_setting
 
 
 @pytest.mark.parametrize("old_result", ["running", "suspended", "verifying"])

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -588,6 +588,8 @@ async def test_multi_room_exit_closes_earlier_room_history(hass, terminal) -> No
     assert unverified[0].data["run_id"] == snapshot["last_run"]["run_id"]
     assert unverified[0].data["cleaning_mode"] == rooms[0].cleaning_mode
     assert unverified[0].data["coverage_setting"] == rooms[0].coverage_setting
+    assert unverified[0].data["reason_code"] == "unverified_completion"
+    assert unverified[0].data["cause"] == "unknown"
 
 
 @pytest.mark.parametrize("old_result", ["running", "suspended", "verifying"])


### PR DESCRIPTION
When a grouped cleaning mission stops, is interrupted, or fails after changing rooms, earlier visited rooms can remain marked as running indefinitely. Close unfinished room attempts from the same managed run as `ended_unverified`, with correlated room events, while preserving the active room’s specific terminal outcome.

Startup also recovers orphaned nonterminal room records. Recovery records the previous status and recovery time without inventing physical end times, completion credit, durations, or rotation opportunities.

Validation: 1,641 Python tests pass with 100% coverage, including six regressions for grouped-mission exits and idempotent legacy recovery. Ruff, strict mypy, and the public-tree privacy check pass.
