### PR TITLE
fix: make managed run evidence end to end

### DIFF
--- a/custom_components/matic_robot/client/observations.py
+++ b/custom_components/matic_robot/client/observations.py
@@ -43,6 +43,10 @@ class ActivityJournal:
         """Associate subsequent integration observations with one managed run."""
         self._run_id = run_id if isinstance(run_id, str) and run_id else None
 
+    def current_run_id(self) -> str | None:
+        """Return the run scope for race-safe cleanup of a watcher."""
+        return self._run_id
+
     def record(self, kind: str, **fields: Any) -> int:
         """Record only fields constructed by the client's observation sites."""
         self._sequence += 1

--- a/custom_components/matic_robot/const.py
+++ b/custom_components/matic_robot/const.py
@@ -38,6 +38,7 @@ EVENT_FIRMWARE_CHANGED: Final = f"{DOMAIN}_firmware_changed"
 EVENT_FIRMWARE_ANALYZED: Final = f"{DOMAIN}_firmware_analyzed"
 EVENT_CLEANING_FINISHED: Final = f"{DOMAIN}_cleaning_finished"
 EVENT_PLAN_FINISHED: Final = f"{DOMAIN}_plan_finished"
+EVENT_PLAN_DOCKED: Final = f"{DOMAIN}_plan_docked"
 EVENT_ACTIVITY_OBSERVED: Final = f"{DOMAIN}_activity_observed"
 EVENT_CUES: Final = f"{DOMAIN}_cues"
 

--- a/custom_components/matic_robot/llm.py
+++ b/custom_components/matic_robot/llm.py
@@ -24,6 +24,7 @@ from .const import (
     EVENT_CUES,
     EVENT_FIRMWARE_ANALYZED,
     EVENT_FIRMWARE_CHANGED,
+    EVENT_PLAN_DOCKED,
     EVENT_PLAN_FINISHED,
 )
 from .plans import CleaningPlanManager, leg_groups
@@ -53,6 +54,7 @@ _ADMIN_ERROR = "Administrator access is required for Matic operational tools"
 _MATIC_EVENT_TYPES = (
     EVENT_ACTIVITY_OBSERVED,
     EVENT_CLEANING_FINISHED,
+    EVENT_PLAN_DOCKED,
     EVENT_PLAN_FINISHED,
     EVENT_CUES,
     EVENT_FIRMWARE_CHANGED,
@@ -85,6 +87,7 @@ _SAFE_EVENT_FIELDS = (
     "intent",
     "plan_id",
     "trigger",
+    "provenance",
     "service",
     "room_id",
     "room",
@@ -168,6 +171,18 @@ class MaticOperationsAPI(llm.API):
                 data["completed_room_count"] = len(completed_rooms)
             if isinstance(room_durations, dict):
                 data["room_duration_count"] = len(room_durations)
+        if event.event_type == EVENT_PLAN_FINISHED:
+            room_outcomes = event.data.get("room_outcomes")
+            if isinstance(room_outcomes, list):
+                data["room_outcomes"] = [
+                    {
+                        key: value[:256]
+                        for key in ("room_id", "room", "outcome")
+                        if isinstance(value := item.get(key), str)
+                    }
+                    for item in room_outcomes[:64]
+                    if isinstance(item, dict)
+                ]
         captured: JsonObjectType = {
             "event_type": str(event.event_type),
             "time_fired": event.time_fired.isoformat(),
@@ -310,6 +325,7 @@ class MaticGetPlanTool(_MaticTool):
                     "last_result": None,
                     "last_opportunity": None,
                     "last_opportunity_source": None,
+                    "last_completion": None,
                     "selection_reason": "saved_order",
                 }
                 for rank, room in enumerate(rooms, start=1)

--- a/custom_components/matic_robot/llm.py
+++ b/custom_components/matic_robot/llm.py
@@ -317,15 +317,33 @@ class MaticGetPlanTool(_MaticTool):
             )
             rotation = rotation_value if isinstance(rotation_value, list) else []
         else:
+            history_value = runtime.cleaning_plans.rotation_details(
+                serial_number, plan["id"], rooms
+            )
+            history = (
+                {
+                    item["room_id"]: item
+                    for item in history_value
+                    if isinstance(item, dict) and isinstance(item.get("room_id"), str)
+                }
+                if isinstance(history_value, list)
+                else {}
+            )
             rotation = [
                 {
                     "rank": rank,
                     "room_id": room.room_id,
                     "room": room.name,
-                    "last_result": None,
-                    "last_opportunity": None,
-                    "last_opportunity_source": None,
-                    "last_completion": None,
+                    "last_result": history.get(room.room_id, {}).get("last_result"),
+                    "last_opportunity": history.get(room.room_id, {}).get(
+                        "last_opportunity"
+                    ),
+                    "last_opportunity_source": history.get(room.room_id, {}).get(
+                        "last_opportunity_source"
+                    ),
+                    "last_completion": history.get(room.room_id, {}).get(
+                        "last_completion"
+                    ),
                     "selection_reason": "saved_order",
                 }
                 for rank, room in enumerate(rooms, start=1)

--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -1120,7 +1120,7 @@ class CleaningPlanManager:
                     "stopped_docked" if docked else normalize_run_outcome(outcome)
                 ),
                 "reason_code": "stopped_docked" if docked else reason_code[:64],
-                "cause": "managed_stop" if docked else cause[:64],
+                "cause": "managed_cancellation" if docked else cause[:64],
                 "completed_room_count": min(max(0, completed_room_count), max_rooms),
             }
         )

--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -933,7 +933,15 @@ class CleaningPlanManager:
             "rotation": (
                 self.rotation_details(serial_number, plan["id"], rooms)
                 if intelligent
-                else _saved_order_rotation_details(rooms)
+                else _saved_order_rotation_details(
+                    rooms,
+                    {
+                        candidate.room.room_id: candidate
+                        for candidate in self._rotation_candidates(
+                            serial_number, plan["id"], rooms
+                        )
+                    },
+                )
             ),
             "room_count": len(chosen),
             "return_to_base": bool(plan.get("return_to_base", True)),
@@ -2274,17 +2282,26 @@ def _rotation_sort_key(candidate: _RotationCandidate) -> tuple[bool, float, int]
 
 def _saved_order_rotation_details(
     rooms: Sequence[CleaningRoom],
+    history: Mapping[str, _RotationCandidate] | None = None,
 ) -> list[dict[str, Any]]:
-    """Describe an ordered plan without implying intelligent history."""
+    """Describe an ordered plan while preserving its saved room order."""
     return [
         {
             "rank": rank,
             "room_id": room.room_id,
             "room": room.name,
-            "last_result": None,
-            "last_opportunity": None,
-            "last_opportunity_source": None,
-            "last_completion": None,
+            "last_result": history[room.room_id].last_result
+            if history and room.room_id in history
+            else None,
+            "last_opportunity": history[room.room_id].effective_value
+            if history and room.room_id in history
+            else None,
+            "last_opportunity_source": history[room.room_id].source
+            if history and room.room_id in history
+            else None,
+            "last_completion": history[room.room_id].last_completion
+            if history and room.room_id in history
+            else None,
             "selection_reason": "saved_order",
         }
         for rank, room in enumerate(rooms, start=1)

--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -36,7 +36,7 @@ from .area_binding import (
     binding_for_area,
 )
 from .client.models import CleaningSessionRecord, FloorPlan, Room
-from .const import DOMAIN
+from .const import DOMAIN, EVENT_PLAN_DOCKED
 
 STORAGE_VERSION = 1
 STORAGE_MINOR_VERSION = 5
@@ -54,6 +54,48 @@ ROTATION_FUTURE_TOLERANCE_SECONDS = 24 * 60 * 60
 OEM_STOP_RECONCILIATION_SECONDS = 12 * 60
 OEM_STOP_FENCE_SECONDS = OEM_STOP_RECONCILIATION_SECONDS
 STOP_FENCE_EXPIRES_AT = "stop_fence_expires_at"
+
+# These are the only terminal outcomes exposed for a managed run.  ``running``
+# remains an internal in-flight marker; room history keeps its own evidence
+# state and is never inferred from this run-level value.
+RUN_OUTCOMES = (
+    "completed",
+    "stopped_docked",
+    "recharge_suspended",
+    "cancelled",
+    "failed",
+    "unverified",
+)
+RunOutcome = Literal[
+    "completed",
+    "stopped_docked",
+    "recharge_suspended",
+    "cancelled",
+    "failed",
+    "unverified",
+]
+RUN_PROVENANCE = ("automation", "user", "internal", "external_unknown")
+RunProvenance = Literal["automation", "user", "internal", "external_unknown"]
+
+_LEGACY_RUN_OUTCOMES: dict[str, RunOutcome] = {
+    "partial": "unverified",
+    "stopped": "cancelled",
+    "interrupted": "unverified",
+}
+
+
+def normalize_run_outcome(value: str) -> RunOutcome:
+    """Map older persisted labels into the explicit terminal vocabulary."""
+    if value in RUN_OUTCOMES:
+        return cast(RunOutcome, value)
+    return _LEGACY_RUN_OUTCOMES.get(value, "unverified")
+
+
+def normalize_run_provenance(value: str | None) -> RunProvenance:
+    """Keep provenance bounded and free of account identifiers."""
+    if value in RUN_PROVENANCE:
+        return cast(RunProvenance, value)
+    return "external_unknown"
 
 
 class SavedPlanLimitError(HomeAssistantError):
@@ -80,6 +122,7 @@ class _RotationCandidate:
     effective_value: str | None
     source: str | None
     last_result: str | None
+    last_completion: str | None
 
 
 def plan_floor_token(floor_plan: FloorPlan) -> str:
@@ -256,7 +299,7 @@ class CleaningPlanManager:
             if isinstance(last_run, dict) and last_run.get("outcome") == "running":
                 last_run.update(
                     {
-                        "outcome": "interrupted",
+                        "outcome": "unverified",
                         "reason_code": "home_assistant_restart",
                         "cause": "home_assistant",
                         "ended_at": None,
@@ -914,6 +957,7 @@ class CleaningPlanManager:
                     "last_result": candidate.last_result,
                     "last_opportunity": candidate.effective_value,
                     "last_opportunity_source": candidate.source,
+                    "last_completion": candidate.last_completion,
                     "selection_reason": reason,
                 }
             )
@@ -988,6 +1032,11 @@ class CleaningPlanManager:
                 effective = global_opportunity
                 source = "global"
             last_result = record.get("last_result")
+            completion_values = _latest_timestamp_value(
+                record.get("last_completed"),
+                global_record.get("last_completed"),
+                now=now,
+            )
             candidates.append(
                 _RotationCandidate(
                     index=index,
@@ -996,6 +1045,9 @@ class CleaningPlanManager:
                     effective_value=effective[1] if effective else None,
                     source=source,
                     last_result=last_result if isinstance(last_result, str) else None,
+                    last_completion=(
+                        completion_values[1] if completion_values else None
+                    ),
                 )
             )
         return candidates
@@ -1009,9 +1061,11 @@ class CleaningPlanManager:
         *,
         trigger: str,
         service: str,
+        provenance: str | None = None,
     ) -> None:
         """Persist the bounded identity and provenance of a managed run."""
         robot = self._robot(serial_number)
+        safe_provenance = normalize_run_provenance(provenance or trigger)
         robot["last_run"] = {
             "run_id": run_id,
             "plan_id": plan_id,
@@ -1020,7 +1074,8 @@ class CleaningPlanManager:
             "ended_at": None,
             "outcome": "running",
             "reason_code": "run_started",
-            "trigger": trigger[:64],
+            "trigger": safe_provenance,
+            "provenance": safe_provenance,
             "service": service[:128],
             "room_count": max(0, room_count),
             "completed_room_count": 0,
@@ -1057,7 +1112,7 @@ class CleaningPlanManager:
         last_run.update(
             {
                 "ended_at": ended_at,
-                "outcome": outcome[:64],
+                "outcome": normalize_run_outcome(outcome),
                 "reason_code": reason_code[:64],
                 "cause": cause[:64],
                 "completed_room_count": min(max(0, completed_room_count), max_rooms),
@@ -1078,6 +1133,62 @@ class CleaningPlanManager:
                 },
                 context=context,
             )
+        return True
+
+    @callback
+    def active_run_id(self, serial_number: str) -> str | None:
+        """Return the current managed run ID without exposing user context."""
+        last_run = self._robot(serial_number).get("last_run")
+        if isinstance(last_run, dict) and last_run.get("outcome") == "running":
+            run_id = last_run.get("run_id")
+            return run_id if isinstance(run_id, str) else None
+        return None
+
+    async def async_mark_run_docked(
+        self,
+        serial_number: str,
+        run_id: str,
+        *,
+        entity_id: str | None = None,
+        context: Context | None = None,
+    ) -> bool:
+        """Close a stopped run only after a correlated final DOCK settles."""
+        robot = self._robot(serial_number)
+        last_run = robot.get("last_run")
+        if not isinstance(last_run, dict) or last_run.get("run_id") != run_id:
+            return False
+        if last_run.get("outcome") not in {"cancelled", "unverified"}:
+            return False
+        now = dt_util.utcnow().isoformat()
+        provenance = normalize_run_provenance(
+            last_run.get("provenance")
+            if isinstance(last_run.get("provenance"), str)
+            else None
+        )
+        last_run.update(
+            {
+                "outcome": "stopped_docked",
+                "reason_code": "stopped_docked",
+                "terminal_activity": "docked",
+                "docked_at": now,
+                "provenance": provenance,
+            }
+        )
+        await self._async_save_and_notify(serial_number)
+        self.hass.bus.async_fire(
+            EVENT_PLAN_DOCKED,
+            {
+                **({"entity_id": entity_id} if entity_id else {}),
+                "run_id": run_id,
+                "plan_id": last_run.get("plan_id"),
+                "outcome": "stopped_docked",
+                "reason_code": "stopped_docked",
+                "terminal_activity": "docked",
+                "docked_at": now,
+                "provenance": provenance,
+            },
+            context=context,
+        )
         return True
 
     async def async_mark_started(
@@ -1590,6 +1701,27 @@ class CleaningPlanManager:
         elif "last_run" not in robot:
             robot["last_run"] = None
             changed = True
+        elif isinstance(last_run, dict):
+            last_run_value = cast(dict[str, Any], last_run)
+            outcome = last_run_value.get("outcome")
+            if isinstance(outcome, str) and outcome != "running":
+                normalized_outcome = normalize_run_outcome(outcome)
+                if outcome != normalized_outcome:
+                    last_run_value["outcome"] = normalized_outcome
+                    changed = True
+            raw_provenance = last_run_value.get("provenance") or last_run_value.get(
+                "trigger"
+            )
+            safe_provenance = normalize_run_provenance(
+                raw_provenance if isinstance(raw_provenance, str) else None
+            )
+            if (
+                last_run_value.get("trigger") != safe_provenance
+                or last_run_value.get("provenance") != safe_provenance
+            ):
+                last_run_value["trigger"] = safe_provenance
+                last_run_value["provenance"] = safe_provenance
+                changed = True
         pending = robot.get("pending_native_reconciliation")
         if pending is not None and _validated_native_reconciliation(pending) is None:
             robot.pop("pending_native_reconciliation", None)
@@ -2124,6 +2256,7 @@ def _saved_order_rotation_details(
             "last_result": None,
             "last_opportunity": None,
             "last_opportunity_source": None,
+            "last_completion": None,
             "selection_reason": "saved_order",
         }
         for rank, room in enumerate(rooms, start=1)

--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -534,6 +534,11 @@ class CleaningPlanManager:
         """Return the lifecycle reason attached to the current cancellation."""
         return self._cancellation_reasons.get(serial_number)
 
+    @callback
+    def mark_managed_stop(self, serial_number: str) -> None:
+        """Authorize an in-flight dock upgrade for a graceful managed stop."""
+        self._cancellation_reasons[serial_number] = "managed_stop"
+
     async def async_cancel_and_wait(self, serial_number: str) -> None:
         """Interrupt a managed run and wait before its client can be closed."""
         task = self._run_tasks.get(serial_number)

--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -269,6 +269,7 @@ class CleaningPlanManager:
         self._managed_motion: dict[str, int] = {}
         self._run_tasks: dict[str, asyncio.Task[None]] = {}
         self._reconciliation_tasks: dict[str, set[asyncio.Task[None]]] = {}
+        self._dock_reconciliation_tasks: dict[str, set[asyncio.Task[None]]] = {}
         self._native_history_saves: dict[str, set[asyncio.Event]] = {}
         self._reconciliation_removal_pending: set[str] = set()
         self._cancellation_reasons: dict[str, str] = {}
@@ -493,11 +494,13 @@ class CleaningPlanManager:
 
     @callback
     def register_reconciliation_task(
-        self, serial_number: str, task: asyncio.Task[None]
+        self, serial_number: str, task: asyncio.Task[None], *, dock: bool = False
     ) -> None:
         """Tie a late native-completion watcher to this robot's lifecycle."""
         tasks = self._reconciliation_tasks.setdefault(serial_number, set())
         tasks.add(task)
+        if dock:
+            self._dock_reconciliation_tasks.setdefault(serial_number, set()).add(task)
 
         def _discard(done: asyncio.Task[None]) -> None:
             current = self._reconciliation_tasks.get(serial_number)
@@ -506,19 +509,26 @@ class CleaningPlanManager:
             current.discard(done)
             if not current:
                 self._reconciliation_tasks.pop(serial_number, None)
+            if dock:
+                dock_current = self._dock_reconciliation_tasks.get(serial_number)
+                if dock_current is not None:
+                    dock_current.discard(done)
+                    if not dock_current:
+                        self._dock_reconciliation_tasks.pop(serial_number, None)
 
         task.add_done_callback(_discard)
 
     @callback
-    def reconciliation_tasks_active(self, serial_number: str) -> bool:
-        """Return whether a late native or dock watcher owns this robot."""
-        return bool(self._reconciliation_tasks.get(serial_number))
+    def dock_reconciliation_active(self, serial_number: str) -> bool:
+        """Return whether a dock watcher still owns this robot's scope."""
+        return bool(self._dock_reconciliation_tasks.get(serial_number))
 
     @callback
     def cancel_reconciliation_tasks(self, serial_number: str) -> None:
         """Cancel obsolete late-completion watchers without blocking."""
         for task in tuple(self._reconciliation_tasks.pop(serial_number, set())):
             task.cancel()
+        self._dock_reconciliation_tasks.pop(serial_number, None)
 
     def cancellation_reason(self, serial_number: str) -> str | None:
         """Return the lifecycle reason attached to the current cancellation."""
@@ -537,6 +547,7 @@ class CleaningPlanManager:
         reconciliation_tasks = tuple(
             self._reconciliation_tasks.pop(serial_number, set())
         )
+        self._dock_reconciliation_tasks.pop(serial_number, None)
         for reconciliation_task in reconciliation_tasks:
             reconciliation_task.cancel()
         if reconciliation_tasks:

--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -621,6 +621,7 @@ class CleaningPlanManager:
         plan = robot["plans"].get(active["plan_id"], {})
         if not plan.get("finish_current_room", False):
             self.cancel(serial_number)
+            self._cancellation_reasons.setdefault(serial_number, "managed_stop")
             return PlanStopDecision("immediate")
 
         try:
@@ -1111,16 +1112,19 @@ class CleaningPlanManager:
             run_id=run_id,
             ended_at=ended_at,
         )
+        docked = last_run.get("outcome") == "stopped_docked"
         last_run.update(
             {
                 "ended_at": ended_at,
-                "outcome": normalize_run_outcome(outcome),
-                "reason_code": reason_code[:64],
-                "cause": cause[:64],
+                "outcome": (
+                    "stopped_docked" if docked else normalize_run_outcome(outcome)
+                ),
+                "reason_code": "stopped_docked" if docked else reason_code[:64],
+                "cause": "managed_stop" if docked else cause[:64],
                 "completed_room_count": min(max(0, completed_room_count), max_rooms),
             }
         )
-        if terminal_activity is not None:
+        if terminal_activity is not None and not docked:
             last_run["terminal_activity"] = terminal_activity[:64]
         await self._async_save_and_notify(serial_number)
         for room in unfinished:
@@ -1159,7 +1163,7 @@ class CleaningPlanManager:
         last_run = robot.get("last_run")
         if not isinstance(last_run, dict) or last_run.get("run_id") != run_id:
             return False
-        if last_run.get("outcome") not in {"cancelled", "unverified"}:
+        if last_run.get("outcome") not in {"running", "cancelled", "unverified"}:
             return False
         now = dt_util.utcnow().isoformat()
         provenance = normalize_run_provenance(

--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -616,6 +616,7 @@ class CleaningPlanManager:
         active = robot.get("active_plan")
         if active is None:
             self.cancel(serial_number)
+            self._cancellation_reasons.setdefault(serial_number, "managed_stop")
             return PlanStopDecision("immediate")
         plan = robot["plans"].get(active["plan_id"], {})
         if not plan.get("finish_current_room", False):
@@ -644,6 +645,7 @@ class CleaningPlanManager:
         progress = _estimated_progress(active, expected)
         if progress is not None and progress < threshold:
             self.cancel(serial_number)
+            self._cancellation_reasons.setdefault(serial_number, "managed_stop")
             return PlanStopDecision("immediate", progress, threshold)
 
         self.cancellation_event(serial_number).clear()

--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -1040,6 +1040,12 @@ class CleaningPlanManager:
                 global_record.get("last_completed"),
                 now=now,
             )
+            if (
+                reset_at is not None
+                and completion_values is not None
+                and completion_values[0] <= reset_at
+            ):
+                completion_values = None
             candidates.append(
                 _RotationCandidate(
                     index=index,

--- a/custom_components/matic_robot/plans.py
+++ b/custom_components/matic_robot/plans.py
@@ -510,6 +510,11 @@ class CleaningPlanManager:
         task.add_done_callback(_discard)
 
     @callback
+    def reconciliation_tasks_active(self, serial_number: str) -> bool:
+        """Return whether a late native or dock watcher owns this robot."""
+        return bool(self._reconciliation_tasks.get(serial_number))
+
+    @callback
     def cancel_reconciliation_tasks(self, serial_number: str) -> None:
         """Cancel obsolete late-completion watchers without blocking."""
         for task in tuple(self._reconciliation_tasks.pop(serial_number, set())):

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -550,6 +550,11 @@ async def async_register_services(hass: HomeAssistant) -> None:
                 "set_run_id",
                 None,
             ),
+            get_activity_run_id=getattr(
+                getattr(entry.runtime_data.client, "activity_journal", None),
+                "current_run_id",
+                None,
+            ),
         )
 
     async def async_clean_room_sequence(call: ServiceCall) -> None:
@@ -661,6 +666,11 @@ async def async_register_services(hass: HomeAssistant) -> None:
             set_activity_run_id=getattr(
                 getattr(entry.runtime_data.client, "activity_journal", None),
                 "set_run_id",
+                None,
+            ),
+            get_activity_run_id=getattr(
+                getattr(entry.runtime_data.client, "activity_journal", None),
+                "current_run_id",
                 None,
             ),
         )
@@ -3354,6 +3364,7 @@ async def _async_execute_rooms(
     floor_token: str | None = None,
     session_identity: Callable[[], Awaitable[bytes | None]] | None = None,
     set_activity_run_id: Callable[[str | None], None] | None = None,
+    get_activity_run_id: Callable[[], str | None] | None = None,
 ) -> None:
     """Execute every resolved room with safe cancellation semantics."""
     lock = manager.lock(serial_number)
@@ -3366,6 +3377,7 @@ async def _async_execute_rooms(
         cancel_event = manager.prepare_run(serial_number)
         motion_token = manager.begin_managed_motion(serial_number)
         cleanup_stop_sent = False
+        dock_confirmation_scheduled = False
         native_identity: bytes | None = None
         run_id = uuid4().hex
         run_started_at = dt_util.utcnow().isoformat()
@@ -3547,13 +3559,15 @@ async def _async_execute_rooms(
                     if finish_room_event.is_set() and completed_room_count < len(
                         chosen
                     ):
-                        schedule_dock_confirmation(
+                        dock_confirmation_scheduled = schedule_dock_confirmation(
                             hass,
                             refresh=refresh or (lambda: asyncio.sleep(0)),
                             manager=manager,
                             serial_number=serial_number,
                             entity_id=entity_id,
                             run_id=run_id,
+                            set_run_id=set_activity_run_id,
+                            get_run_id=get_activity_run_id,
                             on_docked=partial(
                                 _async_mark_run_docked,
                                 manager,
@@ -3813,7 +3827,7 @@ async def _async_execute_rooms(
             finally:
                 manager.end_managed_motion(serial_number, motion_token)
                 manager.unregister_run_task(serial_number)
-                if set_activity_run_id is not None:
+                if set_activity_run_id is not None and not dock_confirmation_scheduled:
                     set_activity_run_id(None)
 
 

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -1163,6 +1163,7 @@ async def _async_run_room(
     room_name_is_unique: bool = True,
     prepared_dispatch: _PreparedRoomDispatch | None = None,
     prefetch_next: Callable[[], Awaitable[_PreparedRoomDispatch | None]] | None = None,
+    finish_room_event: asyncio.Event | None = None,
     floor_is_current: Callable[[], bool] | None = None,
     floor_token: str | None = None,
     session_identity: Callable[[], Awaitable[bytes | None]] | None = None,
@@ -1503,6 +1504,11 @@ async def _async_run_room(
             str(err), "room_interrupted", {"room": room.name}
         ) from err
     except (TimeoutError, HomeAssistantError, MaticError) as err:
+        # A graceful finish request can race a room failure.  Clear that
+        # intent before sending the failure STOP so its dock watcher cannot
+        # upgrade the still-running record and mask the durable failure.
+        if finish_room_event is not None:
+            finish_room_event.clear()
         await _async_cleanup_managed_motion(
             managed_user_command,
             motion_token,
@@ -1660,6 +1666,7 @@ async def _async_run_leg(
             room_name_is_unique=room_name_is_unique,
             prepared_dispatch=prepared_dispatch,
             prefetch_next=prefetch_next,
+            finish_room_event=finish_room_event,
             floor_is_current=floor_is_current,
             floor_token=floor_token,
             session_identity=session_identity,
@@ -1992,6 +1999,11 @@ async def _async_run_leg(
             {"room": active_room.name},
         ) from err
     except (TimeoutError, HomeAssistantError, MaticError) as err:
+        # A graceful finish request can race a room failure.  Clear that
+        # intent before sending the failure STOP so its dock watcher cannot
+        # upgrade the still-running record and mask the durable failure.
+        if finish_room_event is not None:
+            finish_room_event.clear()
         await _async_cleanup_managed_motion(
             managed_user_command,
             motion_token,

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -3882,6 +3882,8 @@ async def _async_execute_rooms(
                 stop_watcher_active = callable(reconciliation_active_reader) and bool(
                     reconciliation_active_reader(serial_number)
                 )
+                if stop_watcher_active and get_activity_run_id is not None:
+                    stop_watcher_active = get_activity_run_id() == run_id
                 if (
                     set_activity_run_id is not None
                     and not dock_confirmation_scheduled

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -3269,7 +3269,7 @@ def _room_outcomes(
         record = records.get(room.room_id, {}) if isinstance(records, dict) else {}
         attempted = isinstance(record, dict) and (
             record.get("run_id") == run_id
-            or record.get("last_result")
+            and record.get("last_result")
             in {
                 "running",
                 "suspended",
@@ -3481,7 +3481,7 @@ async def _async_execute_rooms(
                     break
             completed_room_count = len(completed_room_names)
             if finish_room_event.is_set() and completed_room_count < len(chosen):
-                run_outcome = "stopped"
+                run_outcome = "cancelled"
                 run_reason_code = "managed_stop"
                 run_cause = "managed_cancellation"
             elif completed_room_count == len(chosen):
@@ -3530,11 +3530,7 @@ async def _async_execute_rooms(
                 active_snapshot.get("status") == "suspended"
                 and active_snapshot.get("suspend_reason") == "low_charge"
             )
-            if recharge_suspended:
-                run_outcome = "recharge_suspended"
-                run_reason_code = "low_charge"
-                run_cause = "robot"
-            elif cancellation_reason == "config_entry_unload":
+            if cancellation_reason == "config_entry_unload":
                 run_outcome = "unverified"
                 run_reason_code = "config_entry_unload"
                 run_cause = "home_assistant"
@@ -3544,6 +3540,14 @@ async def _async_execute_rooms(
                 run_outcome = "cancelled"
                 run_reason_code = "managed_replaced"
                 run_cause = "replacement"
+            elif cancellation_reason == "managed_stop":
+                run_outcome = "cancelled"
+                run_reason_code = "managed_stop"
+                run_cause = "managed_cancellation"
+            elif recharge_suspended:
+                run_outcome = "recharge_suspended"
+                run_reason_code = "low_charge"
+                run_cause = "robot"
             else:
                 run_outcome = "cancelled"
                 run_reason_code = "managed_stop"

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -3546,19 +3546,25 @@ async def _async_execute_rooms(
                 serial_number, motion_token
             ):
                 raise PlanCancelledError
+            current = hass.states.get(entity_id)
+            needs_dock_confirmation = finish_room_event.is_set() and (
+                completed_room_count < len(chosen)
+            )
             if (
                 (call.data["return_to_base"] or finish_room_event.is_set())
-                and (current := hass.states.get(entity_id)) is not None
-                and current.state not in {"docked", "returning"}
+                and current is not None
                 and outer_command is not None
                 and not cleanup_stop_sent
                 and not _stop_is_pending(manager, serial_number)
+                and (
+                    current.state not in {"docked", "returning"}
+                    or needs_dock_confirmation
+                )
             ):
                 try:
-                    await outer_command(motion_token, UserCommand.DOCK)
-                    if finish_room_event.is_set() and completed_room_count < len(
-                        chosen
-                    ):
+                    if current.state not in {"docked", "returning"}:
+                        await outer_command(motion_token, UserCommand.DOCK)
+                    if needs_dock_confirmation:
                         dock_confirmation_scheduled = schedule_dock_confirmation(
                             hass,
                             refresh=refresh or (lambda: asyncio.sleep(0)),

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -505,6 +505,11 @@ async def async_register_services(hass: HomeAssistant) -> None:
                         "set_run_id",
                         None,
                     ),
+                    get_run_id=getattr(
+                        getattr(entry.runtime_data.client, "activity_journal", None),
+                        "current_run_id",
+                        None,
+                    ),
                     on_docked=partial(
                         _async_mark_run_docked,
                         manager,
@@ -611,6 +616,11 @@ async def async_register_services(hass: HomeAssistant) -> None:
                     set_run_id=getattr(
                         getattr(entry.runtime_data.client, "activity_journal", None),
                         "set_run_id",
+                        None,
+                    ),
+                    get_run_id=getattr(
+                        getattr(entry.runtime_data.client, "activity_journal", None),
+                        "current_run_id",
                         None,
                     ),
                     on_docked=partial(

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -75,6 +75,7 @@ from .plans import (
     ManagedMotionReplacedError,
     SavedPlanLimitError,
     leg_groups,
+    normalize_run_provenance,
     plan_floor_token,
     resolve_room_reference,
     resolve_rooms,
@@ -480,6 +481,11 @@ async def async_register_services(hass: HomeAssistant) -> None:
         )
 
         async def async_managed_command(token: int, command: UserCommand) -> None:
+            stop_run_id = (
+                manager.active_run_id(serial_number)
+                if command is UserCommand.STOP
+                else None
+            )
             async with manager.managed_command(serial_number, token):
                 await entry.runtime_data.client.async_send_user_command(command)
                 if command is UserCommand.STOP:
@@ -493,6 +499,20 @@ async def async_register_services(hass: HomeAssistant) -> None:
                     manager=manager,
                     serial_number=serial_number,
                     entity_id=entity_id,
+                    run_id=stop_run_id,
+                    set_run_id=getattr(
+                        getattr(entry.runtime_data.client, "activity_journal", None),
+                        "set_run_id",
+                        None,
+                    ),
+                    on_docked=partial(
+                        _async_mark_run_docked,
+                        manager,
+                        serial_number,
+                        stop_run_id,
+                        entity_id,
+                        call.context,
+                    ),
                 )
 
         await _async_execute_rooms(
@@ -569,6 +589,11 @@ async def async_register_services(hass: HomeAssistant) -> None:
         )
 
         async def async_managed_command(token: int, command: UserCommand) -> None:
+            stop_run_id = (
+                manager.active_run_id(serial_number)
+                if command is UserCommand.STOP
+                else None
+            )
             async with manager.managed_command(serial_number, token):
                 await entry.runtime_data.client.async_send_user_command(command)
                 if command is UserCommand.STOP:
@@ -582,6 +607,20 @@ async def async_register_services(hass: HomeAssistant) -> None:
                     manager=manager,
                     serial_number=serial_number,
                     entity_id=entity_id,
+                    run_id=stop_run_id,
+                    set_run_id=getattr(
+                        getattr(entry.runtime_data.client, "activity_journal", None),
+                        "set_run_id",
+                        None,
+                    ),
+                    on_docked=partial(
+                        _async_mark_run_docked,
+                        manager,
+                        serial_number,
+                        stop_run_id,
+                        entity_id,
+                        call.context,
+                    ),
                 )
 
         await _async_execute_rooms(
@@ -1125,6 +1164,7 @@ async def _async_run_room(
         "cleaning_mode": room.cleaning_mode,
         "coverage_setting": room.coverage_setting,
         "run_id": run_id,
+        "provenance": _run_provenance(call),
     }
     await manager.async_mark_started(
         serial_number, call.data["plan_id"], room, run_id=run_id
@@ -1620,6 +1660,7 @@ async def _async_run_leg(
             "cleaning_mode": room.cleaning_mode,
             "coverage_setting": room.coverage_setting,
             "run_id": run_id,
+            "provenance": _run_provenance(call),
         }
 
     active_room = leg[0]
@@ -3183,6 +3224,78 @@ class RoomTakenOverError(HomeAssistantError):
     """The native task ended, changed, or could no longer be identified."""
 
 
+def _run_provenance(call: ServiceCall) -> str:
+    """Return bounded trigger provenance without retaining account identity."""
+    context = call.context
+    if getattr(context, "parent_id", None):
+        return "automation"
+    if getattr(context, "user_id", None):
+        return "user"
+    return normalize_run_provenance(None)
+
+
+async def _async_mark_run_docked(
+    manager: CleaningPlanManager,
+    serial_number: str,
+    run_id: str | None,
+    entity_id: str,
+    context: Context,
+) -> None:
+    """Bridge the stop watcher to durable run closure for service calls."""
+    if run_id is None:
+        return
+    await manager.async_mark_run_docked(
+        serial_number,
+        run_id,
+        entity_id=entity_id,
+        context=context,
+    )
+
+
+def _room_outcomes(
+    manager: CleaningPlanManager,
+    serial_number: str,
+    plan_id: str,
+    run_id: str,
+    chosen: Sequence[CleaningRoom],
+    completed_names: set[str],
+) -> list[dict[str, str]]:
+    """Return the bounded room outcome vocabulary for one terminal run."""
+    history = manager.snapshot(serial_number).get("plan_history", {})
+    plan_history = history.get(plan_id, {}) if isinstance(history, dict) else {}
+    records = plan_history.get("rooms", {}) if isinstance(plan_history, dict) else {}
+    result: list[dict[str, str]] = []
+    for room in chosen:
+        record = records.get(room.room_id, {}) if isinstance(records, dict) else {}
+        attempted = isinstance(record, dict) and (
+            record.get("run_id") == run_id
+            or record.get("last_result")
+            in {
+                "running",
+                "suspended",
+                "verifying",
+                "ended_unverified",
+                "cancelled",
+                "interrupted",
+                "failed",
+            }
+        )
+        result.append(
+            {
+                "room_id": room.room_id,
+                "room": room.name,
+                "outcome": (
+                    "completed"
+                    if room.name in completed_names
+                    else "partial"
+                    if attempted
+                    else "unattempted"
+                ),
+            }
+        )
+    return result
+
+
 async def _async_execute_rooms(
     hass: HomeAssistant,
     call: ServiceCall,
@@ -3222,6 +3335,7 @@ async def _async_execute_rooms(
         run_outcome = "failed"
         run_reason_code = "run_not_finished"
         run_cause = "unknown"
+        run_provenance = _run_provenance(call)
         completed_room_names: set[str] = set()
         chosen: list[CleaningRoom] = []
 
@@ -3265,8 +3379,9 @@ async def _async_execute_rooms(
                     call.data["plan_id"],
                     run_id,
                     len(chosen),
-                    trigger="service_call",
+                    trigger=run_provenance,
                     service=str(call.service),
+                    provenance=run_provenance,
                 )
             prepared_dispatches: dict[str, _PreparedRoomDispatch] = {}
             for index, leg in enumerate(legs):
@@ -3374,7 +3489,7 @@ async def _async_execute_rooms(
                 run_reason_code = "all_rooms_verified"
                 run_cause = "verified_completion"
             else:
-                run_outcome = "partial"
+                run_outcome = "unverified"
                 run_reason_code = "partial_native_result"
                 run_cause = "native_result"
             if cancel_event.is_set() or not manager.managed_motion_is_current(
@@ -3405,18 +3520,32 @@ async def _async_execute_rooms(
                 if callable(cancellation_reason_reader)
                 else None
             )
-            if cancellation_reason == "config_entry_unload":
-                run_outcome = "interrupted"
+            snapshot_reader = getattr(manager, "snapshot", None)
+            active_snapshot = (
+                snapshot_reader(serial_number).get("active_plan")
+                if callable(snapshot_reader)
+                else None
+            )
+            recharge_suspended = isinstance(active_snapshot, dict) and (
+                active_snapshot.get("status") == "suspended"
+                and active_snapshot.get("suspend_reason") == "low_charge"
+            )
+            if recharge_suspended:
+                run_outcome = "recharge_suspended"
+                run_reason_code = "low_charge"
+                run_cause = "robot"
+            elif cancellation_reason == "config_entry_unload":
+                run_outcome = "unverified"
                 run_reason_code = "config_entry_unload"
                 run_cause = "home_assistant"
             elif cancellation_reason == "motion_replaced" or isinstance(
                 err.__cause__, ManagedMotionReplacedError
             ):
-                run_outcome = "stopped"
+                run_outcome = "cancelled"
                 run_reason_code = "managed_replaced"
                 run_cause = "replacement"
             else:
-                run_outcome = "stopped"
+                run_outcome = "cancelled"
                 run_reason_code = "managed_stop"
                 run_cause = "managed_cancellation"
             return
@@ -3431,7 +3560,7 @@ async def _async_execute_rooms(
                 getattr(err, "__cause__", None), RoomStoppedInPlaceError
             )
             if stopped_in_place:
-                run_outcome = "partial"
+                run_outcome = "unverified"
                 run_reason_code = "stopped_in_place"
                 run_cause = "unknown"
                 return
@@ -3441,7 +3570,7 @@ async def _async_execute_rooms(
                 else err
             )
             if isinstance(leaf_error, RoomInterruptedError | RoomTakenOverError):
-                run_outcome = "interrupted"
+                run_outcome = "unverified"
                 run_reason_code = (
                     "native_task_taken_over"
                     if isinstance(leaf_error, RoomTakenOverError)
@@ -3526,6 +3655,7 @@ async def _async_execute_rooms(
                         if current_state is not None
                         else "unknown"
                     )
+                    room_outcomes: list[dict[str, str]] = []
                     try:
                         finish_run = getattr(manager, "async_finish_run", None)
                         if callable(finish_run):
@@ -3540,7 +3670,19 @@ async def _async_execute_rooms(
                                 entity_id=entity_id,
                                 context=call.context,
                             )
+                        room_outcomes = _room_outcomes(
+                            manager,
+                            serial_number,
+                            call.data["plan_id"],
+                            run_id,
+                            chosen,
+                            completed_room_names,
+                        )
                     finally:
+                        # Room terminal events are queued by the HA bus. Yield
+                        # once so the plan terminal event is observed after the
+                        # room boundary it summarizes.
+                        await asyncio.sleep(0)
                         bus = getattr(hass, "bus", None)
                         fire = getattr(bus, "async_fire", None)
                         if callable(fire):
@@ -3550,7 +3692,8 @@ async def _async_execute_rooms(
                                     ATTR_ENTITY_ID: entity_id,
                                     "plan_id": call.data["plan_id"],
                                     "run_id": run_id,
-                                    "trigger": "service_call",
+                                    "trigger": run_provenance,
+                                    "provenance": run_provenance,
                                     "service": str(call.service),
                                     "started_at": run_started_at,
                                     "ended_at": finished_at,
@@ -3560,6 +3703,7 @@ async def _async_execute_rooms(
                                     "terminal_activity": terminal_activity,
                                     "room_count": len(chosen),
                                     "completed_room_count": len(completed_room_names),
+                                    "room_outcomes": room_outcomes,
                                 },
                                 context=call.context,
                             )

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -3292,6 +3292,26 @@ async def _async_mark_run_docked(
     """Bridge the stop watcher to durable run closure for service calls."""
     if run_id is None:
         return
+    snapshot_reader = getattr(manager, "snapshot", None)
+    if callable(snapshot_reader):
+        snapshot = snapshot_reader(serial_number)
+        last_run = snapshot.get("last_run") if isinstance(snapshot, dict) else None
+        if isinstance(last_run, dict) and (
+            last_run.get("run_id") == run_id and last_run.get("outcome") == "running"
+        ):
+            cancellation_reader = getattr(manager, "cancellation_reason", None)
+            cancellation_reason = (
+                cancellation_reader(serial_number)
+                if callable(cancellation_reader)
+                else None
+            )
+            finish_event_reader = getattr(manager, "finish_room_event", None)
+            finish_requested = (
+                callable(finish_event_reader)
+                and finish_event_reader(serial_number).is_set()
+            )
+            if cancellation_reason != "managed_stop" and not finish_requested:
+                return
     await manager.async_mark_run_docked(
         serial_number,
         run_id,
@@ -3834,7 +3854,7 @@ async def _async_execute_rooms(
                 manager.end_managed_motion(serial_number, motion_token)
                 manager.unregister_run_task(serial_number)
                 reconciliation_active_reader = getattr(
-                    manager, "reconciliation_tasks_active", None
+                    manager, "dock_reconciliation_active", None
                 )
                 stop_watcher_active = callable(reconciliation_active_reader) and bool(
                     reconciliation_active_reader(serial_number)

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -1407,6 +1407,7 @@ async def _async_run_room(
             )
         raise
     except RoomTakenOverError as err:
+        err.suspend_reason = _suspended_run_reason(manager, serial_number)
         await manager.async_mark_interrupted(
             serial_number, call.data["plan_id"], room, str(err)
         )
@@ -1951,6 +1952,7 @@ async def _async_run_leg(
             str(err), "room_interrupted", {"room": active_room.name}
         ) from err
     except RoomTakenOverError as err:
+        err.suspend_reason = _suspended_run_reason(manager, serial_number)
         await manager.async_mark_interrupted(
             serial_number, call.data["plan_id"], active_room, str(err)
         )
@@ -3245,6 +3247,10 @@ def _suspended_run_reason(
 class RoomTakenOverError(HomeAssistantError):
     """The native task ended, changed, or could no longer be identified."""
 
+    def __init__(self, *args: object, suspend_reason: str | None = None) -> None:
+        super().__init__(*args)
+        self.suspend_reason = suspend_reason
+
 
 def _run_provenance(call: ServiceCall) -> str:
     """Return bounded trigger provenance without retaining account identity."""
@@ -3598,6 +3604,11 @@ async def _async_execute_rooms(
                 if isinstance(err, ServiceValidationError) and err.__cause__ is not None
                 else err
             )
+            if getattr(leaf_error, "suspend_reason", None) == "low_charge":
+                run_outcome = "recharge_suspended"
+                run_reason_code = "low_charge"
+                run_cause = "robot"
+                raise
             if isinstance(leaf_error, RoomInterruptedError | RoomTakenOverError):
                 run_outcome = "unverified"
                 run_reason_code = (
@@ -3685,6 +3696,11 @@ async def _async_execute_rooms(
                         else "unknown"
                     )
                     room_outcomes: list[dict[str, str]] = []
+                    event_outcome = run_outcome
+                    event_reason_code = run_reason_code
+                    event_cause = run_cause
+                    event_terminal_activity = terminal_activity
+                    event_completed_room_count = len(completed_room_names)
                     try:
                         finish_run = getattr(manager, "async_finish_run", None)
                         if callable(finish_run):
@@ -3699,6 +3715,35 @@ async def _async_execute_rooms(
                                 entity_id=entity_id,
                                 context=call.context,
                             )
+                        snapshot_reader = getattr(manager, "snapshot", None)
+                        final_snapshot = (
+                            snapshot_reader(serial_number)
+                            if callable(snapshot_reader)
+                            else None
+                        )
+                        final_last_run = (
+                            final_snapshot.get("last_run")
+                            if isinstance(final_snapshot, dict)
+                            else None
+                        )
+                        if isinstance(final_last_run, dict) and (
+                            final_last_run.get("run_id") == run_id
+                        ):
+                            event_outcome = str(
+                                final_last_run.get("outcome", event_outcome)
+                            )
+                            event_reason_code = str(
+                                final_last_run.get("reason_code", event_reason_code)
+                            )
+                            event_cause = str(final_last_run.get("cause", event_cause))
+                            event_terminal_activity = str(
+                                final_last_run.get(
+                                    "terminal_activity", event_terminal_activity
+                                )
+                            )
+                            completed = final_last_run.get("completed_room_count")
+                            if isinstance(completed, int):
+                                event_completed_room_count = completed
                         room_outcomes = _room_outcomes(
                             manager,
                             serial_number,
@@ -3726,12 +3771,12 @@ async def _async_execute_rooms(
                                     "service": str(call.service),
                                     "started_at": run_started_at,
                                     "ended_at": finished_at,
-                                    "outcome": run_outcome,
-                                    "reason_code": run_reason_code,
-                                    "cause": run_cause,
-                                    "terminal_activity": terminal_activity,
+                                    "outcome": event_outcome,
+                                    "reason_code": event_reason_code,
+                                    "cause": event_cause,
+                                    "terminal_activity": event_terminal_activity,
                                     "room_count": len(chosen),
-                                    "completed_room_count": len(completed_room_names),
+                                    "completed_room_count": event_completed_room_count,
                                     "room_outcomes": room_outcomes,
                                 },
                                 context=call.context,

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -1355,7 +1355,8 @@ async def _async_run_room(
             context=call.context,
         )
         raise PlanCancelledError from err
-    except PlanCancelledError:
+    except PlanCancelledError as err:
+        err.suspend_reason = _suspended_run_reason(manager, serial_number)
         if manager.cancellation_reason(serial_number) == "config_entry_unload":
             await _async_cleanup_managed_motion(
                 managed_user_command,
@@ -1885,7 +1886,8 @@ async def _async_run_leg(
             context=call.context,
         )
         raise PlanCancelledError from err
-    except PlanCancelledError:
+    except PlanCancelledError as err:
+        err.suspend_reason = _suspended_run_reason(manager, serial_number)
         if manager.cancellation_reason(serial_number) == "config_entry_unload":
             await _async_cleanup_managed_motion(
                 managed_user_command,
@@ -3178,6 +3180,10 @@ async def _async_wait_for_vacuum_state(
 class PlanCancelledError(HomeAssistantError):
     """An operator cancelled a managed cleaning plan."""
 
+    def __init__(self, *args: object, suspend_reason: str | None = None) -> None:
+        super().__init__(*args)
+        self.suspend_reason = suspend_reason
+
 
 class RoomStartTimeoutError(TimeoutError):
     """The commanded room did not become active before its start deadline."""
@@ -3218,6 +3224,22 @@ def _interruption_reason_code(error: RoomInterruptedError) -> str:
     if isinstance(error, RoomStoppedInPlaceError):
         return "stopped_in_place"
     return "interrupted"
+
+
+def _suspended_run_reason(
+    manager: CleaningPlanManager, serial_number: str
+) -> str | None:
+    """Capture a low-charge suspension before room cleanup clears its marker."""
+    snapshot = getattr(manager, "snapshot", None)
+    if not callable(snapshot):
+        return None
+    active = snapshot(serial_number).get("active_plan")
+    if isinstance(active, dict) and (
+        active.get("status") == "suspended"
+        and active.get("suspend_reason") == "low_charge"
+    ):
+        return "low_charge"
+    return None
 
 
 class RoomTakenOverError(HomeAssistantError):
@@ -3526,8 +3548,11 @@ async def _async_execute_rooms(
                 if callable(snapshot_reader)
                 else None
             )
-            recharge_suspended = isinstance(active_snapshot, dict) and (
-                active_snapshot.get("status") == "suspended"
+            recharge_suspended = getattr(
+                err, "suspend_reason", None
+            ) == "low_charge" or (
+                isinstance(active_snapshot, dict)
+                and active_snapshot.get("status") == "suspended"
                 and active_snapshot.get("suspend_reason") == "low_charge"
             )
             if cancellation_reason == "config_entry_unload":

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -3833,7 +3833,17 @@ async def _async_execute_rooms(
             finally:
                 manager.end_managed_motion(serial_number, motion_token)
                 manager.unregister_run_task(serial_number)
-                if set_activity_run_id is not None and not dock_confirmation_scheduled:
+                reconciliation_active_reader = getattr(
+                    manager, "reconciliation_tasks_active", None
+                )
+                stop_watcher_active = callable(reconciliation_active_reader) and bool(
+                    reconciliation_active_reader(serial_number)
+                )
+                if (
+                    set_activity_run_id is not None
+                    and not dock_confirmation_scheduled
+                    and not stop_watcher_active
+                ):
                     set_activity_run_id(None)
 
 

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -3375,7 +3375,8 @@ def _room_outcomes(
                     "completed"
                     if room.room_id in completed_room_ids
                     or (
-                        record.get("run_id") == run_id
+                        isinstance(record, dict)
+                        and record.get("run_id") == run_id
                         and record.get("last_result") == "completed"
                     )
                     else "partial"

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -80,7 +80,7 @@ from .plans import (
     resolve_room_reference,
     resolve_rooms,
 )
-from .stop_return import schedule_dock_after_stop
+from .stop_return import schedule_dock_after_stop, schedule_dock_confirmation
 
 SERVICE_CLEAN = "clean"
 SERVICE_CLEAN_ROOM_SEQUENCE = "clean_room_sequence"
@@ -3534,6 +3534,25 @@ async def _async_execute_rooms(
             ):
                 try:
                     await outer_command(motion_token, UserCommand.DOCK)
+                    if finish_room_event.is_set() and completed_room_count < len(
+                        chosen
+                    ):
+                        schedule_dock_confirmation(
+                            hass,
+                            refresh=refresh or (lambda: asyncio.sleep(0)),
+                            manager=manager,
+                            serial_number=serial_number,
+                            entity_id=entity_id,
+                            run_id=run_id,
+                            on_docked=partial(
+                                _async_mark_run_docked,
+                                manager,
+                                serial_number,
+                                run_id,
+                                entity_id,
+                                call.context,
+                            ),
+                        )
                 except ManagedMotionReplacedError as err:
                     raise PlanCancelledError from err
                 except MaticError as err:

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -1169,6 +1169,7 @@ async def _async_run_room(
     session_identity: Callable[[], Awaitable[bytes | None]] | None = None,
     on_native_identity: Callable[[bytes | None], None] | None = None,
     run_id: str | None = None,
+    record_room_completed: Callable[[CleaningRoom], None] | None = None,
 ) -> bool:
     """Run one room and report whether native history verified completion."""
     if not room_name_is_unique:
@@ -1590,6 +1591,8 @@ async def _async_run_room(
 
     if completion_verified:
         await manager.async_mark_completed(serial_number, call.data["plan_id"], room)
+        if record_room_completed is not None:
+            record_room_completed(room)
         if confirm_room_completed is not None:
             confirm_room_completed(room.name)
         hass.bus.async_fire(
@@ -1639,6 +1642,7 @@ async def _async_run_leg(
     session_identity: Callable[[], Awaitable[bytes | None]] | None = None,
     on_native_identity: Callable[[bytes | None], None] | None = None,
     run_id: str | None = None,
+    record_room_completed: Callable[[CleaningRoom], None] | None = None,
 ) -> bool:
     """Run one mission leg and credit only natively verified rooms.
 
@@ -1672,6 +1676,7 @@ async def _async_run_leg(
             session_identity=session_identity,
             on_native_identity=on_native_identity,
             run_id=run_id,
+            record_room_completed=record_room_completed,
         )
     if not room_name_is_unique:
         raise _validation_error(
@@ -2066,6 +2071,8 @@ async def _async_run_leg(
             )
             if confirm_room_completed is not None:
                 confirm_room_completed(room.name)
+            if record_room_completed is not None:
+                record_room_completed(room)
             hass.bus.async_fire(
                 f"{DOMAIN}_room_completed",
                 {**event_data(room), "reason_code": "verified_completion"},
@@ -3338,7 +3345,7 @@ def _room_outcomes(
     plan_id: str,
     run_id: str,
     chosen: Sequence[CleaningRoom],
-    completed_names: set[str],
+    completed_room_ids: set[str],
 ) -> list[dict[str, str]]:
     """Return the bounded room outcome vocabulary for one terminal run."""
     history = manager.snapshot(serial_number).get("plan_history", {})
@@ -3366,7 +3373,11 @@ def _room_outcomes(
                 "room": room.name,
                 "outcome": (
                     "completed"
-                    if room.name in completed_names
+                    if room.room_id in completed_room_ids
+                    or (
+                        record.get("run_id") == run_id
+                        and record.get("last_result") == "completed"
+                    )
                     else "partial"
                     if attempted
                     else "unattempted"
@@ -3418,7 +3429,7 @@ async def _async_execute_rooms(
         run_reason_code = "run_not_finished"
         run_cause = "unknown"
         run_provenance = _run_provenance(call)
-        completed_room_names: set[str] = set()
+        completed_room_ids: set[str] = set()
         chosen: list[CleaningRoom] = []
 
         def bind_native_identity(identity: bytes | None) -> None:
@@ -3436,10 +3447,8 @@ async def _async_execute_rooms(
         if set_activity_run_id is not None:
             set_activity_run_id(run_id)
 
-        def record_room_completion(room_name: str) -> None:
-            completed_room_names.add(room_name)
-            if confirm_room_completed is not None:
-                confirm_room_completed(room_name)
+        def record_room_completion(room: CleaningRoom) -> None:
+            completed_room_ids.add(room.room_id)
 
         try:
             # Publish ownership before the first suspending check. Otherwise
@@ -3524,7 +3533,7 @@ async def _async_execute_rooms(
                     motion_token,
                     active_session,
                     session_history,
-                    record_room_completion,
+                    confirm_room_completed,
                     managed_user_command,
                     room_name_is_unique=(
                         not mapped_room_names
@@ -3545,6 +3554,7 @@ async def _async_execute_rooms(
                     session_identity=session_identity,
                     on_native_identity=bind_native_identity,
                     run_id=run_id,
+                    record_room_completed=record_room_completion,
                 )
                 if not completion_verified:
                     break
@@ -3561,7 +3571,7 @@ async def _async_execute_rooms(
                         )
                         cleanup_stop_sent = _stop_is_pending(manager, serial_number)
                     break
-            completed_room_count = len(completed_room_names)
+            completed_room_count = len(completed_room_ids)
             if finish_room_event.is_set() and completed_room_count < len(chosen):
                 run_outcome = "cancelled"
                 run_reason_code = "managed_stop"
@@ -3781,7 +3791,7 @@ async def _async_execute_rooms(
                     event_reason_code = run_reason_code
                     event_cause = run_cause
                     event_terminal_activity = terminal_activity
-                    event_completed_room_count = len(completed_room_names)
+                    event_completed_room_count = len(completed_room_ids)
                     try:
                         finish_run = getattr(manager, "async_finish_run", None)
                         if callable(finish_run):
@@ -3790,7 +3800,7 @@ async def _async_execute_rooms(
                                 run_id,
                                 run_outcome,
                                 run_reason_code,
-                                len(completed_room_names),
+                                len(completed_room_ids),
                                 terminal_activity=terminal_activity,
                                 cause=run_cause,
                                 entity_id=entity_id,
@@ -3831,7 +3841,7 @@ async def _async_execute_rooms(
                             call.data["plan_id"],
                             run_id,
                             chosen,
-                            completed_room_names,
+                            completed_room_ids,
                         )
                     finally:
                         # Room terminal events are queued by the HA bus. Yield

--- a/custom_components/matic_robot/services.py
+++ b/custom_components/matic_robot/services.py
@@ -3324,12 +3324,7 @@ async def _async_mark_run_docked(
                 if callable(cancellation_reader)
                 else None
             )
-            finish_event_reader = getattr(manager, "finish_room_event", None)
-            finish_requested = (
-                callable(finish_event_reader)
-                and finish_event_reader(serial_number).is_set()
-            )
-            if cancellation_reason != "managed_stop" and not finish_requested:
+            if cancellation_reason != "managed_stop":
                 return
     await manager.async_mark_run_docked(
         serial_number,
@@ -3577,6 +3572,9 @@ async def _async_execute_rooms(
                 run_outcome = "cancelled"
                 run_reason_code = "managed_stop"
                 run_cause = "managed_cancellation"
+                mark_managed_stop = getattr(manager, "mark_managed_stop", None)
+                if callable(mark_managed_stop):
+                    mark_managed_stop(serial_number)
             elif completed_room_count == len(chosen):
                 run_outcome = "completed"
                 run_reason_code = "all_rooms_verified"
@@ -3717,6 +3715,12 @@ async def _async_execute_rooms(
                 if isinstance(err, HomeAssistantError | MaticError | TimeoutError)
                 else "internal"
             )
+            finish_event_reader = getattr(manager, "finish_room_event", None)
+            if callable(finish_event_reader):
+                # A graceful stop request can race an unexpected exception.
+                # Retire that intent before failure cleanup so a dock watcher
+                # cannot authorize an in-flight failure upgrade.
+                finish_event_reader(serial_number).clear()
             # Leaf handlers retire expected failures. Unexpected failures must
             # also leave a terminal record before ownership is released.
             active = manager.snapshot(serial_number)["active_plan"]

--- a/custom_components/matic_robot/stop_return.py
+++ b/custom_components/matic_robot/stop_return.py
@@ -171,15 +171,36 @@ async def async_dock_when_stop_settles(
                                 confirm_deadline = (
                                     monotonic() + DOCK_CONFIRM_TIMEOUT_SECONDS
                                 )
+                                replacement_deadline: float | None = None
                                 while True:
+                                    if not manager.stop_pending(serial_number):
+                                        break
                                     confirmed = hass.states.get(entity_id)
+                                    now = monotonic()
                                     if (
                                         confirmed is not None
                                         and confirmed.state in DOCKED_STATES
                                     ):
                                         await on_docked()
                                         break
-                                    if monotonic() >= confirm_deadline:
+                                    if (
+                                        confirmed is not None
+                                        and confirmed.state in REPLACEMENT_STATES
+                                    ):
+                                        if replacement_deadline is None:
+                                            replacement_deadline = (
+                                                now
+                                                + DOCK_SETTLE_TRANSITION_GRACE_SECONDS
+                                            )
+                                        elif now >= replacement_deadline:
+                                            _LOGGER.debug(
+                                                "Matic DOCK confirmation abandoned "
+                                                "after replacement motion"
+                                            )
+                                            break
+                                    else:
+                                        replacement_deadline = None
+                                    if now >= confirm_deadline:
                                         _LOGGER.debug(
                                             "Matic DOCK accepted but docked state was "
                                             "not observed"

--- a/custom_components/matic_robot/stop_return.py
+++ b/custom_components/matic_robot/stop_return.py
@@ -84,6 +84,7 @@ async def async_dock_when_stop_settles(
     entity_id: str,
     run_id: str | None = None,
     set_run_id: Callable[[str | None], None] | None = None,
+    get_run_id: Callable[[], str | None] | None = None,
     on_docked: Callable[[], Awaitable[None]] | None = None,
 ) -> bool:
     """Dock once the stopped task ends and report whether DOCK was sent."""
@@ -93,6 +94,12 @@ async def async_dock_when_stop_settles(
         deadline, started + DOCK_SETTLE_TRANSITION_GRACE_SECONDS
     )
     settled_state_observed = False
+
+    def clear_run_scope() -> None:
+        """Release this watcher without clearing a newer managed run."""
+        if set_run_id is not None and (get_run_id is None or get_run_id() == run_id):
+            set_run_id(None)
+
     while True:
         if not manager.stop_pending(serial_number):
             return False
@@ -136,7 +143,7 @@ async def async_dock_when_stop_settles(
                         if latest_state is None or latest_state.state != SETTLED_STATE:
                             return False
                         try:
-                            if set_run_id is not None:
+                            if set_run_id is not None and run_id is not None:
                                 set_run_id(run_id)
                             await client.async_send_user_command(UserCommand.DOCK)
                         except MaticError as err:
@@ -144,31 +151,32 @@ async def async_dock_when_stop_settles(
                                 "Unable to dock Matic after its stop settled (%s)",
                                 type(err).__name__,
                             )
+                            clear_run_scope()
                             return False
+                        try:
+                            await refresh()
+                            if on_docked is not None:
+                                confirm_deadline = (
+                                    monotonic() + DOCK_CONFIRM_TIMEOUT_SECONDS
+                                )
+                                while True:
+                                    confirmed = hass.states.get(entity_id)
+                                    if (
+                                        confirmed is not None
+                                        and confirmed.state in DOCKED_STATES
+                                    ):
+                                        await on_docked()
+                                        break
+                                    if monotonic() >= confirm_deadline:
+                                        _LOGGER.debug(
+                                            "Matic DOCK accepted but docked state was "
+                                            "not observed"
+                                        )
+                                        break
+                                    await asyncio.sleep(DOCK_SETTLE_POLL_SECONDS)
+                                    await refresh()
                         finally:
-                            if set_run_id is not None:
-                                set_run_id(None)
-                        await refresh()
-                        if on_docked is not None:
-                            confirm_deadline = (
-                                monotonic() + DOCK_CONFIRM_TIMEOUT_SECONDS
-                            )
-                            while True:
-                                confirmed = hass.states.get(entity_id)
-                                if (
-                                    confirmed is not None
-                                    and confirmed.state in DOCKED_STATES
-                                ):
-                                    await on_docked()
-                                    break
-                                if monotonic() >= confirm_deadline:
-                                    _LOGGER.debug(
-                                        "Matic DOCK accepted but docked state was "
-                                        "not observed"
-                                    )
-                                    break
-                                await asyncio.sleep(DOCK_SETTLE_POLL_SECONDS)
-                                await refresh()
+                            clear_run_scope()
                         return True
         if now >= deadline:
             return False
@@ -187,6 +195,7 @@ def schedule_dock_after_stop(
     entity_id: str,
     run_id: str | None = None,
     set_run_id: Callable[[str | None], None] | None = None,
+    get_run_id: Callable[[], str | None] | None = None,
     on_docked: Callable[[], Awaitable[None]] | None = None,
 ) -> None:
     """Start a lifecycle-bound watcher that docks a settled stop."""
@@ -203,6 +212,7 @@ def schedule_dock_after_stop(
             entity_id=entity_id,
             run_id=run_id,
             set_run_id=set_run_id,
+            get_run_id=get_run_id,
             on_docked=on_docked,
         ),
         f"{DOMAIN} dock after stop",

--- a/custom_components/matic_robot/stop_return.py
+++ b/custom_components/matic_robot/stop_return.py
@@ -31,7 +31,7 @@ from .plans import OEM_STOP_FENCE_SECONDS, CleaningPlanManager
 
 DOCK_SETTLE_POLL_SECONDS = 3
 DOCK_SETTLE_TIMEOUT_SECONDS = OEM_STOP_FENCE_SECONDS
-DOCK_CONFIRM_TIMEOUT_SECONDS = 60
+DOCK_CONFIRM_TIMEOUT_SECONDS = OEM_STOP_FENCE_SECONDS
 # Coordinator state can still show the pre-STOP task for one refresh. Keep
 # that stale edge from abandoning the settlement watcher, but stop waiting if
 # cleaning or pause persists long enough to be replacement work.
@@ -150,9 +150,8 @@ async def async_dock_when_stop_settles(
                                 set_run_id(None)
                         await refresh()
                         if on_docked is not None:
-                            confirm_deadline = min(
-                                deadline,
-                                monotonic() + DOCK_CONFIRM_TIMEOUT_SECONDS,
+                            confirm_deadline = (
+                                monotonic() + DOCK_CONFIRM_TIMEOUT_SECONDS
                             )
                             while True:
                                 confirmed = hass.states.get(entity_id)

--- a/custom_components/matic_robot/stop_return.py
+++ b/custom_components/matic_robot/stop_return.py
@@ -190,7 +190,7 @@ async def async_dock_when_stop_settles(
                                         if replacement_deadline is None:
                                             replacement_deadline = (
                                                 now
-                                                + DOCK_SETTLE_TRANSITION_GRACE_SECONDS
+                                                + DOCK_CONFIRM_TRANSITION_GRACE_SECONDS
                                             )
                                         elif now >= replacement_deadline:
                                             _LOGGER.debug(

--- a/custom_components/matic_robot/stop_return.py
+++ b/custom_components/matic_robot/stop_return.py
@@ -36,6 +36,7 @@ DOCK_CONFIRM_TIMEOUT_SECONDS = OEM_STOP_FENCE_SECONDS
 # that stale edge from abandoning the settlement watcher, but stop waiting if
 # cleaning or pause persists long enough to be replacement work.
 DOCK_SETTLE_TRANSITION_GRACE_SECONDS = 60
+DOCK_CONFIRM_TRANSITION_GRACE_SECONDS = DOCK_SETTLE_TRANSITION_GRACE_SECONDS
 
 SETTLED_STATE = "idle"
 HOMEWARD_STATES = frozenset({"docked", "returning"})
@@ -228,21 +229,52 @@ async def async_confirm_docked(
     refresh: Callable[[], Awaitable[None]],
     entity_id: str,
     on_docked: Callable[[], Awaitable[None]],
+    run_id: str | None = None,
+    set_run_id: Callable[[str | None], None] | None = None,
+    get_run_id: Callable[[], str | None] | None = None,
 ) -> bool:
     """Wait for a DOCK command to produce an observed docked state."""
     deadline = monotonic() + DOCK_CONFIRM_TIMEOUT_SECONDS
-    while True:
-        state = hass.states.get(entity_id)
-        if state is not None and state.state in REPLACEMENT_STATES:
-            _LOGGER.debug("Matic DOCK confirmation abandoned after replacement motion")
+    run_scope_claimed = False
+    if set_run_id is not None and run_id is not None:
+        current_run_id = get_run_id() if get_run_id is not None else None
+        if get_run_id is not None and current_run_id not in {None, run_id}:
             return False
-        if state is not None and state.state in DOCKED_STATES:
-            await on_docked()
-            return True
-        if monotonic() >= deadline:
-            return False
-        await asyncio.sleep(DOCK_SETTLE_POLL_SECONDS)
+        set_run_id(run_id)
+        run_scope_claimed = True
+    replacement_deadline: float | None = None
+    try:
+        # The command sender has usually refreshed once, but that read can be
+        # the pre-command cleaning state. Refresh before interpreting the
+        # first confirmation state, then allow a bounded transition edge.
         await refresh()
+        while True:
+            state = hass.states.get(entity_id)
+            now = monotonic()
+            if state is not None and state.state in DOCKED_STATES:
+                await on_docked()
+                return True
+            if state is not None and state.state in REPLACEMENT_STATES:
+                if replacement_deadline is None:
+                    replacement_deadline = now + DOCK_CONFIRM_TRANSITION_GRACE_SECONDS
+                if now >= replacement_deadline:
+                    _LOGGER.debug(
+                        "Matic DOCK confirmation abandoned after replacement motion"
+                    )
+                    return False
+            else:
+                replacement_deadline = None
+            if now >= deadline:
+                return False
+            await asyncio.sleep(DOCK_SETTLE_POLL_SECONDS)
+            await refresh()
+    finally:
+        if (
+            run_scope_claimed
+            and set_run_id is not None
+            and (get_run_id is None or get_run_id() == run_id)
+        ):
+            set_run_id(None)
 
 
 def schedule_dock_confirmation(
@@ -254,20 +286,26 @@ def schedule_dock_confirmation(
     entity_id: str,
     run_id: str,
     on_docked: Callable[[], Awaitable[None]],
-) -> None:
+    set_run_id: Callable[[str | None], None] | None = None,
+    get_run_id: Callable[[], str | None] | None = None,
+) -> bool:
     """Start a lifecycle-bound watcher for an already-sent DOCK command."""
     create_background_task = getattr(hass, "async_create_background_task", None)
     if not callable(create_background_task):
-        return
+        return False
     task = create_background_task(
         async_confirm_docked(
             hass,
             refresh=refresh,
             entity_id=entity_id,
             on_docked=on_docked,
+            run_id=run_id,
+            set_run_id=set_run_id,
+            get_run_id=get_run_id,
         ),
         f"{DOMAIN} confirm managed dock {run_id}",
     )
     register_task = getattr(manager, "register_reconciliation_task", None)
     if isinstance(task, asyncio.Task) and callable(register_task):
         register_task(serial_number, task)
+    return isinstance(task, asyncio.Task)

--- a/custom_components/matic_robot/stop_return.py
+++ b/custom_components/matic_robot/stop_return.py
@@ -233,6 +233,9 @@ async def async_confirm_docked(
     deadline = monotonic() + DOCK_CONFIRM_TIMEOUT_SECONDS
     while True:
         state = hass.states.get(entity_id)
+        if state is not None and state.state in REPLACEMENT_STATES:
+            _LOGGER.debug("Matic DOCK confirmation abandoned after replacement motion")
+            return False
         if state is not None and state.state in DOCKED_STATES:
             await on_docked()
             return True

--- a/custom_components/matic_robot/stop_return.py
+++ b/custom_components/matic_robot/stop_return.py
@@ -80,6 +80,9 @@ async def async_dock_when_stop_settles(
     manager: CleaningPlanManager,
     serial_number: str,
     entity_id: str,
+    run_id: str | None = None,
+    set_run_id: Callable[[str | None], None] | None = None,
+    on_docked: Callable[[], Awaitable[None]] | None = None,
 ) -> bool:
     """Dock once the stopped task ends and report whether DOCK was sent."""
     started = monotonic()
@@ -131,6 +134,8 @@ async def async_dock_when_stop_settles(
                         if latest_state is None or latest_state.state != SETTLED_STATE:
                             return False
                         try:
+                            if set_run_id is not None:
+                                set_run_id(run_id)
                             await client.async_send_user_command(UserCommand.DOCK)
                         except MaticError as err:
                             _LOGGER.warning(
@@ -138,7 +143,12 @@ async def async_dock_when_stop_settles(
                                 type(err).__name__,
                             )
                             return False
+                        finally:
+                            if set_run_id is not None:
+                                set_run_id(None)
                         await refresh()
+                        if on_docked is not None:
+                            await on_docked()
                         return True
         if now >= deadline:
             return False
@@ -155,6 +165,9 @@ def schedule_dock_after_stop(
     manager: CleaningPlanManager,
     serial_number: str,
     entity_id: str,
+    run_id: str | None = None,
+    set_run_id: Callable[[str | None], None] | None = None,
+    on_docked: Callable[[], Awaitable[None]] | None = None,
 ) -> None:
     """Start a lifecycle-bound watcher that docks a settled stop."""
     create_background_task = getattr(hass, "async_create_background_task", None)
@@ -168,6 +181,9 @@ def schedule_dock_after_stop(
             manager=manager,
             serial_number=serial_number,
             entity_id=entity_id,
+            run_id=run_id,
+            set_run_id=set_run_id,
+            on_docked=on_docked,
         ),
         f"{DOMAIN} dock after stop",
     )

--- a/custom_components/matic_robot/stop_return.py
+++ b/custom_components/matic_robot/stop_return.py
@@ -210,3 +210,51 @@ def schedule_dock_after_stop(
     register_task = getattr(manager, "register_reconciliation_task", None)
     if isinstance(task, asyncio.Task) and callable(register_task):
         register_task(serial_number, task)
+
+
+async def async_confirm_docked(
+    hass: HomeAssistant,
+    *,
+    refresh: Callable[[], Awaitable[None]],
+    entity_id: str,
+    on_docked: Callable[[], Awaitable[None]],
+) -> bool:
+    """Wait for a DOCK command to produce an observed docked state."""
+    deadline = monotonic() + DOCK_CONFIRM_TIMEOUT_SECONDS
+    while True:
+        state = hass.states.get(entity_id)
+        if state is not None and state.state in DOCKED_STATES:
+            await on_docked()
+            return True
+        if monotonic() >= deadline:
+            return False
+        await asyncio.sleep(DOCK_SETTLE_POLL_SECONDS)
+        await refresh()
+
+
+def schedule_dock_confirmation(
+    hass: HomeAssistant,
+    *,
+    refresh: Callable[[], Awaitable[None]],
+    manager: CleaningPlanManager,
+    serial_number: str,
+    entity_id: str,
+    run_id: str,
+    on_docked: Callable[[], Awaitable[None]],
+) -> None:
+    """Start a lifecycle-bound watcher for an already-sent DOCK command."""
+    create_background_task = getattr(hass, "async_create_background_task", None)
+    if not callable(create_background_task):
+        return
+    task = create_background_task(
+        async_confirm_docked(
+            hass,
+            refresh=refresh,
+            entity_id=entity_id,
+            on_docked=on_docked,
+        ),
+        f"{DOMAIN} confirm managed dock {run_id}",
+    )
+    register_task = getattr(manager, "register_reconciliation_task", None)
+    if isinstance(task, asyncio.Task) and callable(register_task):
+        register_task(serial_number, task)

--- a/custom_components/matic_robot/stop_return.py
+++ b/custom_components/matic_robot/stop_return.py
@@ -39,7 +39,7 @@ DOCK_SETTLE_TRANSITION_GRACE_SECONDS = 60
 DOCK_CONFIRM_TRANSITION_GRACE_SECONDS = DOCK_SETTLE_TRANSITION_GRACE_SECONDS
 
 SETTLED_STATE = "idle"
-HOMEWARD_STATES = frozenset({"docked", "returning"})
+HOMEWARD_STATES = frozenset({"docked", "returning", "charging"})
 DOCKED_STATES = frozenset({"docked", "charging"})
 REPLACEMENT_STATES = frozenset({"cleaning", "paused"})
 

--- a/custom_components/matic_robot/stop_return.py
+++ b/custom_components/matic_robot/stop_return.py
@@ -173,8 +173,6 @@ async def async_dock_when_stop_settles(
                                 )
                                 replacement_deadline: float | None = None
                                 while True:
-                                    if not manager.stop_pending(serial_number):
-                                        break
                                     confirmed = hass.states.get(entity_id)
                                     now = monotonic()
                                     if (

--- a/custom_components/matic_robot/stop_return.py
+++ b/custom_components/matic_robot/stop_return.py
@@ -109,6 +109,16 @@ async def async_dock_when_stop_settles(
         state = hass.states.get(entity_id)
         if state is not None:
             if state.state in HOMEWARD_STATES:
+                if on_docked is not None:
+                    return await async_confirm_docked(
+                        hass,
+                        refresh=refresh,
+                        entity_id=entity_id,
+                        on_docked=on_docked,
+                        run_id=run_id,
+                        set_run_id=set_run_id,
+                        get_run_id=get_run_id,
+                    )
                 return False
             if state.state in REPLACEMENT_STATES:
                 # The first state read commonly still reflects the task that

--- a/custom_components/matic_robot/stop_return.py
+++ b/custom_components/matic_robot/stop_return.py
@@ -95,6 +95,7 @@ async def async_dock_when_stop_settles(
         deadline, started + DOCK_SETTLE_TRANSITION_GRACE_SECONDS
     )
     settled_state_observed = False
+    run_scope_claimed = False
 
     def clear_run_scope() -> None:
         """Release this watcher without clearing a newer managed run."""
@@ -153,18 +154,18 @@ async def async_dock_when_stop_settles(
                         latest_state = hass.states.get(entity_id)
                         if latest_state is None or latest_state.state != SETTLED_STATE:
                             return False
+                        if set_run_id is not None and run_id is not None:
+                            set_run_id(run_id)
+                            run_scope_claimed = True
                         try:
-                            if set_run_id is not None and run_id is not None:
-                                set_run_id(run_id)
-                            await client.async_send_user_command(UserCommand.DOCK)
-                        except MaticError as err:
-                            _LOGGER.warning(
-                                "Unable to dock Matic after its stop settled (%s)",
-                                type(err).__name__,
-                            )
-                            clear_run_scope()
-                            return False
-                        try:
+                            try:
+                                await client.async_send_user_command(UserCommand.DOCK)
+                            except MaticError as err:
+                                _LOGGER.warning(
+                                    "Unable to dock Matic after its stop settled (%s)",
+                                    type(err).__name__,
+                                )
+                                return False
                             await refresh()
                             if on_docked is not None:
                                 confirm_deadline = (
@@ -187,7 +188,8 @@ async def async_dock_when_stop_settles(
                                     await asyncio.sleep(DOCK_SETTLE_POLL_SECONDS)
                                     await refresh()
                         finally:
-                            clear_run_scope()
+                            if run_scope_claimed:
+                                clear_run_scope()
                         return True
         if now >= deadline:
             return False

--- a/custom_components/matic_robot/stop_return.py
+++ b/custom_components/matic_robot/stop_return.py
@@ -31,6 +31,7 @@ from .plans import OEM_STOP_FENCE_SECONDS, CleaningPlanManager
 
 DOCK_SETTLE_POLL_SECONDS = 3
 DOCK_SETTLE_TIMEOUT_SECONDS = OEM_STOP_FENCE_SECONDS
+DOCK_CONFIRM_TIMEOUT_SECONDS = 60
 # Coordinator state can still show the pre-STOP task for one refresh. Keep
 # that stale edge from abandoning the settlement watcher, but stop waiting if
 # cleaning or pause persists long enough to be replacement work.
@@ -38,6 +39,7 @@ DOCK_SETTLE_TRANSITION_GRACE_SECONDS = 60
 
 SETTLED_STATE = "idle"
 HOMEWARD_STATES = frozenset({"docked", "returning"})
+DOCKED_STATES = frozenset({"docked", "charging"})
 REPLACEMENT_STATES = frozenset({"cleaning", "paused"})
 
 _LOGGER = logging.getLogger(__name__)
@@ -148,7 +150,26 @@ async def async_dock_when_stop_settles(
                                 set_run_id(None)
                         await refresh()
                         if on_docked is not None:
-                            await on_docked()
+                            confirm_deadline = min(
+                                deadline,
+                                monotonic() + DOCK_CONFIRM_TIMEOUT_SECONDS,
+                            )
+                            while True:
+                                confirmed = hass.states.get(entity_id)
+                                if (
+                                    confirmed is not None
+                                    and confirmed.state in DOCKED_STATES
+                                ):
+                                    await on_docked()
+                                    break
+                                if monotonic() >= confirm_deadline:
+                                    _LOGGER.debug(
+                                        "Matic DOCK accepted but docked state was "
+                                        "not observed"
+                                    )
+                                    break
+                                await asyncio.sleep(DOCK_SETTLE_POLL_SECONDS)
+                                await refresh()
                         return True
         if now >= deadline:
             return False

--- a/custom_components/matic_robot/stop_return.py
+++ b/custom_components/matic_robot/stop_return.py
@@ -230,7 +230,7 @@ def schedule_dock_after_stop(
     )
     register_task = getattr(manager, "register_reconciliation_task", None)
     if isinstance(task, asyncio.Task) and callable(register_task):
-        register_task(serial_number, task)
+        register_task(serial_number, task, dock=True)
 
 
 async def async_confirm_docked(
@@ -317,5 +317,5 @@ def schedule_dock_confirmation(
     )
     register_task = getattr(manager, "register_reconciliation_task", None)
     if isinstance(task, asyncio.Task) and callable(register_task):
-        register_task(serial_number, task)
+        register_task(serial_number, task, dock=True)
     return isinstance(task, asyncio.Task)

--- a/custom_components/matic_robot/vacuum.py
+++ b/custom_components/matic_robot/vacuum.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from dataclasses import asdict
 from hashlib import sha256
 from typing import Any
@@ -134,6 +135,12 @@ class MaticVacuum(MaticEntity, StateVacuumEntity):
     ) -> None:
         """Serialize a user command and immediately refresh state."""
         serial_number = self.coordinator.data.info.serial_number
+        active_run_id = getattr(self._plans, "active_run_id", None)
+        run_id = (
+            active_run_id(serial_number)
+            if command is UserCommand.STOP and callable(active_run_id)
+            else None
+        )
         generation = self._plans.motion_generation(serial_number)
         if command is not UserCommand.STOP:
             await self._async_ensure_stop_settled(serial_number)
@@ -152,7 +159,7 @@ class MaticVacuum(MaticEntity, StateVacuumEntity):
                 await self._plans.async_mark_stop_pending(serial_number)
             await self.coordinator.async_request_refresh()
         if command is UserCommand.STOP:
-            self._schedule_dock_after_stop(serial_number)
+            self._schedule_dock_after_stop(serial_number, run_id=run_id)
 
     async def _async_ensure_stop_settled(self, serial_number: str) -> None:
         """Reject new motion while the firmware's graceful STOP is counting down."""
@@ -250,6 +257,8 @@ class MaticVacuum(MaticEntity, StateVacuumEntity):
     async def async_return_to_base(self, **kwargs: object) -> None:
         """Send the robot to its dock and end any task driving it."""
         serial_number = self.coordinator.data.info.serial_number
+        active_run_id = getattr(self._plans, "active_run_id", None)
+        run_id = active_run_id(serial_number) if callable(active_run_id) else None
         operational = self.coordinator.data.operational
         stop_before_dock = self._plans.has_managed_task(
             serial_number
@@ -279,12 +288,25 @@ class MaticVacuum(MaticEntity, StateVacuumEntity):
                 await self.coordinator.async_request_refresh()
                 stopped = False
         if stopped:
-            self._schedule_dock_after_stop(serial_number)
+            self._schedule_dock_after_stop(serial_number, run_id=run_id)
 
-    def _schedule_dock_after_stop(self, serial_number: str) -> None:
+    def _schedule_dock_after_stop(
+        self, serial_number: str, *, run_id: str | None = None
+    ) -> None:
         """Dock the robot as soon as its accepted stop settles."""
         if self.entity_id is None:
             return
+        on_docked: Callable[[], Awaitable[None]] | None = None
+        if run_id is not None:
+
+            async def mark_docked() -> None:
+                await self._plans.async_mark_run_docked(
+                    serial_number,
+                    run_id,
+                    entity_id=self.entity_id,
+                )
+
+            on_docked = mark_docked
         schedule_dock_after_stop(
             self.hass,
             client=self.coordinator.client,
@@ -292,6 +314,13 @@ class MaticVacuum(MaticEntity, StateVacuumEntity):
             manager=self._plans,
             serial_number=serial_number,
             entity_id=self.entity_id,
+            run_id=run_id,
+            set_run_id=getattr(
+                getattr(self.coordinator.client, "activity_journal", None),
+                "set_run_id",
+                None,
+            ),
+            on_docked=on_docked,
         )
 
     async def async_get_segments(self) -> list[Segment]:

--- a/custom_components/matic_robot/vacuum.py
+++ b/custom_components/matic_robot/vacuum.py
@@ -320,6 +320,11 @@ class MaticVacuum(MaticEntity, StateVacuumEntity):
                 "set_run_id",
                 None,
             ),
+            get_run_id=getattr(
+                getattr(self.coordinator.client, "activity_journal", None),
+                "current_run_id",
+                None,
+            ),
             on_docked=on_docked,
         )
 

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -101,7 +101,8 @@ before automating the switch.
 | `matic_robot_room_cancelled` | A managed room was cancelled; the event includes a machine-readable `reason_code` and cause |
 | `matic_robot_room_interrupted` | A managed task was stopped or replaced; `reason_code` identifies the observed path while `cause: unknown` remains when the source is unproven |
 | `matic_robot_room_ended_unverified` | The task ended without sufficient completion evidence (`reason_code: unverified_completion`) |
-| `matic_robot_plan_finished` | One managed plan run ended; includes `run_id`, `outcome`, `reason_code`, `cause`, safe trigger/service labels, terminal activity, and verified room counts |
+| `matic_robot_plan_finished` | One managed plan run ended; includes `run_id`, `outcome`, `reason_code`, `cause`, safe trigger/service labels, terminal activity, verified room counts, and per-room `room_outcomes` |
+| `matic_robot_plan_docked` | A stopped or unverified run reached a proven dock; carries the same `run_id` and `outcome: stopped_docked` |
 | `matic_robot_cleaning_finished` | A newly ended native session, with times, duration, room results, and robot identifiers |
 | `matic_robot_firmware_changed` | A new firmware/protocol pair, with previous values and robot identifiers |
 | `matic_robot_firmware_analyzed` | Endpoint comparison counts and new wire paths |

--- a/docs/e2e-contract.md
+++ b/docs/e2e-contract.md
@@ -7,10 +7,13 @@ history record is useful evidence, but it is not by itself proof that a saved
 plan completed or that a person caused a stop.
 
 1. **Managed outcomes.** Every managed run gets one local `run_id` and emits a
-   `matic_robot_plan_finished` event when its runner exits. Its `outcome` is
-   `completed`, `partial`, `stopped`, `failed`, or `interrupted`; `reason_code`, `cause`, and verified
-   room counts explain the result. `room_completed` is emitted only after the
-   existing native completion guard passes.
+   `matic_robot_plan_finished` event when its runner exits. Its terminal
+   `outcome` is `completed`, `stopped_docked`, `recharge_suspended`,
+   `cancelled`, `failed`, or `unverified`; `reason_code`, `cause`, and verified
+   room counts and `room_outcomes` (`completed`, `partial`, or `unattempted`) explain the result. A later `matic_robot_plan_docked` event
+   upgrades a cancelled or unverified stop to `stopped_docked` only after the
+   correlated final DOCK is accepted. `room_completed` is emitted only after
+   the existing native completion guard passes.
 2. **Trigger provenance.** The run record carries the safe `trigger` label and
    Home Assistant service name. It never carries a context user ID, account
    name, or email. An OEM-app, physical, or robot-originated action remains
@@ -20,7 +23,8 @@ plan completed or that a person caused a stop.
    has an `observation_session` and monotonic `sequence`; a restart starts a
    new observation window.
 4. **Intelligent rotation.** `MaticGetPlan` and `preview_plan` expose the
-   exact selected order, last opportunity, source, result, and tie-break reason.
+   exact selected order, last opportunity, last completion, source, result, and
+   tie-break reason. The preview is explicitly labelled `next_run`.
    The preview and executor share the same deterministic rotation key.
 5. **Evidence retention.** Low-volume operational events have a separate
    bounded 64-event trail. High-frequency state and command observations retain
@@ -40,11 +44,17 @@ plan completed or that a person caused a stop.
 
 | Scenario | Required evidence | Room-credit rule |
 | --- | --- | --- |
+| Departure trigger starts a plan | Trigger trace, `run_id`, first room event, and command journal | Credit only rooms with verified native completion |
+| Return-home stop | `plan_finished: cancelled`, STOP plus final DOCK with the same `run_id`, then `plan_docked: stopped_docked` | Never credit the room that was stopped |
+| Stop during a room | Room event `partial`, native visited/partial evidence, and no completion credit | Keep the room due for rotation |
+| Finish-current-room threshold | Policy decision, threshold/progress, and either room completion or cancelled stop | Credit only when native completion verification passes |
+| Recharge and resume | Suspended event, native recharge/resume transition, and resumed room timeline | A resumed room can complete; an unreconciled low-charge stop is `recharge_suspended` |
+| Mixed settings | Preview `settings_boundary_count`, per-leg settings, and command timeline | Each leg keeps its own mode and coverage |
 | All selected rooms verify | `plan_finished: completed`, matching `run_id`, all room events | Credit verified rooms only |
-| Native session ends early | `plan_finished: partial`, `partial_native_result`, `stopped_in_place`, or `unverified_completion` | Leave unverified rooms due; a known in-place stop is a controlled partial result, not a generic service fault |
-| Managed stop | `plan_finished: stopped`, `managed_stop`, stop command/activity when available | Do not credit the unfinished room |
-| Independent command replaces a plan | `plan_finished: stopped`, `managed_replaced`, `cause: replacement` | Do not credit the unfinished room or dispatch another plan command |
-| Home Assistant unload | `plan_finished: interrupted`, `config_entry_unload` | No completion credit |
+| Native session ends early | `plan_finished: unverified`, `partial_native_result`, `stopped_in_place`, or `unverified_completion` | Leave unverified rooms due; a known in-place stop is a controlled unverified result, not a generic service fault |
+| Delayed native history | Initial `unverified`/pending reconciliation, then exact room/run match or expiry | Never advance rotation until the delayed evidence is exact |
+| Home Assistant restart recovery | `unverified`, `home_assistant_restart`, recovered room records, and new observation session | No completion credit or invented end time |
+| External/OEM interruption | Native ownership change, `cause: unknown`, and `external_unknown` provenance | No completion credit and no guessed fault |
 | Timeout or robot error | `plan_finished: failed`, stable failure code, room failure event | No completion credit |
 | Rotation preview and execution | Same room order and selection reasons | Advance opportunity on a confirmed cleaning start; credit completion only after verification |
 | Activity churn or restart | Operational events remain visible; journal session/sequence boundaries are explicit | Never infer a cause from missing activity |
@@ -52,7 +62,7 @@ plan completed or that a person caused a stop.
 Keep release evidence separate from robot credentials, network identifiers,
 serials, maps, and personal account identifiers.
 
-After an abrupt Home Assistant restart, the persisted run becomes `interrupted`
+After an abrupt Home Assistant restart, the persisted run becomes `unverified`
 with `reason_code: home_assistant_restart`. `recovered_at` records when recovery
 observed it; `ended_at` remains unknown. Recovery does not reconstruct a missing
 terminal event or award room credit. Verified counts are saved with room history,

--- a/tests/test_activity_observations.py
+++ b/tests/test_activity_observations.py
@@ -27,6 +27,11 @@ from tests.test_api_paths import _OpenMethod, _Stream
 def test_raw_transitions_are_bounded_detached_and_payload_free() -> None:
     delivered = []
     journal = ActivityJournal(delivered.append)
+    assert journal.current_run_id() is None
+    journal.set_run_id("run-1")
+    assert journal.current_run_id() == "run-1"
+    journal.set_run_id(None)
+    assert journal.current_run_id() is None
     state = RobotOperationalState(
         80,
         (101, 119),

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -453,6 +453,15 @@ async def test_plan_tool_reports_exact_leg_boundaries() -> None:
         {"id": "saved", "run_behavior": "saved_order", "return_to_base": False},
         rooms[:1],
     )
+    manager.rotation_details.return_value = [
+        {
+            "room_id": "kitchen",
+            "last_result": "completed",
+            "last_opportunity": "2026-09-12T20:00:00+00:00",
+            "last_opportunity_source": "plan",
+            "last_completion": "2026-09-12T20:00:00+00:00",
+        }
+    ]
     manager.snapshot.return_value = {"active_plan": None}
     ordered = await tool.async_call(
         hass, llm.ToolInput(tool.name, {"plan": "saved"}), _context()
@@ -460,6 +469,7 @@ async def test_plan_tool_reports_exact_leg_boundaries() -> None:
     assert ordered["preview_scope"] == "next_run"
     assert ordered["active_run_for_plan"] is None
     assert ordered["plan"]["name"] == "saved"
+    assert ordered["rotation"][0]["last_completion"] == ("2026-09-12T20:00:00+00:00")
 
     manager.lock.return_value.locked.return_value = False
     idle = await tool.async_call(

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -157,7 +157,7 @@ async def test_api_registration_event_capture_and_admin_gate() -> None:
     hass = _hass(_entry())
     api = MaticOperationsAPI(hass)
     api.async_start()
-    assert hass.bus.async_listen.call_count == 13
+    assert hass.bus.async_listen.call_count == 14
 
     event_callback = hass.bus.async_listen.call_args_list[0].args[1]
     event_callback(
@@ -279,6 +279,26 @@ async def test_api_registration_event_capture_and_admin_gate() -> None:
         "room_duration_count": 1,
     }
 
+    event_callback(
+        Event(
+            "matic_robot_plan_finished",
+            {
+                "run_id": "run-1",
+                "room_outcomes": [
+                    {"room_id": "room-1", "room": "Kitchen", "outcome": "partial"},
+                    {"room_id": "room-2", "room": "Study", "outcome": "unattempted"},
+                    {"room": "ignored", "outcome": 7},
+                ],
+            },
+            time_fired_timestamp=5,
+        )
+    )
+    assert api.recent_events[-1]["data"]["room_outcomes"] == [
+        {"room_id": "room-1", "room": "Kitchen", "outcome": "partial"},
+        {"room_id": "room-2", "room": "Study", "outcome": "unattempted"},
+        {"room": "ignored"},
+    ]
+
     missing_context = _context(None)
     with pytest.raises(HomeAssistantError, match="Administrator"):
         await api.async_get_api_instance(missing_context)
@@ -308,7 +328,7 @@ async def test_api_registration_event_capture_and_admin_gate() -> None:
     with patch("custom_components.matic_robot.llm.llm.async_register_api") as register:
         registered = async_register_matic_llm_api(hass)
     register.assert_called_once_with(hass, registered)
-    assert hass.bus.async_listen.call_count == 26
+    assert hass.bus.async_listen.call_count == 28
 
 
 async def test_operations_and_robot_resolution() -> None:

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -216,6 +216,44 @@ async def test_run_finalizer_preserves_scope_for_stop_watcher(hass) -> None:
     await asyncio.sleep(0)
 
 
+async def test_run_finalizer_clears_scope_owned_by_another_run(hass) -> None:
+    """An older dock watcher cannot pin a newer run's activity scope."""
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    set_run_id = MagicMock()
+    watcher_release = asyncio.Event()
+
+    async def watcher() -> None:
+        await watcher_release.wait()
+
+    async def fake_leg(*_args, **_kwargs):
+        manager.register_reconciliation_task(
+            "serial", asyncio.create_task(watcher()), dock=True
+        )
+        return True
+
+    with patch(
+        "custom_components.matic_robot.services._async_run_leg",
+        AsyncMock(side_effect=fake_leg),
+    ):
+        await _async_execute_rooms(
+            hass,
+            _call(hass),
+            manager,
+            "vacuum.matic",
+            "serial",
+            [_room("Kitchen", "room-kitchen")],
+            intelligent=False,
+            set_activity_run_id=set_run_id,
+            get_activity_run_id=lambda: "newer-run",
+        )
+
+    assert set_run_id.call_args_list[-1].args[0] is None
+    watcher_release.set()
+    manager.cancel_reconciliation_tasks("serial")
+    await asyncio.sleep(0)
+
+
 async def test_native_stop_in_place_is_a_controlled_partial_run(hass) -> None:
     """A stopped native task never credits a room or fails the automation."""
     manager = CleaningPlanManager(hass)

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -3244,7 +3244,9 @@ async def test_room_native_plan_lifecycle_preview_selection_and_reset(hass) -> N
     manager._robot("serial")["plans"]["whole_home"]["run_behavior"] = "intelligent"
     await manager.async_reset_history("serial", "whole_home")
     assert manager.snapshot("serial")["completed_runs"] == 0
-    assert manager.preview("serial", room_map)["rooms"][0]["name"] == "Kitchen"
+    reset_preview = manager.preview("serial", room_map)
+    assert reset_preview["rooms"][0]["name"] == "Kitchen"
+    assert all(item["last_completion"] is None for item in reset_preview["rotation"])
     await manager.async_delete_plan("serial", "whole_home")
     assert manager.snapshot("serial")["selected_plan"] == "upstairs"
     await manager.async_reset_history("serial")

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -4123,6 +4123,7 @@ async def test_leg_uses_matching_prepared_dispatch_and_rejects_mismatch(hass) ->
         return (_leg_record(("Kitchen", "Office"), ("Kitchen", "Office")),)
 
     confirmed: list[str] = []
+    recorded: list[str] = []
     prepared = _PreparedRoomDispatch(
         tuple(rooms), frozenset(), dt_util.utcnow() - timedelta(seconds=1)
     )
@@ -4135,10 +4136,12 @@ async def test_leg_uses_matching_prepared_dispatch_and_rejects_mismatch(hass) ->
         rooms,
         session_history=history,
         confirm_room_completed=confirmed.append,
+        record_room_completed=lambda room: recorded.append(room.room_id),
         prepared_dispatch=prepared,
     )
     assert completed is True
     assert confirmed == ["Kitchen", "Office"]
+    assert recorded == ["room-kitchen", "room-office"]
 
     with pytest.raises(ValueError):
         await _async_run_leg(

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -80,6 +80,7 @@ from custom_components.matic_robot.services import (
     _async_wait_for_vacuum_state,
     _entry_for_entity,
     _PreparedRoomDispatch,
+    _room_outcomes,
 )
 
 
@@ -281,6 +282,97 @@ async def test_recharge_suspension_has_its_own_run_outcome(hass) -> None:
     last_run = manager.snapshot("serial")["last_run"]
     assert last_run["outcome"] == "recharge_suspended"
     assert last_run["reason_code"] == "low_charge"
+
+
+async def test_explicit_stop_wins_over_recharge_suspension(hass) -> None:
+    """A managed stop remains cancellation even if the room was low-charge suspended."""
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    room = _room("Kitchen", "room-kitchen")
+
+    async def suspended_leg(*_args, **_kwargs):
+        manager._robot("serial")["active_plan"] = {
+            "plan_id": "away",
+            "room_id": "room-kitchen",
+            "status": "suspended",
+            "suspend_reason": "low_charge",
+        }
+        manager._cancellation_reasons["serial"] = "managed_stop"
+        raise PlanCancelledError
+
+    with patch(
+        "custom_components.matic_robot.services._async_run_leg",
+        AsyncMock(side_effect=suspended_leg),
+    ):
+        await _async_execute_rooms(
+            hass,
+            _call(hass),
+            manager,
+            "vacuum.matic",
+            "serial",
+            [room],
+            intelligent=False,
+        )
+
+    last_run = manager.snapshot("serial")["last_run"]
+    assert last_run["outcome"] == "cancelled"
+    assert last_run["reason_code"] == "managed_stop"
+
+
+async def test_finish_current_room_uses_normalized_cancelled_outcome(hass) -> None:
+    """Graceful stop events use the public run outcome vocabulary."""
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    room = _room("Kitchen", "room-kitchen")
+
+    async def stopped_leg(*_args, **_kwargs):
+        manager.finish_room_event("serial").set()
+        return False
+
+    with patch(
+        "custom_components.matic_robot.services._async_run_leg",
+        AsyncMock(side_effect=stopped_leg),
+    ):
+        await _async_execute_rooms(
+            hass,
+            _call(hass),
+            manager,
+            "vacuum.matic",
+            "serial",
+            [room],
+            intelligent=False,
+        )
+
+    assert manager.snapshot("serial")["last_run"]["outcome"] == "cancelled"
+
+
+async def test_room_outcomes_ignore_prior_run_terminal_state(hass) -> None:
+    """A prior room failure cannot make an unvisited room partial now."""
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    robot = manager._robot("serial")
+    robot["plan_history"] = {
+        "away": {
+            "rooms": {
+                "room-kitchen": {
+                    "run_id": "old-run",
+                    "last_result": "failed",
+                }
+            }
+        }
+    }
+
+    outcomes = _room_outcomes(
+        manager,
+        "serial",
+        "away",
+        "new-run",
+        [_room("Kitchen", "room-kitchen")],
+        set(),
+    )
+    assert outcomes == [
+        {"room_id": "room-kitchen", "room": "Kitchen", "outcome": "unattempted"}
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -136,6 +136,7 @@ async def test_managed_run_identity_outcome_and_activity_scope(hass) -> None:
 
     async def fake_leg(*args, **kwargs):
         args[11](args[5][0].name)
+        kwargs["record_room_completed"](args[5][0])
         return True
 
     with patch(
@@ -449,6 +450,27 @@ async def test_room_outcomes_ignore_prior_run_terminal_state(hass) -> None:
     )
     assert outcomes == [
         {"room_id": "room-kitchen", "room": "Kitchen", "outcome": "unattempted"}
+    ]
+
+
+async def test_room_outcomes_use_room_ids_for_duplicate_names(hass) -> None:
+    """One completed duplicate-name room cannot credit its sibling."""
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    rooms = [_room("Hall", "room-hall-a"), _room("Hall", "room-hall-b")]
+
+    outcomes = _room_outcomes(
+        manager,
+        "serial",
+        "away",
+        "run-1",
+        rooms,
+        {"room-hall-a"},
+    )
+
+    assert outcomes == [
+        {"room_id": "room-hall-a", "room": "Hall", "outcome": "completed"},
+        {"room_id": "room-hall-b", "room": "Hall", "outcome": "unattempted"},
     ]
 
 
@@ -3280,6 +3302,7 @@ async def test_room_native_plan_lifecycle_preview_selection_and_reset(hass) -> N
     ordered_preview = manager.preview("serial", room_map)
     assert ordered_preview["rotation_basis"] == "saved_order"
     assert ordered_preview["rooms"][0]["name"] == "Kitchen"
+    assert ordered_preview["rotation"][0]["last_completion"] is not None
     manager._robot("serial")["plans"]["whole_home"]["run_behavior"] = "intelligent"
     await manager.async_reset_history("serial", "whole_home")
     assert manager.snapshot("serial")["completed_runs"] == 0

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -176,6 +176,43 @@ async def test_managed_run_identity_outcome_and_activity_scope(hass) -> None:
     )
 
 
+async def test_run_finalizer_preserves_scope_for_stop_watcher(hass) -> None:
+    """A registered STOP watcher owns the journal until dock confirmation ends."""
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    set_run_id = MagicMock()
+    watcher_release = asyncio.Event()
+
+    async def watcher() -> None:
+        await watcher_release.wait()
+
+    async def fake_leg(*_args, **_kwargs):
+        manager.register_reconciliation_task("serial", asyncio.create_task(watcher()))
+        return True
+
+    with patch(
+        "custom_components.matic_robot.services._async_run_leg",
+        AsyncMock(side_effect=fake_leg),
+    ):
+        await _async_execute_rooms(
+            hass,
+            _call(hass),
+            manager,
+            "vacuum.matic",
+            "serial",
+            [_room("Kitchen", "room-kitchen")],
+            intelligent=False,
+            set_activity_run_id=set_run_id,
+        )
+
+    assert set_run_id.call_count == 1
+    assert set_run_id.call_args.args[0]
+    assert manager.reconciliation_tasks_active("serial") is True
+    watcher_release.set()
+    manager.cancel_reconciliation_tasks("serial")
+    await asyncio.sleep(0)
+
+
 async def test_native_stop_in_place_is_a_controlled_partial_run(hass) -> None:
     """A stopped native task never credits a room or fails the automation."""
     manager = CleaningPlanManager(hass)
@@ -6119,15 +6156,18 @@ async def test_reconciliation_tasks_are_lifecycle_bound(hass) -> None:
 
     task = asyncio.create_task(reconcile())
     manager.register_reconciliation_task("serial", task)
+    assert manager.reconciliation_tasks_active("serial") is True
     await started.wait()
     await manager.async_cancel_and_wait("serial")
     assert task.cancelled()
+    assert manager.reconciliation_tasks_active("serial") is False
     assert "serial" not in manager._reconciliation_tasks
 
     finished = asyncio.create_task(asyncio.sleep(0))
     manager.register_reconciliation_task("serial", finished)
     await finished
     await asyncio.sleep(0)
+    assert manager.reconciliation_tasks_active("serial") is False
     assert "serial" not in manager._reconciliation_tasks
 
 

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -4289,6 +4289,8 @@ async def test_leg_suspension_mid_leg_resumes(hass) -> None:
 
 async def test_leg_completion_timeout_fails(hass) -> None:
     manager = _leg_manager()
+    finish_room_event = asyncio.Event()
+    finish_room_event.set()
 
     async def send_command(_call) -> None:
         hass.states.async_set("vacuum.matic", "cleaning", {"current_area": "Kitchen"})
@@ -4303,10 +4305,12 @@ async def test_leg_completion_timeout_fails(hass) -> None:
             "vacuum.matic",
             "serial",
             _leg_rooms(),
+            finish_room_event=finish_room_event,
         )
 
     manager.async_mark_failed.assert_awaited_once()
     assert "completion timeout" in manager.async_mark_failed.await_args.args[3]
+    assert not finish_room_event.is_set()
 
 
 async def test_leg_matic_error_dispatch_fails(hass) -> None:

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -249,6 +249,44 @@ async def test_docked_stop_upgrades_only_after_correlated_final_command(hass) ->
     assert not await manager.async_mark_run_docked("serial", "run-1")
 
 
+async def test_docked_stop_can_win_race_with_run_finalizer(hass) -> None:
+    """A dock observation received before final cleanup remains durable."""
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    await manager.async_begin_run(
+        "serial",
+        "away",
+        "run-1",
+        1,
+        trigger="user",
+        service="clean_room_sequence",
+        provenance="user",
+    )
+
+    assert await manager.async_mark_run_docked("serial", "run-1")
+    assert await manager.async_finish_run(
+        "serial", "run-1", "cancelled", "managed_stop", 0, terminal_activity="idle"
+    )
+    last_run = manager.snapshot("serial")["last_run"]
+    assert last_run["outcome"] == "stopped_docked"
+    assert last_run["reason_code"] == "stopped_docked"
+    assert last_run["terminal_activity"] == "docked"
+
+
+async def test_immediate_stop_records_managed_stop_reason(hass) -> None:
+    """The default stop policy is distinguishable from motion replacement."""
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    manager._robot("serial")["active_plan"] = {"plan_id": "away"}
+    await manager.lock("serial").acquire()
+    try:
+        decision = manager.request_stop("serial")
+        assert decision.behavior == "immediate"
+        assert manager.cancellation_reason("serial") == "managed_stop"
+    finally:
+        manager.lock("serial").release()
+
+
 async def test_recharge_suspension_has_its_own_run_outcome(hass) -> None:
     """A low-charge pause is distinguishable from a user cancellation."""
     manager = CleaningPlanManager(hass)

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -187,7 +187,9 @@ async def test_run_finalizer_preserves_scope_for_stop_watcher(hass) -> None:
         await watcher_release.wait()
 
     async def fake_leg(*_args, **_kwargs):
-        manager.register_reconciliation_task("serial", asyncio.create_task(watcher()))
+        manager.register_reconciliation_task(
+            "serial", asyncio.create_task(watcher()), dock=True
+        )
         return True
 
     with patch(
@@ -207,7 +209,7 @@ async def test_run_finalizer_preserves_scope_for_stop_watcher(hass) -> None:
 
     assert set_run_id.call_count == 1
     assert set_run_id.call_args.args[0]
-    assert manager.reconciliation_tasks_active("serial") is True
+    assert manager.dock_reconciliation_active("serial") is True
     watcher_release.set()
     manager.cancel_reconciliation_tasks("serial")
     await asyncio.sleep(0)
@@ -6156,18 +6158,18 @@ async def test_reconciliation_tasks_are_lifecycle_bound(hass) -> None:
 
     task = asyncio.create_task(reconcile())
     manager.register_reconciliation_task("serial", task)
-    assert manager.reconciliation_tasks_active("serial") is True
+    assert "serial" in manager._reconciliation_tasks
     await started.wait()
     await manager.async_cancel_and_wait("serial")
     assert task.cancelled()
-    assert manager.reconciliation_tasks_active("serial") is False
+    assert manager.dock_reconciliation_active("serial") is False
     assert "serial" not in manager._reconciliation_tasks
 
     finished = asyncio.create_task(asyncio.sleep(0))
     manager.register_reconciliation_task("serial", finished)
     await finished
     await asyncio.sleep(0)
-    assert manager.reconciliation_tasks_active("serial") is False
+    assert manager.dock_reconciliation_active("serial") is False
     assert "serial" not in manager._reconciliation_tasks
 
 

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -29,7 +29,11 @@ from custom_components.matic_robot.client.models import (
     FloorPlan,
     Room,
 )
-from custom_components.matic_robot.const import DOMAIN, EVENT_PLAN_FINISHED
+from custom_components.matic_robot.const import (
+    DOMAIN,
+    EVENT_PLAN_DOCKED,
+    EVENT_PLAN_FINISHED,
+)
 from custom_components.matic_robot.plans import (
     MAX_SAVED_PLANS_PER_ROBOT,
     OEM_STOP_RECONCILIATION_SECONDS,
@@ -155,7 +159,8 @@ async def test_managed_run_identity_outcome_and_activity_scope(hass) -> None:
     assert last_run["room_count"] == 1
     assert last_run["completed_room_count"] == 1
     confirmed.assert_called_once_with("Kitchen")
-    assert last_run["trigger"] == "service_call"
+    assert last_run["trigger"] == "external_unknown"
+    assert last_run["provenance"] == "external_unknown"
     assert last_run["service"] == "intelligent_clean"
     assert len(events) == 1
     event = events[0].data
@@ -196,11 +201,86 @@ async def test_native_stop_in_place_is_a_controlled_partial_run(hass) -> None:
         )
 
     last_run = manager.snapshot("serial")["last_run"]
-    assert last_run["outcome"] == "partial"
+    assert last_run["outcome"] == "unverified"
     assert last_run["reason_code"] == "stopped_in_place"
     assert last_run["completed_room_count"] == 0
     assert events[0].data["cause"] == "unknown"
     assert events[0].data["completed_room_count"] == 0
+
+
+async def test_docked_stop_upgrades_only_after_correlated_final_command(hass) -> None:
+    """A stop is not reported docked until the watcher confirms DOCK."""
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    events = []
+    hass.bus.async_listen(EVENT_PLAN_DOCKED, events.append)
+    await manager.async_begin_run(
+        "serial",
+        "away",
+        "run-1",
+        1,
+        trigger="user",
+        service="clean_room_sequence",
+        provenance="user",
+    )
+    assert manager.active_run_id("serial") == "run-1"
+    assert manager.active_run_id("missing") is None
+    await manager.async_finish_run(
+        "serial",
+        "run-1",
+        "cancelled",
+        "managed_stop",
+        0,
+        terminal_activity="cleaning",
+    )
+    assert manager.snapshot("serial")["last_run"]["outcome"] == "cancelled"
+    assert not await manager.async_mark_run_docked("serial", "wrong-run")
+
+    assert await manager.async_mark_run_docked(
+        "serial", "run-1", entity_id="vacuum.matic"
+    )
+    await hass.async_block_till_done()
+    last_run = manager.snapshot("serial")["last_run"]
+    assert last_run["outcome"] == "stopped_docked"
+    assert last_run["terminal_activity"] == "docked"
+    assert events[0].data["run_id"] == "run-1"
+    assert events[0].data["outcome"] == "stopped_docked"
+    assert not await manager.async_mark_run_docked("serial", "run-1")
+
+
+async def test_recharge_suspension_has_its_own_run_outcome(hass) -> None:
+    """A low-charge pause is distinguishable from a user cancellation."""
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    room = _room("Kitchen", "room-kitchen")
+
+    async def suspended_leg(*_args, **_kwargs):
+        manager._robot("serial")["active_plan"] = {
+            "plan_id": "away",
+            "room_id": "room-kitchen",
+            "status": "suspended",
+            "suspend_reason": "low_charge",
+        }
+        assert manager.snapshot("serial")["active_plan"]["status"] == "suspended"
+        raise PlanCancelledError
+
+    with patch(
+        "custom_components.matic_robot.services._async_run_leg",
+        AsyncMock(side_effect=suspended_leg),
+    ):
+        await _async_execute_rooms(
+            hass,
+            _call(hass),
+            manager,
+            "vacuum.matic",
+            "serial",
+            [room],
+            intelligent=False,
+        )
+
+    last_run = manager.snapshot("serial")["last_run"]
+    assert last_run["outcome"] == "recharge_suspended"
+    assert last_run["reason_code"] == "low_charge"
 
 
 @pytest.mark.parametrize(
@@ -285,7 +365,7 @@ async def test_restart_retires_persisted_running_outcome(
     await recovering.async_load()
     last_run = recovering.snapshot("serial")["last_run"]
     assert last_run["run_id"] == "synthetic-run"
-    assert last_run["outcome"] == "interrupted"
+    assert last_run["outcome"] == "unverified"
     assert last_run["reason_code"] == "home_assistant_restart"
     assert last_run["cause"] == "home_assistant"
     assert last_run["ended_at"] is None
@@ -295,6 +375,34 @@ async def test_restart_retires_persisted_running_outcome(
     recovering._store.async_load.return_value = deepcopy(recovering._data)
     await recovering.async_load()
     assert recovering.snapshot("serial")["last_run"] == last_run
+
+
+async def test_load_normalizes_legacy_run_outcome_and_provenance(hass) -> None:
+    """Old persisted labels are repaired without retaining service identity."""
+    manager = CleaningPlanManager(hass)
+    manager._store = SimpleNamespace(async_save=AsyncMock())
+    await manager.async_begin_run(
+        "serial",
+        "away",
+        "legacy-run",
+        1,
+        trigger="service_call",
+        service="run_selected_plan",
+    )
+    legacy = deepcopy(manager._data)
+    legacy_run = legacy["robots"]["serial"]["last_run"]
+    legacy_run["outcome"] = "partial"
+    legacy_run["trigger"] = "service_call"
+    legacy_run.pop("provenance", None)
+    recovering = CleaningPlanManager(hass)
+    recovering._store = SimpleNamespace(
+        async_load=AsyncMock(return_value=legacy), async_save=AsyncMock()
+    )
+    await recovering.async_load()
+    last_run = recovering.snapshot("serial")["last_run"]
+    assert last_run["outcome"] == "unverified"
+    assert last_run["trigger"] == "external_unknown"
+    assert last_run["provenance"] == "external_unknown"
 
 
 @pytest.mark.parametrize("save_fails", [False, True])
@@ -387,13 +495,19 @@ async def test_initial_save_failure_still_retires_the_run(
     ("scenario", "outcome", "reason", "room_event", "credit"),
     [
         ("complete", "completed", "all_rooms_verified", "room_completed", 1),
-        ("unverified", "partial", "partial_native_result", "room_ended_unverified", 0),
-        ("native_stop", "partial", "stopped_in_place", "room_interrupted", 0),
-        ("stop", "stopped", "managed_stop", "room_cancelled", 0),
-        ("replacement", "stopped", "managed_replaced", "room_cancelled", 0),
-        ("unload", "interrupted", "config_entry_unload", "room_interrupted", 0),
-        ("interrupted", "interrupted", "interrupted", "room_interrupted", 0),
-        ("takeover", "interrupted", "native_task_taken_over", "room_interrupted", 0),
+        (
+            "unverified",
+            "unverified",
+            "partial_native_result",
+            "room_ended_unverified",
+            0,
+        ),
+        ("native_stop", "unverified", "stopped_in_place", "room_interrupted", 0),
+        ("stop", "cancelled", "managed_stop", "room_cancelled", 0),
+        ("replacement", "cancelled", "managed_replaced", "room_cancelled", 0),
+        ("unload", "unverified", "config_entry_unload", "room_interrupted", 0),
+        ("interrupted", "unverified", "interrupted", "room_interrupted", 0),
+        ("takeover", "unverified", "native_task_taken_over", "room_interrupted", 0),
     ],
 )
 async def test_managed_terminal_matrix_uses_real_room_history_and_events(
@@ -2961,6 +3075,7 @@ async def test_room_native_plan_lifecycle_preview_selection_and_reset(hass) -> N
     assert rotation[1]["room"] == "Kitchen"
     assert rotation[1]["last_result"] == "completed"
     assert rotation[1]["last_opportunity_source"] == "plan"
+    assert rotation[1]["last_completion"] is not None
 
     same_opportunity = (dt_util.utcnow() - timedelta(hours=1)).isoformat()
     robot = manager._robot("serial")

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -2058,6 +2058,41 @@ async def test_room_cancellation_records_history_and_reraises() -> None:
     assert bus.async_fire.call_args_list[-1].args[0] == "matic_robot_room_cancelled"
 
 
+async def test_room_cancellation_preserves_low_charge_reason() -> None:
+    """Room cleanup carries suspension evidence to the plan finalizer."""
+    services = SimpleNamespace(async_call=AsyncMock())
+    bus = SimpleNamespace(async_fire=MagicMock())
+    hass = SimpleNamespace(services=services, bus=bus)
+    manager = SimpleNamespace(
+        async_mark_started=AsyncMock(),
+        async_mark_completed=AsyncMock(),
+        async_mark_ended_unverified=AsyncMock(),
+        async_mark_verifying=AsyncMock(),
+        async_mark_cancelled=AsyncMock(),
+        cancellation_reason=MagicMock(return_value=None),
+        snapshot=MagicMock(
+            return_value={
+                "active_plan": {
+                    "status": "suspended",
+                    "suspend_reason": "low_charge",
+                }
+            }
+        ),
+    )
+    room = CleaningRoom("room-study", "Study", "vacuum", "quick")
+    with (
+        patch(
+            "custom_components.matic_robot.services._async_wait_for_vacuum_state",
+            AsyncMock(side_effect=PlanCancelledError),
+        ),
+        pytest.raises(PlanCancelledError) as excinfo,
+    ):
+        await _async_run_room(
+            hass, _execution_call(hass), manager, "vacuum.test", "serial", room
+        )
+    assert excinfo.value.suspend_reason == "low_charge"
+
+
 @pytest.mark.parametrize("changes_during_history", [False, True])
 async def test_room_dispatch_rechecks_exact_floor_before_robot_command(
     changes_during_history: bool,

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -132,10 +132,7 @@ async def test_dock_upgrade_does_not_mask_unmanaged_running_failure(
 
     await _async_mark_run_docked(manager, "serial", "run-1", "vacuum.matic", Context())
 
-    if finish_requested:
-        manager.async_mark_run_docked.assert_awaited_once()
-    else:
-        manager.async_mark_run_docked.assert_not_awaited()
+    manager.async_mark_run_docked.assert_not_awaited()
 
 
 async def test_dock_upgrade_allows_managed_stop_running_failure(hass) -> None:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -2291,6 +2291,8 @@ async def test_room_failures_translate_client_errors_at_boundary(
         async_mark_verifying=AsyncMock(),
         async_mark_failed=AsyncMock(),
     )
+    finish_room_event = asyncio.Event()
+    finish_room_event.set()
     room = CleaningRoom("room-study", "Study", "vacuum", "quick")
     with (
         patch(
@@ -2300,7 +2302,13 @@ async def test_room_failures_translate_client_errors_at_boundary(
         pytest.raises(expected_type) as excinfo,
     ):
         await _async_run_room(
-            hass, _execution_call(hass), manager, "vacuum.test", "serial", room
+            hass,
+            _execution_call(hass),
+            manager,
+            "vacuum.test",
+            "serial",
+            room,
+            finish_room_event=finish_room_event,
         )
     if isinstance(error, MaticError):
         assert excinfo.value.translation_key == "robot_command_failed"
@@ -2308,6 +2316,7 @@ async def test_room_failures_translate_client_errors_at_boundary(
     else:
         assert excinfo.value is error
     manager.async_mark_failed.assert_awaited_once()
+    assert not finish_room_event.is_set()
     manager.async_mark_completed.assert_not_awaited()
     assert bus.async_fire.call_args_list[-1].args[0] == "matic_robot_room_failed"
     event_data = bus.async_fire.call_args_list[-1].args[1]

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -60,6 +60,7 @@ from custom_components.matic_robot.services import (
     _async_dispatch_leg_command,
     _async_execute_rooms,
     _async_expire_native_reconciliation,
+    _async_mark_run_docked,
     _async_reconcile_native_stop,
     _async_run_room,
     _async_wait_for_vacuum_state,
@@ -71,10 +72,45 @@ from custom_components.matic_robot.services import (
     _require_matic_control,
     _resolve_loaded_matic_vacuums,
     _resolve_room_id,
+    _run_provenance,
     _saved_plan_context,
     _schedule_native_reconciliation,
     async_register_services,
 )
+
+
+async def test_run_provenance_and_docked_bridge_are_bounded(hass) -> None:
+    """Automation/user context maps to labels and never stores identity."""
+    automation = ServiceCall(
+        hass,
+        DOMAIN,
+        "run_selected_plan",
+        {},
+        context=Context(parent_id="parent", user_id="private-user"),
+    )
+    user = ServiceCall(
+        hass,
+        DOMAIN,
+        "run_selected_plan",
+        {},
+        context=Context(user_id="private-user"),
+    )
+    unknown = ServiceCall(hass, DOMAIN, "run_selected_plan", {}, context=Context())
+    assert _run_provenance(automation) == "automation"
+    assert _run_provenance(user) == "user"
+    assert _run_provenance(unknown) == "external_unknown"
+
+    manager = SimpleNamespace(async_mark_run_docked=AsyncMock())
+    await _async_mark_run_docked(
+        manager, "serial", None, "vacuum.matic", automation.context
+    )
+    manager.async_mark_run_docked.assert_not_awaited()
+    await _async_mark_run_docked(
+        manager, "serial", "run-1", "vacuum.matic", automation.context
+    )
+    manager.async_mark_run_docked.assert_awaited_once_with(
+        "serial", "run-1", entity_id="vacuum.matic", context=automation.context
+    )
 
 
 def _registered_handler(services, service: str):

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -113,6 +113,47 @@ async def test_run_provenance_and_docked_bridge_are_bounded(hass) -> None:
     )
 
 
+@pytest.mark.parametrize("finish_requested", [False, True])
+async def test_dock_upgrade_does_not_mask_unmanaged_running_failure(
+    hass, finish_requested: bool
+) -> None:
+    """Only a managed stop may upgrade a still-running run at the dock."""
+    finish_event = asyncio.Event()
+    if finish_requested:
+        finish_event.set()
+    manager = SimpleNamespace(
+        snapshot=MagicMock(
+            return_value={"last_run": {"run_id": "run-1", "outcome": "running"}}
+        ),
+        cancellation_reason=MagicMock(return_value=None),
+        finish_room_event=MagicMock(return_value=finish_event),
+        async_mark_run_docked=AsyncMock(),
+    )
+
+    await _async_mark_run_docked(manager, "serial", "run-1", "vacuum.matic", Context())
+
+    if finish_requested:
+        manager.async_mark_run_docked.assert_awaited_once()
+    else:
+        manager.async_mark_run_docked.assert_not_awaited()
+
+
+async def test_dock_upgrade_allows_managed_stop_running_failure(hass) -> None:
+    """The managed STOP reason authorizes the early dock upgrade."""
+    manager = SimpleNamespace(
+        snapshot=MagicMock(
+            return_value={"last_run": {"run_id": "run-1", "outcome": "running"}}
+        ),
+        cancellation_reason=MagicMock(return_value="managed_stop"),
+        finish_room_event=MagicMock(return_value=asyncio.Event()),
+        async_mark_run_docked=AsyncMock(),
+    )
+
+    await _async_mark_run_docked(manager, "serial", "run-1", "vacuum.matic", Context())
+
+    manager.async_mark_run_docked.assert_awaited_once()
+
+
 def _registered_handler(services, service: str):
     return next(
         item.args[2]

--- a/tests/test_stop_return.py
+++ b/tests/test_stop_return.py
@@ -204,6 +204,48 @@ async def test_skips_when_the_robot_is_already_home_or_heading_there(
     client.async_send_user_command.assert_not_awaited()
 
 
+async def test_already_docked_stop_closes_the_correlated_run(hass) -> None:
+    """An OEM stop that already reached the dock still records dock evidence."""
+    hass.states.async_set(ENTITY, "docked", {})
+    on_docked = AsyncMock()
+
+    assert await async_dock_when_stop_settles(
+        hass,
+        client=_client(session=False),
+        refresh=AsyncMock(),
+        manager=_manager(),
+        serial_number="serial",
+        entity_id=ENTITY,
+        run_id="run-1",
+        set_run_id=MagicMock(),
+        on_docked=on_docked,
+    )
+    on_docked.assert_awaited_once()
+
+
+async def test_returning_stop_waits_for_correlated_dock(
+    hass, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A returning robot is confirmed at the dock before closing the run."""
+    monkeypatch.setattr(stop_return, "DOCK_CONFIRM_TIMEOUT_SECONDS", 1)
+    hass.states.async_set(ENTITY, "returning", {})
+    refresh = AsyncMock(side_effect=lambda: hass.states.async_set(ENTITY, "docked", {}))
+    on_docked = AsyncMock()
+
+    assert await async_dock_when_stop_settles(
+        hass,
+        client=_client(session=False),
+        refresh=refresh,
+        manager=_manager(),
+        serial_number="serial",
+        entity_id=ENTITY,
+        run_id="run-1",
+        set_run_id=MagicMock(),
+        on_docked=on_docked,
+    )
+    on_docked.assert_awaited_once()
+
+
 @pytest.mark.parametrize("state", ["cleaning", "paused"])
 async def test_skips_when_new_work_replaced_the_stop(
     hass, state: str, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_stop_return.py
+++ b/tests/test_stop_return.py
@@ -447,6 +447,18 @@ async def test_confirmation_times_out_without_docked_state(
     on_docked.assert_not_awaited()
 
 
+@pytest.mark.parametrize("state", ["cleaning", "paused"])
+async def test_confirmation_aborts_after_replacement_motion(hass, state: str) -> None:
+    """A later unrelated task cannot upgrade this run when it docks."""
+    hass.states.async_set(ENTITY, state, {})
+    on_docked = AsyncMock()
+
+    assert not await async_confirm_docked(
+        hass, refresh=AsyncMock(), entity_id=ENTITY, on_docked=on_docked
+    )
+    on_docked.assert_not_awaited()
+
+
 async def test_schedule_is_a_no_op_without_background_task_support() -> None:
     manager = _manager()
     fake_hass = SimpleNamespace(states=SimpleNamespace(get=MagicMock()))

--- a/tests/test_stop_return.py
+++ b/tests/test_stop_return.py
@@ -193,6 +193,32 @@ async def test_final_dock_does_not_close_run_without_docked_state(
     assert refresh.await_count >= 2
 
 
+async def test_final_dock_confirmation_aborts_replacement_motion(
+    hass, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A replacement task cannot claim an obsolete final DOCK."""
+    monkeypatch.setattr(stop_return, "DOCK_CONFIRM_TIMEOUT_SECONDS", 1)
+    monkeypatch.setattr(stop_return, "DOCK_SETTLE_TRANSITION_GRACE_SECONDS", 0)
+    hass.states.async_set(ENTITY, "idle", {})
+    client = _client(session=False)
+
+    async def refresh() -> None:
+        hass.states.async_set(ENTITY, "cleaning", {})
+
+    on_docked = AsyncMock()
+    assert await async_dock_when_stop_settles(
+        hass,
+        client=client,
+        refresh=refresh,
+        manager=_manager(),
+        serial_number="serial",
+        entity_id=ENTITY,
+        on_docked=on_docked,
+    )
+    client.async_send_user_command.assert_awaited_once_with(UserCommand.DOCK)
+    on_docked.assert_not_awaited()
+
+
 @pytest.mark.parametrize("state", ["docked", "returning"])
 async def test_skips_when_the_robot_is_already_home_or_heading_there(
     hass, state: str

--- a/tests/test_stop_return.py
+++ b/tests/test_stop_return.py
@@ -240,7 +240,7 @@ async def test_final_dock_confirmation_aborts_when_stop_fence_clears(hass) -> No
     on_docked.assert_not_awaited()
 
 
-@pytest.mark.parametrize("state", ["docked", "returning"])
+@pytest.mark.parametrize("state", ["docked", "charging", "returning"])
 async def test_skips_when_the_robot_is_already_home_or_heading_there(
     hass, state: str
 ) -> None:
@@ -251,9 +251,10 @@ async def test_skips_when_the_robot_is_already_home_or_heading_there(
     client.async_send_user_command.assert_not_awaited()
 
 
-async def test_already_docked_stop_closes_the_correlated_run(hass) -> None:
+@pytest.mark.parametrize("state", ["docked", "charging"])
+async def test_already_docked_stop_closes_the_correlated_run(hass, state: str) -> None:
     """An OEM stop that already reached the dock still records dock evidence."""
-    hass.states.async_set(ENTITY, "docked", {})
+    hass.states.async_set(ENTITY, state, {})
     on_docked = AsyncMock()
 
     assert await async_dock_when_stop_settles(

--- a/tests/test_stop_return.py
+++ b/tests/test_stop_return.py
@@ -96,17 +96,21 @@ async def test_final_dock_preserves_run_correlation_and_closes_stop(hass) -> Non
     on_docked.assert_awaited_once()
 
 
-async def test_final_dock_does_not_close_run_without_docked_state(hass) -> None:
+async def test_final_dock_does_not_close_run_without_docked_state(
+    hass, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """An accepted DOCK command alone does not create dock evidence."""
+    monkeypatch.setattr(stop_return, "DOCK_CONFIRM_TIMEOUT_SECONDS", 0.001)
     hass.states.async_set(ENTITY, "idle", {})
     client = _client(session=False)
     on_docked = AsyncMock()
+    refresh = AsyncMock()
 
     assert (
         await async_dock_when_stop_settles(
             hass,
             client=client,
-            refresh=AsyncMock(),
+            refresh=refresh,
             manager=_manager(),
             serial_number="serial",
             entity_id=ENTITY,
@@ -115,6 +119,7 @@ async def test_final_dock_does_not_close_run_without_docked_state(hass) -> None:
         is True
     )
     on_docked.assert_not_awaited()
+    assert refresh.await_count >= 2
 
 
 @pytest.mark.parametrize("state", ["docked", "returning"])

--- a/tests/test_stop_return.py
+++ b/tests/test_stop_return.py
@@ -219,6 +219,27 @@ async def test_final_dock_confirmation_aborts_replacement_motion(
     on_docked.assert_not_awaited()
 
 
+async def test_final_dock_confirmation_aborts_when_stop_fence_clears(hass) -> None:
+    """A cleared stop fence cannot produce stale dock evidence."""
+    hass.states.async_set(ENTITY, "idle", {})
+    client = _client(session=False)
+    manager = _manager()
+    manager.stop_pending.side_effect = [True, True, True, False]
+    on_docked = AsyncMock()
+
+    assert await async_dock_when_stop_settles(
+        hass,
+        client=client,
+        refresh=AsyncMock(),
+        manager=manager,
+        serial_number="serial",
+        entity_id=ENTITY,
+        on_docked=on_docked,
+    )
+    client.async_send_user_command.assert_awaited_once_with(UserCommand.DOCK)
+    on_docked.assert_not_awaited()
+
+
 @pytest.mark.parametrize("state", ["docked", "returning"])
 async def test_skips_when_the_robot_is_already_home_or_heading_there(
     hass, state: str

--- a/tests/test_stop_return.py
+++ b/tests/test_stop_return.py
@@ -66,6 +66,32 @@ async def test_docks_once_the_stopped_task_reports_inactive(hass) -> None:
     refresh.assert_awaited_once()
 
 
+async def test_final_dock_preserves_run_correlation_and_closes_stop(hass) -> None:
+    """The final DOCK observation and callback share the stopped run ID."""
+    hass.states.async_set(ENTITY, "idle", {})
+    client = _client(session=False)
+    refresh = AsyncMock()
+    set_run_id = MagicMock()
+    on_docked = AsyncMock()
+
+    docked = await async_dock_when_stop_settles(
+        hass,
+        client=client,
+        refresh=refresh,
+        manager=_manager(),
+        serial_number="serial",
+        entity_id=ENTITY,
+        run_id="run-1",
+        set_run_id=set_run_id,
+        on_docked=on_docked,
+    )
+
+    assert docked is True
+    assert set_run_id.call_args_list[0].args == ("run-1",)
+    assert set_run_id.call_args_list[-1].args == (None,)
+    on_docked.assert_awaited_once()
+
+
 @pytest.mark.parametrize("state", ["docked", "returning"])
 async def test_skips_when_the_robot_is_already_home_or_heading_there(
     hass, state: str

--- a/tests/test_stop_return.py
+++ b/tests/test_stop_return.py
@@ -198,7 +198,7 @@ async def test_final_dock_confirmation_aborts_replacement_motion(
 ) -> None:
     """A replacement task cannot claim an obsolete final DOCK."""
     monkeypatch.setattr(stop_return, "DOCK_CONFIRM_TIMEOUT_SECONDS", 1)
-    monkeypatch.setattr(stop_return, "DOCK_SETTLE_TRANSITION_GRACE_SECONDS", 0)
+    monkeypatch.setattr(stop_return, "DOCK_CONFIRM_TRANSITION_GRACE_SECONDS", 0)
     hass.states.async_set(ENTITY, "idle", {})
     client = _client(session=False)
 

--- a/tests/test_stop_return.py
+++ b/tests/test_stop_return.py
@@ -21,6 +21,7 @@ ENTITY = "vacuum.matic"
 def _fast_poll(monkeypatch: pytest.MonkeyPatch) -> None:
     """Keep the watcher's real control flow but drop its wait between polls."""
     monkeypatch.setattr(stop_return, "DOCK_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(stop_return, "DOCK_CONFIRM_TIMEOUT_SECONDS", 0)
 
 
 def _manager(pending: bool = True) -> SimpleNamespace:
@@ -70,7 +71,10 @@ async def test_final_dock_preserves_run_correlation_and_closes_stop(hass) -> Non
     """The final DOCK observation and callback share the stopped run ID."""
     hass.states.async_set(ENTITY, "idle", {})
     client = _client(session=False)
-    refresh = AsyncMock()
+
+    async def refresh() -> None:
+        hass.states.async_set(ENTITY, "charging", {})
+
     set_run_id = MagicMock()
     on_docked = AsyncMock()
 
@@ -90,6 +94,27 @@ async def test_final_dock_preserves_run_correlation_and_closes_stop(hass) -> Non
     assert set_run_id.call_args_list[0].args == ("run-1",)
     assert set_run_id.call_args_list[-1].args == (None,)
     on_docked.assert_awaited_once()
+
+
+async def test_final_dock_does_not_close_run_without_docked_state(hass) -> None:
+    """An accepted DOCK command alone does not create dock evidence."""
+    hass.states.async_set(ENTITY, "idle", {})
+    client = _client(session=False)
+    on_docked = AsyncMock()
+
+    assert (
+        await async_dock_when_stop_settles(
+            hass,
+            client=client,
+            refresh=AsyncMock(),
+            manager=_manager(),
+            serial_number="serial",
+            entity_id=ENTITY,
+            on_docked=on_docked,
+        )
+        is True
+    )
+    on_docked.assert_not_awaited()
 
 
 @pytest.mark.parametrize("state", ["docked", "returning"])

--- a/tests/test_stop_return.py
+++ b/tests/test_stop_return.py
@@ -10,8 +10,10 @@ from custom_components.matic_robot import stop_return
 from custom_components.matic_robot.client.commands import UserCommand
 from custom_components.matic_robot.client.exceptions import MaticError
 from custom_components.matic_robot.stop_return import (
+    async_confirm_docked,
     async_dock_when_stop_settles,
     schedule_dock_after_stop,
+    schedule_dock_confirmation,
 )
 
 ENTITY = "vacuum.matic"
@@ -327,6 +329,40 @@ async def test_schedule_registers_a_lifecycle_bound_task(hass) -> None:
     assert isinstance(
         manager.register_reconciliation_task.call_args.args[1], asyncio.Task
     )
+
+
+async def test_schedule_confirmation_registers_and_closes_docked_run(hass) -> None:
+    manager = _manager()
+    hass.states.async_set(ENTITY, "charging", {})
+    on_docked = AsyncMock()
+
+    schedule_dock_confirmation(
+        hass,
+        refresh=AsyncMock(),
+        manager=manager,
+        serial_number="serial",
+        entity_id=ENTITY,
+        run_id="run-1",
+        on_docked=on_docked,
+    )
+    await hass.async_block_till_done()
+
+    manager.register_reconciliation_task.assert_called_once()
+    on_docked.assert_awaited_once()
+
+
+async def test_confirmation_waits_for_docked_state(
+    hass, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(stop_return, "DOCK_CONFIRM_TIMEOUT_SECONDS", 1)
+    hass.states.async_set(ENTITY, "returning", {})
+    refresh = AsyncMock(side_effect=lambda: hass.states.async_set(ENTITY, "docked", {}))
+    on_docked = AsyncMock()
+
+    assert await async_confirm_docked(
+        hass, refresh=refresh, entity_id=ENTITY, on_docked=on_docked
+    )
+    on_docked.assert_awaited_once()
 
 
 async def test_schedule_is_a_no_op_without_background_task_support() -> None:

--- a/tests/test_stop_return.py
+++ b/tests/test_stop_return.py
@@ -365,6 +365,19 @@ async def test_confirmation_waits_for_docked_state(
     on_docked.assert_awaited_once()
 
 
+async def test_confirmation_times_out_without_docked_state(
+    hass, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(stop_return, "DOCK_CONFIRM_TIMEOUT_SECONDS", 0)
+    hass.states.async_set(ENTITY, "returning", {})
+    on_docked = AsyncMock()
+
+    assert not await async_confirm_docked(
+        hass, refresh=AsyncMock(), entity_id=ENTITY, on_docked=on_docked
+    )
+    on_docked.assert_not_awaited()
+
+
 async def test_schedule_is_a_no_op_without_background_task_support() -> None:
     manager = _manager()
     fake_hass = SimpleNamespace(states=SimpleNamespace(get=MagicMock()))

--- a/tests/test_stop_return.py
+++ b/tests/test_stop_return.py
@@ -404,20 +404,32 @@ async def test_schedule_confirmation_registers_and_closes_docked_run(hass) -> No
     manager = _manager()
     hass.states.async_set(ENTITY, "charging", {})
     on_docked = AsyncMock()
+    scope: dict[str, str | None] = {"run_id": None}
+    observed_scopes: list[str | None] = []
+
+    def set_run_id(run_id: str | None) -> None:
+        scope["run_id"] = run_id
+
+    async def refresh() -> None:
+        observed_scopes.append(scope["run_id"])
 
     schedule_dock_confirmation(
         hass,
-        refresh=AsyncMock(),
+        refresh=refresh,
         manager=manager,
         serial_number="serial",
         entity_id=ENTITY,
         run_id="run-1",
         on_docked=on_docked,
+        set_run_id=set_run_id,
+        get_run_id=lambda: scope["run_id"],
     )
     await hass.async_block_till_done()
 
     manager.register_reconciliation_task.assert_called_once()
     on_docked.assert_awaited_once()
+    assert observed_scopes == ["run-1"]
+    assert scope["run_id"] is None
 
 
 async def test_confirmation_waits_for_docked_state(
@@ -456,6 +468,65 @@ async def test_confirmation_aborts_after_replacement_motion(hass, state: str) ->
     assert not await async_confirm_docked(
         hass, refresh=AsyncMock(), entity_id=ENTITY, on_docked=on_docked
     )
+    on_docked.assert_not_awaited()
+
+
+async def test_confirmation_refreshes_past_stale_pre_dock_state(
+    hass, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stale pre-command cleaning state gets one bounded transition edge."""
+    monkeypatch.setattr(stop_return, "DOCK_CONFIRM_TIMEOUT_SECONDS", 1)
+    monkeypatch.setattr(stop_return, "DOCK_CONFIRM_TRANSITION_GRACE_SECONDS", 1)
+    hass.states.async_set(ENTITY, "cleaning", {})
+    refresh_count = 0
+
+    async def refresh() -> None:
+        nonlocal refresh_count
+        refresh_count += 1
+        if refresh_count == 2:
+            hass.states.async_set(ENTITY, "returning", {})
+        elif refresh_count == 3:
+            hass.states.async_set(ENTITY, "charging", {})
+
+    on_docked = AsyncMock()
+    assert await async_confirm_docked(
+        hass, refresh=refresh, entity_id=ENTITY, on_docked=on_docked
+    )
+    on_docked.assert_awaited_once()
+    assert refresh_count == 3
+
+
+async def test_confirmation_aborts_persistent_replacement_motion(
+    hass, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Persistent cleaning after the transition edge cannot claim the dock."""
+    monkeypatch.setattr(stop_return, "DOCK_CONFIRM_TIMEOUT_SECONDS", 1)
+    monkeypatch.setattr(stop_return, "DOCK_CONFIRM_TRANSITION_GRACE_SECONDS", 0)
+    hass.states.async_set(ENTITY, "cleaning", {})
+    on_docked = AsyncMock()
+
+    assert not await async_confirm_docked(
+        hass, refresh=AsyncMock(), entity_id=ENTITY, on_docked=on_docked
+    )
+    on_docked.assert_not_awaited()
+
+
+async def test_confirmation_does_not_claim_a_newer_run_scope(hass) -> None:
+    """A newer activity scope prevents an obsolete dock watcher from running."""
+    hass.states.async_set(ENTITY, "charging", {})
+    set_run_id = MagicMock()
+    on_docked = AsyncMock()
+
+    assert not await async_confirm_docked(
+        hass,
+        refresh=AsyncMock(),
+        entity_id=ENTITY,
+        on_docked=on_docked,
+        run_id="run-old",
+        set_run_id=set_run_id,
+        get_run_id=lambda: "run-new",
+    )
+    set_run_id.assert_not_called()
     on_docked.assert_not_awaited()
 
 

--- a/tests/test_stop_return.py
+++ b/tests/test_stop_return.py
@@ -73,11 +73,19 @@ async def test_final_dock_preserves_run_correlation_and_closes_stop(hass) -> Non
     """The final DOCK observation and callback share the stopped run ID."""
     hass.states.async_set(ENTITY, "idle", {})
     client = _client(session=False)
+    scope: dict[str, str | None] = {"run_id": None}
+    observed_scopes: list[str | None] = []
+
+    def set_run_id(run_id: str | None) -> None:
+        scope["run_id"] = run_id
+
+    def get_run_id() -> str | None:
+        return scope["run_id"]
 
     async def refresh() -> None:
+        observed_scopes.append(scope["run_id"])
         hass.states.async_set(ENTITY, "charging", {})
 
-    set_run_id = MagicMock()
     on_docked = AsyncMock()
 
     docked = await async_dock_when_stop_settles(
@@ -89,13 +97,74 @@ async def test_final_dock_preserves_run_correlation_and_closes_stop(hass) -> Non
         entity_id=ENTITY,
         run_id="run-1",
         set_run_id=set_run_id,
+        get_run_id=get_run_id,
         on_docked=on_docked,
     )
 
     assert docked is True
-    assert set_run_id.call_args_list[0].args == ("run-1",)
-    assert set_run_id.call_args_list[-1].args == (None,)
+    assert observed_scopes == ["run-1"]
+    assert scope["run_id"] is None
     on_docked.assert_awaited_once()
+
+
+async def test_final_dock_does_not_clear_a_newer_run_scope(hass) -> None:
+    """A replacement run keeps ownership of the activity journal."""
+    hass.states.async_set(ENTITY, "idle", {})
+    client = _client(session=False)
+    scope: dict[str, str | None] = {"run_id": None}
+
+    def set_run_id(run_id: str | None) -> None:
+        scope["run_id"] = run_id
+
+    async def on_docked() -> None:
+        scope["run_id"] = "run-new"
+
+    async def refresh() -> None:
+        hass.states.async_set(ENTITY, "charging", {})
+
+    assert (
+        await async_dock_when_stop_settles(
+            hass,
+            client=client,
+            refresh=refresh,
+            manager=_manager(),
+            serial_number="serial",
+            entity_id=ENTITY,
+            run_id="run-old",
+            set_run_id=set_run_id,
+            get_run_id=lambda: scope["run_id"],
+            on_docked=on_docked,
+        )
+        is True
+    )
+    assert scope["run_id"] == "run-new"
+
+
+async def test_rejected_dock_clears_its_run_scope(hass) -> None:
+    """A failed final command releases the run scope it claimed."""
+    hass.states.async_set(ENTITY, "idle", {})
+    client = _client(session=False)
+    client.async_send_user_command = AsyncMock(side_effect=MaticError("rejected"))
+    scope: dict[str, str | None] = {"run_id": None}
+
+    def set_run_id(run_id: str | None) -> None:
+        scope["run_id"] = run_id
+
+    assert (
+        await async_dock_when_stop_settles(
+            hass,
+            client=client,
+            refresh=AsyncMock(),
+            manager=_manager(),
+            serial_number="serial",
+            entity_id=ENTITY,
+            run_id="run-1",
+            set_run_id=set_run_id,
+            get_run_id=lambda: scope["run_id"],
+        )
+        is False
+    )
+    assert scope["run_id"] is None
 
 
 async def test_final_dock_does_not_close_run_without_docked_state(

--- a/tests/test_stop_return.py
+++ b/tests/test_stop_return.py
@@ -219,25 +219,28 @@ async def test_final_dock_confirmation_aborts_replacement_motion(
     on_docked.assert_not_awaited()
 
 
-async def test_final_dock_confirmation_aborts_when_stop_fence_clears(hass) -> None:
-    """A cleared stop fence cannot produce stale dock evidence."""
+async def test_final_dock_confirmation_survives_stop_fence_expiry(hass) -> None:
+    """An accepted DOCK keeps its independent confirmation window."""
     hass.states.async_set(ENTITY, "idle", {})
     client = _client(session=False)
     manager = _manager()
-    manager.stop_pending.side_effect = [True, True, True, False]
+    manager.stop_pending.side_effect = [True, True, True]
     on_docked = AsyncMock()
+
+    async def refresh() -> None:
+        hass.states.async_set(ENTITY, "charging", {})
 
     assert await async_dock_when_stop_settles(
         hass,
         client=client,
-        refresh=AsyncMock(),
+        refresh=refresh,
         manager=manager,
         serial_number="serial",
         entity_id=ENTITY,
         on_docked=on_docked,
     )
     client.async_send_user_command.assert_awaited_once_with(UserCommand.DOCK)
-    on_docked.assert_not_awaited()
+    on_docked.assert_awaited_once()
 
 
 @pytest.mark.parametrize("state", ["docked", "charging", "returning"])

--- a/tests/test_vacuum_areas.py
+++ b/tests/test_vacuum_areas.py
@@ -625,3 +625,20 @@ def test_dock_after_stop_is_skipped_before_the_entity_is_registered() -> None:
 
     schedule.assert_called_once()
     assert schedule.call_args.kwargs["entity_id"] == "vacuum.test"
+
+
+async def test_dock_after_stop_callback_closes_the_correlated_run() -> None:
+    entity = _vacuum()
+    entity.entity_id = "vacuum.test"
+    entity._plans.async_mark_run_docked = AsyncMock()
+    entity.coordinator.client = MagicMock()
+    entity.coordinator.async_request_refresh = AsyncMock()
+    with patch(
+        "custom_components.matic_robot.vacuum.schedule_dock_after_stop"
+    ) as schedule:
+        entity._schedule_dock_after_stop("serial", run_id="run-1")
+
+    await schedule.call_args.kwargs["on_docked"]()
+    entity._plans.async_mark_run_docked.assert_awaited_once_with(
+        "serial", "run-1", entity_id="vacuum.test"
+    )


### PR DESCRIPTION
## Problem
Managed cleaning evidence still used legacy terminal labels, lost provenance boundaries, and dropped the run ID when the stop-settlement watcher sent the final DOCK. Rotation previews also omitted the last verified completion, which made post-run selection harder to audit.

## Change
- enforce the terminal run vocabulary: `completed`, `stopped_docked`, `recharge_suspended`, `cancelled`, `failed`, and `unverified`
- normalize legacy persisted outcomes and provenance to safe labels: `automation`, `user`, `internal`, and `external_unknown`
- carry the same run ID through the final DOCK command journal and emit `matic_robot_plan_docked` only after the dock transition is proven
- expose per-room `completed`/`partial`/`unattempted` outcomes and rotation `last_completion`
- document the deterministic end-to-end scenario matrix and add focused coverage

## Validation
- 1,646 tests passed with 100% coverage
- Ruff and format checks passed
- mypy passed
- public-tree privacy check passed
